### PR TITLE
Add flipper movement

### DIFF
--- a/VisualPinball.Engine.Test/Test/BaseTests.cs
+++ b/VisualPinball.Engine.Test/Test/BaseTests.cs
@@ -1,5 +1,9 @@
 ﻿using NLog;
 using NLog.Targets;
+using VisualPinball.Engine.Game;
+using VisualPinball.Engine.Math;
+using VisualPinball.Engine.VPT.Ball;
+using VisualPinball.Engine.VPT.Table;
 using Xunit.Abstractions;
 
 namespace VisualPinball.Engine.Test.Test
@@ -15,6 +19,11 @@ namespace VisualPinball.Engine.Test.Test
 			config.AddRule(LogLevel.Trace, LogLevel.Fatal, logConsole);
 			LogManager.Configuration = config;
 			Logger = LogManager.GetCurrentClassLogger();
+		}
+
+		protected static Ball CreateBall(Player player, float x, float y, float z, float vx = 0, float vy = 0, float vz = 0)
+		{
+			return player.CreateBall(new TestBallCreator(x, y, z, vx, vy, vz));
 		}
 	}
 
@@ -32,6 +41,27 @@ namespace VisualPinball.Engine.Test.Test
 		{
 			var msg = Layout.Render(logEvent);
 			_output.WriteLine(msg);
+		}
+	}
+
+	public class TestBallCreator : IBallCreationPosition
+	{
+		private readonly Vertex3D _pos;
+		private readonly Vertex3D _vel;
+
+		public TestBallCreator(float x, float y, float z, float vx, float vy, float vz)
+		{
+			_pos = new Vertex3D(x, y, z);
+			_vel = new Vertex3D(vx, vy, vz);
+		}
+
+		public Vertex3D GetBallCreationPosition(Table table) => _pos;
+
+		public Vertex3D GetBallCreationVelocity(Table table) => _vel;
+
+		public void OnBallCreated(PlayerPhysics physics, Ball ball)
+		{
+			// do nothing
 		}
 	}
 }

--- a/VisualPinball.Engine.Test/VPT/Flipper/FlipperPhysicsTests.cs
+++ b/VisualPinball.Engine.Test/VPT/Flipper/FlipperPhysicsTests.cs
@@ -1,0 +1,26 @@
+﻿using VisualPinball.Engine.Game;
+using VisualPinball.Engine.Math;
+using VisualPinball.Engine.Test.Test;
+using Xunit;
+
+namespace VisualPinball.Engine.Test.VPT.Flipper
+{
+	public class FlipperPhysicsTests
+	{
+		[Fact]
+		public void ShouldMove()
+		{
+			var table = Engine.VPT.Table.Table.Load(VpxPath.Flipper);
+			var player = new Player(table).Init();
+
+			var flipper = table.Flippers["FlipperR"];
+			var flipperState = flipper.State;
+			var endAngleRad = MathF.DegToRad(flipper.Data.EndAngle);
+
+			flipper.RotateToEnd();
+			player.SimulateTime(100);
+
+			Assert.Equal(endAngleRad, flipperState.Angle);
+		}
+	}
+}

--- a/VisualPinball.Engine.Test/VPT/Flipper/FlipperPhysicsTests.cs
+++ b/VisualPinball.Engine.Test/VPT/Flipper/FlipperPhysicsTests.cs
@@ -1,4 +1,5 @@
-﻿using VisualPinball.Engine.Game;
+﻿using FluentAssertions;
+using VisualPinball.Engine.Game;
 using VisualPinball.Engine.Math;
 using VisualPinball.Engine.Test.Test;
 using Xunit;
@@ -7,20 +8,76 @@ namespace VisualPinball.Engine.Test.VPT.Flipper
 {
 	public class FlipperPhysicsTests
 	{
-		[Fact]
-		public void ShouldMove()
-		{
-			var table = Engine.VPT.Table.Table.Load(VpxPath.Flipper);
-			var player = new Player(table).Init();
+		private readonly Engine.VPT.Table.Table _table;
 
-			var flipper = table.Flippers["FlipperR"];
-			var flipperState = flipper.State;
+		public FlipperPhysicsTests()
+		{
+			_table = Engine.VPT.Table.Table.Load(VpxPath.Flipper);
+		}
+
+		[Fact]
+		public void ShouldMoveToTheEndWhenSolenoidIsTurnedOn()
+		{
+			var player = new Player(_table).Init();
+			var flipper = _table.Flippers["FlipperR"];
+			var startAngleRad = MathF.DegToRad(flipper.Data.StartAngle);
 			var endAngleRad = MathF.DegToRad(flipper.Data.EndAngle);
+
+			// assert it's down
+			flipper.State.Angle.Should().Be(startAngleRad);
 
 			flipper.RotateToEnd();
 			player.SimulateTime(100);
 
-			Assert.Equal(endAngleRad, flipperState.Angle);
+			// assert it's up
+			flipper.State.Angle.Should().Be(endAngleRad);
+		}
+
+		[Fact]
+		public void ShouldMoveToStartWhenSolenoidIsTurnedOff()
+		{
+			var player = new Player(_table).Init();
+			var flipper = _table.Flippers["FlipperR"];
+			var startAngleRad = MathF.DegToRad(flipper.Data.StartAngle);
+
+			// move up
+			flipper.RotateToEnd();
+			player.SimulateTime(52);
+
+			// move down again
+			flipper.RotateToStart();
+			player.SimulateTime(300);
+
+			flipper.State.Angle.Should().Be(startAngleRad);
+		}
+
+		[Fact]
+		public void ShouldMoveBackToEndWhenPressedWhileMoving()
+		{
+			var player = new Player(_table).Init();
+			var flipper = _table.Flippers["FlipperR"];
+			var startAngleRad = MathF.DegToRad(flipper.Data.StartAngle);
+			var endAngleRad = MathF.DegToRad(flipper.Data.EndAngle);
+
+			// move up
+			flipper.RotateToEnd();
+			player.SimulateTime(52); // hit at 51ms
+			flipper.State.Angle.Should().BeGreaterThan(startAngleRad);
+
+			// move down
+			flipper.RotateToStart();
+			player.SimulateTime(200);
+
+			// assert it's in the middle
+			flipper.State.Angle.Should().BeGreaterThan(startAngleRad);
+			flipper.State.Angle.Should().BeLessThan(endAngleRad);
+
+			// move up again
+			flipper.RotateToEnd();
+			player.SimulateTime(500);
+
+			// assert it's back up in less than half the time
+			flipper.State.Angle.Should().Be(endAngleRad);
 		}
 	}
 }

--- a/VisualPinball.Engine.Test/VPT/Flipper/FlipperPhysicsTests.cs
+++ b/VisualPinball.Engine.Test/VPT/Flipper/FlipperPhysicsTests.cs
@@ -3,14 +3,15 @@ using VisualPinball.Engine.Game;
 using VisualPinball.Engine.Math;
 using VisualPinball.Engine.Test.Test;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace VisualPinball.Engine.Test.VPT.Flipper
 {
-	public class FlipperPhysicsTests
+	public class FlipperPhysicsTests : BaseTests
 	{
 		private readonly Engine.VPT.Table.Table _table;
 
-		public FlipperPhysicsTests()
+		public FlipperPhysicsTests(ITestOutputHelper output) : base(output)
 		{
 			_table = Engine.VPT.Table.Table.Load(VpxPath.Flipper);
 		}
@@ -78,6 +79,156 @@ namespace VisualPinball.Engine.Test.VPT.Flipper
 
 			// assert it's back up in less than half the time
 			flipper.State.Angle.Should().Be(endAngleRad);
+		}
+
+		[Fact]
+		public void ShouldCollideWithTheBallWhenHittingOnTheFace()
+		{
+			var player = new Player(_table).Init();
+
+			// put ball on top of flipper face
+			var ball = CreateBall(player, 350f, 1600f, 0f);
+
+			player.SimulateTime(2000);
+
+			ball.State.Pos.X.Should().BeGreaterThan(420f);  // diverted to the right
+			ball.State.Pos.Y.Should().BeGreaterThan(1650f);  // but still below
+		}
+
+		[Fact]
+		public void ShouldCollideWithTheBallWhenHittingOnTheEnd()
+		{
+			var player = new Player(_table).Init();
+
+			// put ball on top of flipper end
+			var ball = CreateBall(player, 420f, 1645f, 0);
+
+			player.SimulateTime(2000);
+
+			ball.State.Pos.X.Should().BeGreaterThan(460f);  // diverted to the right
+			ball.State.Pos.Y.Should().BeGreaterThan(1670f);  // but still below
+		}
+
+		[Fact]
+		public void ShouldRollOnTheFlipper()
+		{
+			var player = new Player(_table).Init();
+
+			// put ball on top of flipper
+			var ball = CreateBall(player, 310, 1590, 0);
+
+			player.SimulateTime(2000);
+
+			// assert it's on flipper's bottom
+			ball.State.Pos.X.Should().BeInRange(393f, 401f);
+			ball.State.Pos.Y.Should().BeInRange(1647f, 1651f);
+		}
+
+		[Fact]
+		public void ShouldMoveTheBallUp()
+		{
+			var player = new Player(_table).Init();
+			var flipper = _table.Flippers["DefaultFlipper"];
+
+			// put ball on top of flipper
+			var ball = CreateBall(player, 310, 1590, 0);
+
+			// let it roll a bit
+			player.SimulateTime(1500);
+
+			// now, flip
+			flipper.RotateToEnd();
+			player.SimulateTime(1550);
+
+			// should be moving top right
+			ball.State.Pos.X.Should().BeGreaterThan(380);
+			ball.State.Pos.Y.Should().BeLessThan(1550f);
+		}
+
+		[Fact]
+		public void ShouldPushTheCoilDownWhenHitWithHighSpeed()
+		{
+			var player = new Player(_table).Init();
+			var flipper = _table.Flippers["DefaultFlipper"];
+			CreateBall(player, 395, 1547, 0, 0, 20);
+
+			// assert initial flipper position
+			MathF.RadToDeg(flipper.State.Angle).Should().BeApproximately(121, 0.00001f);
+
+			// let it collide
+			player.SimulateTime(100);
+
+			MathF.RadToDeg(flipper.State.Angle).Should().BeLessThan(115);
+		}
+
+		[Fact]
+		public void ShouldMoveWhenHitAtTheSameTime()
+		{
+			var player = new Player(_table).Init();
+			var flipper = _table.Flippers["DefaultFlipper"];
+
+			// shoot ball onto flipper and flip at the same time
+			var ball = CreateBall(player, 420, 1550, 0, 0, 5);
+			flipper.RotateToEnd();
+
+			player.UpdatePhysics(280);
+
+			// should be moving up
+			ball.State.Pos.Y.Should().BeLessThan(830);
+
+			// now, flip
+			flipper.RotateToEnd();
+			player.SimulateTime(1550);
+		}
+
+		[Fact]
+		public void ShouldSlideOnTheFlipper()
+		{
+			var player = new Player(_table).Init();
+
+			// shoot ball parallel onto flipper
+			var ball = CreateBall(player, 214, 1520, 0, 10, 7.1f);
+
+			player.UpdatePhysics(0);
+			ball.State.Pos.X.Should().Be(214);
+			ball.State.Pos.Y.Should().Be(1520);
+
+			player.UpdatePhysics(50);
+			ball.State.Pos.X.Should().BeInRange(259, 263);
+			ball.State.Pos.Y.Should().BeInRange(1552, 1556);
+
+			player.UpdatePhysics(100);
+			ball.State.Pos.X.Should().BeInRange(306, 310);
+			ball.State.Pos.Y.Should().BeInRange(1586, 1590);
+
+			player.UpdatePhysics(150);
+			ball.State.Pos.X.Should().BeInRange(350, 354);
+			ball.State.Pos.Y.Should().BeInRange(1617, 1621);
+		}
+
+		[Fact]
+		public void ShouldMoveTheFlipperUpWhenHitFromBelow()
+		{
+			var player = new Player(_table).Init();
+			var flipper = _table.Flippers["DefaultFlipper"];
+
+			// shoot ball from below onto flipper
+			CreateBall(player, 374, 1766, 0, 0, -10);
+
+			player.UpdatePhysics(0);
+			MathF.RadToDeg(flipper.State.Angle).Should().BeApproximately(121, 0.00001f);
+
+			player.UpdatePhysics(50);
+			MathF.RadToDeg(flipper.State.Angle).Should().BeLessThan(121);
+
+			player.UpdatePhysics(100);
+			MathF.RadToDeg(flipper.State.Angle).Should().BeLessThan(110);
+
+			player.UpdatePhysics(150);
+			MathF.RadToDeg(flipper.State.Angle).Should().BeGreaterThan(110);
+
+			player.UpdatePhysics(200);
+			MathF.RadToDeg(flipper.State.Angle).Should().BeApproximately(121, 0.00001f);
 		}
 	}
 }

--- a/VisualPinball.Engine.Test/VPT/Table/TableDataTests.cs
+++ b/VisualPinball.Engine.Test/VPT/Table/TableDataTests.cs
@@ -153,7 +153,7 @@ namespace VisualPinball.Engine.Test.VPT.Table
 			Assert.Equal(1, data.NumMaterials);
 			Assert.Equal(0, data.NumSounds);
 			Assert.Equal(1, data.NumTextures);
-			Assert.Equal(true, data.OverridePhysics);
+			Assert.Equal(1, data.OverridePhysics);
 			Assert.Equal(true, data.OverridePhysicsFlipper);
 			Assert.Equal(true, data.OverwriteGlobalDayNight);
 			Assert.Equal(true, data.OverwriteGlobalDetailLevel);

--- a/VisualPinball.Engine.Test/VisualPinball.Engine.Test.csproj
+++ b/VisualPinball.Engine.Test/VisualPinball.Engine.Test.csproj
@@ -209,6 +209,7 @@
     <Compile Include="VPT\Flasher\FlasherDataTests.cs" />
     <Compile Include="VPT\Flipper\FlipperMeshTests.cs" />
     <Compile Include="VPT\Flipper\FlipperDataTests.cs" />
+    <Compile Include="VPT\Flipper\FlipperPhysicsTests.cs" />
     <Compile Include="VPT\Gate\GateDataTests.cs" />
     <Compile Include="VPT\Gate\GateMeshTests.cs" />
     <Compile Include="VPT\HitTarget\HitTargetMeshTests.cs" />

--- a/VisualPinball.Engine.Test/VisualPinball.Engine.Test.csproj
+++ b/VisualPinball.Engine.Test/VisualPinball.Engine.Test.csproj
@@ -33,6 +33,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FluentAssertions, Version=5.10.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a">
+      <HintPath>..\packages\FluentAssertions.5.10.2\lib\net47\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="JeremyAnsel.Media.WavefrontObj, Version=2.0.6.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\JeremyAnsel.Media.WavefrontObj.2.0.6\lib\net40\JeremyAnsel.Media.WavefrontObj.dll</HintPath>
       <Private>True</Private>

--- a/VisualPinball.Engine.Test/packages.config
+++ b/VisualPinball.Engine.Test/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FluentAssertions" version="5.10.2" targetFramework="net472" />
   <package id="JeremyAnsel.Media.WavefrontObj" version="2.0.6" targetFramework="net472" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net472" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net472" />

--- a/VisualPinball.Engine/Common/Registry.cs
+++ b/VisualPinball.Engine/Common/Registry.cs
@@ -1,0 +1,13 @@
+﻿namespace VisualPinball.Engine.Common
+{
+	public class Registry
+	{
+		private static Registry _instance;
+
+		public static Registry Instance => _instance ?? (_instance = new Registry());
+
+		public T Get<T>(string key, string value, T fallback) {
+			return fallback;
+		}
+	}
+}

--- a/VisualPinball.Engine/Game/Player.cs
+++ b/VisualPinball.Engine/Game/Player.cs
@@ -37,6 +37,8 @@ namespace VisualPinball.Engine.Game
 			}
 		}
 
+		public void UpdatePhysics() => _physics.UpdatePhysics();
+
 		private void SetupTableElements()
 		{
 			foreach (var playable in _table.Playables) {

--- a/VisualPinball.Engine/Game/Player.cs
+++ b/VisualPinball.Engine/Game/Player.cs
@@ -1,4 +1,5 @@
 using System;
+using VisualPinball.Engine.VPT.Ball;
 using VisualPinball.Engine.VPT.Table;
 
 namespace VisualPinball.Engine.Game
@@ -38,6 +39,12 @@ namespace VisualPinball.Engine.Game
 		}
 
 		public void UpdatePhysics() => _physics.UpdatePhysics();
+		public void UpdatePhysics(float dTime) => _physics.UpdatePhysics((long)(dTime * 1000));
+
+		public Ball CreateBall(IBallCreationPosition ballCreator, float radius = 25f, float mass = 1)
+		{
+			return _physics.CreateBall(ballCreator, this, radius, mass);
+		}
 
 		private void SetupTableElements()
 		{

--- a/VisualPinball.Engine/Game/PlayerPhysics.cs
+++ b/VisualPinball.Engine/Game/PlayerPhysics.cs
@@ -313,7 +313,7 @@ namespace VisualPinball.Engine.Game
 			UpdatePhysics(NowUsec());
 		}
 
-		public float UpdatePhysics(long initialTimeUsec)
+		public void UpdatePhysics(long initialTimeUsec)
 		{
 			if (IsPaused) {
 				// Shift whole game forward in time
@@ -419,8 +419,6 @@ namespace VisualPinball.Engine.Game
 				_curPhysicsFrameTime = _nextPhysicsFrameTime;                  // new cycle, on physics frame boundary
 				_nextPhysicsFrameTime += PhysicsConstants.PhysicsStepTime;     // advance physics position
 			} // end while (m_curPhysicsFrameTime < initial_time_usec)
-
-			return physIterations;
 		}
 
 		public void UpdateVelocities()

--- a/VisualPinball.Engine/Game/PlayerPhysics.cs
+++ b/VisualPinball.Engine/Game/PlayerPhysics.cs
@@ -99,13 +99,13 @@ namespace VisualPinball.Engine.Game
 		/// </summary>
 		public void Init()
 		{
-			var minSlope = _table.Data.OverridePhysics ? PhysicsConstants.DefaultTableMinSlope : _table.Data.AngleTiltMin;
-			var maxSlope = _table.Data.OverridePhysics ? PhysicsConstants.DefaultTableMaxSlope : _table.Data.AngleTiltMax;
+			var minSlope = _table.Data.OverridePhysics != 0 ? PhysicsConstants.DefaultTableMinSlope : _table.Data.AngleTiltMin;
+			var maxSlope = _table.Data.OverridePhysics != 0 ? PhysicsConstants.DefaultTableMaxSlope : _table.Data.AngleTiltMax;
 			var slope = minSlope + (maxSlope - minSlope) * _table.Data.GlobalDifficulty;
 
 			Gravity.X = 0;
-			Gravity.Y = MathF.Sin(MathF.DegToRad(slope)) * (_table.Data.OverridePhysics ? PhysicsConstants.DefaultTableGravity : _table.Data.Gravity);
-			Gravity.Z = -MathF.Cos(MathF.DegToRad(slope)) * (_table.Data.OverridePhysics ? PhysicsConstants.DefaultTableGravity : _table.Data.Gravity);
+			Gravity.Y = MathF.Sin(MathF.DegToRad(slope)) * (_table.Data.OverridePhysics != 0 ? PhysicsConstants.DefaultTableGravity : _table.Data.Gravity);
+			Gravity.Z = -MathF.Cos(MathF.DegToRad(slope)) * (_table.Data.OverridePhysics != 0 ? PhysicsConstants.DefaultTableGravity : _table.Data.Gravity);
 
 			// TODO [vpx-js added] init animation timers
 			// foreach (var animatable in this.Table.GetAnimatables()) {

--- a/VisualPinball.Engine/Game/PlayerPhysics.cs
+++ b/VisualPinball.Engine/Game/PlayerPhysics.cs
@@ -309,9 +309,9 @@ namespace VisualPinball.Engine.Game
 			}
 		}
 
-		public float UpdatePhysics()
+		public void UpdatePhysics()
 		{
-			return UpdatePhysics(NowUsec());
+			UpdatePhysics(NowUsec());
 		}
 
 		public float UpdatePhysics(long initialTimeUsec)

--- a/VisualPinball.Engine/Game/PlayerPhysics.cs
+++ b/VisualPinball.Engine/Game/PlayerPhysics.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using VisualPinball.Engine.Math;
 using VisualPinball.Engine.Physics;
 using VisualPinball.Engine.VPT.Ball;
+using VisualPinball.Engine.VPT.Flipper;
 using VisualPinball.Engine.VPT.Table;
 using VisualPinball.Engine.VPT.Timer;
 
@@ -47,7 +48,7 @@ namespace VisualPinball.Engine.Game
 
 		//TODO private readonly PinInput pinInput;
 		private List<IMoverObject> _movers;                                              // m_vmover
-		//TODO private readonly FlipperMover flipperMovers[] = [];
+		private FlipperMover[] _flipperMovers;
 
 		private readonly List<HitObject> _hitObjects = new List<HitObject>();            // m_vho
 		private readonly List<HitObject> _hitObjectsDynamic = new List<HitObject>();     // m_vho_dynamic
@@ -138,8 +139,8 @@ namespace VisualPinball.Engine.Game
 			_hitPlayfield = _table.GeneratePlayfieldHit();
 			_hitTopGlass = _table.GenerateGlassHit();
 
-			// TODO index flippers
-			//this.FlipperMovers.AddRange(Table.Flippers.Values.Select(f => f.GetMover()));
+			// index flippers
+			_flipperMovers = _table.Flippers.Values.Select(f => f.FlipperMover).ToArray();
 		}
 
 		private void InitOcTree(Table table)
@@ -167,16 +168,14 @@ namespace VisualPinball.Engine.Game
 			while (dTime > 0) {
 				var hitTime = dTime;
 
-				// TODO find earliest time where a flipper collides with its stop
-				// foreach (var flipperMover in this.FlipperMovers)
-				// {
-				// 	var flipperHitTime = flipperMover.GetHitTime();
-				// 	if (flipperHitTime > 0 && flipperHitTime < hitTime)
-				// 	{
-				// 		//!! >= 0.F causes infinite loop
-				// 		hitTime = flipperHitTime;
-				// 	}
-				// }
+				// find earliest time where a flipper collides with its stop
+				foreach (var flipperMover in _flipperMovers) {
+					var flipperHitTime = flipperMover.GetHitTime();
+					if (flipperHitTime > 0 && flipperHitTime < hitTime) {
+						//!! >= 0.F causes infinite loop
+						hitTime = flipperHitTime;
+					}
+				}
 
 				RecordContacts = true;
 				Contacts.Clear();

--- a/VisualPinball.Engine/Math/Constants.cs
+++ b/VisualPinball.Engine/Math/Constants.cs
@@ -90,6 +90,11 @@ namespace VisualPinball.Engine.Math
 		public const float ToleranceEndPoints = 0.0f;                          // C_TOL_ENDPNTS
 		public const float ToleranceRadius =  0.005f;                          // C_TOL_RADIUS
 
+		/// <summary>
+		/// Precision level and cycles for interative calculations // acceptable contact time ... near zero time
+		/// </summary>
+		public const int Internations = 20;                                    // C_INTERATIONS
+
 
 
 	}

--- a/VisualPinball.Engine/Physics/HitCircle.cs
+++ b/VisualPinball.Engine/Physics/HitCircle.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using VisualPinball.Engine.Game;
+using VisualPinball.Engine.Math;
+using VisualPinball.Engine.VPT.Ball;
+
+namespace VisualPinball.Engine.Physics
+{
+	public class HitCircle : HitObject
+	{
+		public readonly Vertex2D Center;
+		public readonly float Radius;
+
+		public HitCircle(Vertex2D center, float radius, float zLow, float zHigh)
+		{
+			Center = center;
+			Radius = radius;
+			HitBBox.ZLow = zLow;
+			HitBBox.ZHigh = zHigh;
+		}
+
+		public override void Collide(CollisionEvent coll, PlayerPhysics physics)
+		{
+			coll.Ball.Hit.Collide3DWall(coll.HitNormal, Elasticity, ElasticityFalloff, Friction,
+				Scatter);
+		}
+
+		public override void CalcHitBBox()
+		{
+			// Allow roundoff
+			HitBBox.Left = Center.X - Radius;
+			HitBBox.Right = Center.X + Radius;
+			HitBBox.Top = Center.Y - Radius;
+			HitBBox.Bottom = Center.Y + Radius;
+			// zlow & zhigh already set in ctor
+		}
+
+		public override float HitTest(Ball ball, float dTime, CollisionEvent coll, PlayerPhysics physics)
+		{
+			// normal face, lateral, rigid
+			return HitTestBasicRadius(ball, dTime, coll, true, true, true);
+		}
+
+		protected float HitTestBasicRadius(Ball ball, float dTime, CollisionEvent coll, bool direction, bool lateral, bool rigid)
+		{
+			if (!IsEnabled || ball.State.IsFrozen) {
+				return -1.0f;
+			}
+
+			var c = new Vertex3D(Center.X, Center.Y, 0.0f);
+			var dist = ball.State.Pos.Clone().Sub(c); // relative ball position
+			var dv = ball.Hit.Vel.Clone();
+
+			var capsule3D = !lateral && ball.State.Pos.Z > HitBBox.ZHigh;
+			var isKicker = ObjType == CollisionType.Kicker;
+			var isKickerOrTrigger = ObjType == CollisionType.Trigger || ObjType == CollisionType.Kicker;
+
+			float targetRadius;
+			if (capsule3D) {
+				targetRadius = Radius * (float) (13.0 / 5.0);
+				c.Z = HitBBox.ZHigh - Radius * (float) (12.0 / 5.0);
+				dist.Z = ball.State.Pos.Z - c.Z; // ball rolling point - capsule center height
+			}
+			else {
+				targetRadius = Radius;
+				if (lateral) {
+					targetRadius += ball.Data.Radius;
+				}
+
+				dist.Z = 0.0f;
+				dv.Z = 0.0f;
+			}
+
+			var bcddsq = dist.LengthSq();        // ball center to circle center distance ... squared
+			var bcdd = MathF.Sqrt(bcddsq);       // distance center to center
+			if (bcdd <= 1.0e-6) {
+				// no hit on exact center
+				return -1.0f;
+			}
+
+			var b = dist.Dot(dv);
+			var bnv = b / bcdd;                  // ball normal velocity
+
+			if (direction && bnv > PhysicsConstants.LowNormVel) {
+				// clearly receding from radius
+				return -1.0f;
+			}
+
+			var bnd = bcdd - targetRadius;       // ball normal distance to
+
+			var a = dv.LengthSq();
+
+			var hitTime = 0f;
+			var isUnhit = false;
+			var isContact = false;
+
+			// Kicker is special.. handle ball stalled on kicker, commonly hit while receding, knocking back into kicker pocket
+			if (isKicker && bnd <= 0 && bnd >= -Radius &&
+			    a < PhysicsConstants.ContactVel * PhysicsConstants.ContactVel && ball.Hit.IsRealBall()) {
+				if (ball.Hit.VpVolObjs.Contains(Obj)) {
+					ball.Hit.VpVolObjs.Remove(Obj); // cause capture
+				}
+			}
+
+			// contact positive possible in future ... objects Negative in contact now
+			if (rigid && bnd < PhysicsConstants.PhysTouch) {
+				if (bnd < -ball.Data.Radius) {
+					return -1.0f;
+				}
+
+				if (MathF.Abs(bnv) <= PhysicsConstants.ContactVel) {
+					isContact = true;
+
+				} else {
+					// estimate based on distance and speed along distance
+					// the ball can be that fast that in the next hit cycle the ball will be inside the hit shape of a bumper or other element.
+					// if that happens bnd is negative and greater than the negative bnv value that results in a negative hittime
+					// below the "if (infNan(hittime) || hittime <0.F...)" will then be true and the hit function will return -1.0f = no hit
+					hitTime = MathF.Max(0.0f, (float) (-bnd / bnv));
+				}
+
+			} else if (isKickerOrTrigger && ball.Hit.IsRealBall() && bnd < 0 == ball.Hit.VpVolObjs.IndexOf(Obj) < 0) {
+				// triggers & kickers
+
+				// here if ... ball inside and no hit set .... or ... ball outside and hit set
+				if (MathF.Abs(bnd - Radius) < 0.05) {
+					// if ball appears in center of trigger, then assumed it was gen"ed there
+					ball.Hit.VpVolObjs.Add(Obj); // special case for trigger overlaying a kicker
+
+				} else {
+					// this will add the ball to the trigger space without a Hit
+					isUnhit = bnd > 0; // ball on outside is UnHit, otherwise it"s a Hit
+				}
+
+			} else {
+				if (!rigid && bnd * bnv > 0 || a < 1.0e-8) {
+					// (outside and receding) or (inside and approaching)
+					// no hit ... ball not moving relative to object
+					return -1.0f;
+				}
+
+				var sol = Functions.SolveQuadraticEq(a, 2.0f * b, bcddsq - targetRadius * targetRadius);
+				if (sol == null) {
+					return -1.0f;
+				}
+
+				var (time1, time2) = sol;
+				isUnhit = time1 * time2 < 0;
+				hitTime = isUnhit ? MathF.Max(time1, time2) : MathF.Min(time1, time2); // ball is inside the circle
+			}
+
+			if (float.IsNaN(hitTime) || float.IsInfinity(hitTime) || hitTime < 0 || hitTime > dTime) {
+				// contact out of physics frame
+				return -1.0f;
+			}
+
+			var hitZ = ball.State.Pos.Z + ball.Hit.Vel.Z * hitTime; // rolling point
+			if (hitZ + ball.Data.Radius * 0.5 < HitBBox.ZLow
+			    || !capsule3D && hitZ - ball.Data.Radius * 0.5 > HitBBox.ZHigh
+			    || capsule3D && hitZ < HitBBox.ZHigh) {
+				return -1.0f;
+			}
+
+			var hitX = ball.State.Pos.X + ball.Hit.Vel.X * hitTime;
+			var hitY = ball.State.Pos.Y + ball.Hit.Vel.Y * hitTime;
+			var sqrLen = (hitX - c.X) * (hitX - c.X) + (hitY - c.Y) * (hitY - c.Y);
+
+			coll.HitNormal.SetZero();
+
+			// over center?
+			if (sqrLen > 1.0e-8) {
+				// no
+				var invLen = 1.0f / MathF.Sqrt(sqrLen);
+				coll.HitNormal.X = (hitX - c.X) * invLen;
+				coll.HitNormal.Y = (hitY - c.Y) * invLen;
+
+			} else {
+				// yes, over center
+				coll.HitNormal.X = 0.0f; // make up a value, any direction is ok
+				coll.HitNormal.Y = 1.0f;
+				coll.HitNormal.Z = 0.0f;
+			}
+
+			if (!rigid) {
+				// non rigid body collision? return direction
+				coll.HitFlag = isUnhit; // UnHit signal is receding from target
+			}
+
+			coll.IsContact = isContact;
+			if (isContact) {
+				coll.HitOrgNormalVelocity = bnv;
+			}
+
+			coll.HitDistance = bnd; // actual contact distance ...
+			//coll.M_hitRigid = rigid;                         // collision type
+
+			return hitTime;
+		}
+	}
+}

--- a/VisualPinball.Engine/Physics/HitKd.cs
+++ b/VisualPinball.Engine/Physics/HitKd.cs
@@ -7,7 +7,7 @@ namespace VisualPinball.Engine.Physics
 {
 	public class HitKd
 	{
-		public List<int> OrgIdx;                                               // m_org_idx
+		public int[] OrgIdx;                                                   // m_org_idx
 		public int NumNodes;                                                   // m_num_nodes
 		public int[] Indices;                                                  // tmp
 
@@ -31,7 +31,7 @@ namespace VisualPinball.Engine.Physics
 			if (_numItems > _maxItems) {
 				_maxItems = _numItems;
 
-				OrgIdx = new List<int>(_numItems);
+				OrgIdx = new int[_numItems];
 				Indices = new int[_numItems];
 				_nodes = new HitKdNode[(_numItems * 2 + 1) & ~1u];
 			}

--- a/VisualPinball.Engine/Physics/HitObject.cs
+++ b/VisualPinball.Engine/Physics/HitObject.cs
@@ -62,7 +62,7 @@ namespace VisualPinball.Engine.Physics
 		/// <param name="coll"></param>
 		/// <param name="dTime"></param>
 		/// <param name="physics"></param>
-		public void Contact(CollisionEvent coll, float dTime, PlayerPhysics physics)
+		public virtual void Contact(CollisionEvent coll, float dTime, PlayerPhysics physics)
 		{
 			coll.Ball.Hit.HandleStaticContact(coll, Friction, dTime, physics);
 		}

--- a/VisualPinball.Engine/VPT/Ball/BallMover.cs
+++ b/VisualPinball.Engine/VPT/Ball/BallMover.cs
@@ -37,7 +37,7 @@ namespace VisualPinball.Engine.VPT.Ball
 		public void UpdateVelocities(PlayerPhysics physics)
 		{
 			if (!_state.IsFrozen) {
-				_hit.Vel.Add(physics.Gravity.MultiplyScalar(PhysicsConstants.PhysFactor));
+				_hit.Vel.Add(physics.Gravity.Clone().MultiplyScalar(PhysicsConstants.PhysFactor));
 
 				// todo nudge
 				// _hit.Vel.X += player.NudgeX; // depends TODO on STEPTIME

--- a/VisualPinball.Engine/VPT/Ball/BallState.cs
+++ b/VisualPinball.Engine/VPT/Ball/BallState.cs
@@ -4,12 +4,15 @@ namespace VisualPinball.Engine.VPT.Ball
 {
 	public class BallState
 	{
-		public Vertex3D Pos = new Vertex3D();
-		public Matrix2D Orientation = new Matrix2D();
+		public readonly string Name;
+		public readonly Vertex3D Pos;
+		public readonly Matrix2D Orientation = new Matrix2D();
 		public bool IsFrozen = false;
 
 		public BallState(string name, Vertex3D pos)
 		{
+			Name = name;
+			Pos = pos;
 		}
 	}
 }

--- a/VisualPinball.Engine/VPT/Flipper/Flipper.cs
+++ b/VisualPinball.Engine/VPT/Flipper/Flipper.cs
@@ -1,15 +1,21 @@
 ﻿using System.IO;
 using VisualPinball.Engine.Game;
+using VisualPinball.Engine.Physics;
 
 namespace VisualPinball.Engine.VPT.Flipper
 {
-	public class Flipper : Item<FlipperData>, IRenderable
+	public class Flipper : Item<FlipperData>, IRenderable, IPlayable, IMovable, IHittable
 	{
+		public EventProxy EventProxy { get; private set; }
+
 		private readonly FlipperMeshGenerator _meshGenerator;
+		private readonly FlipperState _state;
+		private FlipperHit _hit;
 
 		public Flipper(FlipperData data) : base(data)
 		{
 			_meshGenerator = new FlipperMeshGenerator(Data);
+			_state = new FlipperState(Data.Name, data.IsVisible, data.StartAngle, data.Center.Clone(), data.Material, data.Image, data.RubberMaterial);
 		}
 
 		public Flipper(BinaryReader reader, string itemName) : this(new FlipperData(reader, itemName)) { }
@@ -18,5 +24,16 @@ namespace VisualPinball.Engine.VPT.Flipper
 		{
 			return _meshGenerator.GetRenderObjects(table, origin, asRightHanded);
 		}
+
+		public void SetupPlayer(Player player, Table.Table table)
+		{
+			EventProxy = new EventProxy(this);
+			_hit = new FlipperHit(Data, _state, EventProxy, table);
+		}
+
+		public IMoverObject GetMover() => _hit.GetMoverObject();
+		public bool IsCollidable => true;
+
+		public HitObject[] GetHitShapes() => new HitObject[] { _hit };
 	}
 }

--- a/VisualPinball.Engine/VPT/Flipper/Flipper.cs
+++ b/VisualPinball.Engine/VPT/Flipper/Flipper.cs
@@ -40,5 +40,11 @@ namespace VisualPinball.Engine.VPT.Flipper
 			_hit.GetMoverObject().EnableRotateEvent = 1;
 			_hit.GetMoverObject().SetSolenoidState(true);
 		}
+
+		// todo move to api
+		public void RotateToStart() {
+			_hit.GetMoverObject().EnableRotateEvent = -1;
+			_hit.GetMoverObject().SetSolenoidState(false);
+		}
 	}
 }

--- a/VisualPinball.Engine/VPT/Flipper/Flipper.cs
+++ b/VisualPinball.Engine/VPT/Flipper/Flipper.cs
@@ -6,16 +6,16 @@ namespace VisualPinball.Engine.VPT.Flipper
 {
 	public class Flipper : Item<FlipperData>, IRenderable, IPlayable, IMovable, IHittable
 	{
+		public FlipperState State { get; }
 		public EventProxy EventProxy { get; private set; }
 
 		private readonly FlipperMeshGenerator _meshGenerator;
-		private readonly FlipperState _state;
 		private FlipperHit _hit;
 
 		public Flipper(FlipperData data) : base(data)
 		{
 			_meshGenerator = new FlipperMeshGenerator(Data);
-			_state = new FlipperState(Data.Name, data.IsVisible, data.StartAngle, data.Center.Clone(), data.Material, data.Image, data.RubberMaterial);
+			State = new FlipperState(Data.Name, data.IsVisible, data.StartAngle, data.Center.Clone(), data.Material, data.Image, data.RubberMaterial);
 		}
 
 		public Flipper(BinaryReader reader, string itemName) : this(new FlipperData(reader, itemName)) { }
@@ -28,12 +28,17 @@ namespace VisualPinball.Engine.VPT.Flipper
 		public void SetupPlayer(Player player, Table.Table table)
 		{
 			EventProxy = new EventProxy(this);
-			_hit = new FlipperHit(Data, _state, EventProxy, table);
+			_hit = new FlipperHit(Data, State, EventProxy, table);
 		}
 
 		public IMoverObject GetMover() => _hit.GetMoverObject();
 		public bool IsCollidable => true;
-
 		public HitObject[] GetHitShapes() => new HitObject[] { _hit };
+
+		// todo move to api
+		public void RotateToEnd() {
+			_hit.GetMoverObject().EnableRotateEvent = 1;
+			_hit.GetMoverObject().SetSolenoidState(true);
+		}
 	}
 }

--- a/VisualPinball.Engine/VPT/Flipper/Flipper.cs
+++ b/VisualPinball.Engine/VPT/Flipper/Flipper.cs
@@ -32,6 +32,8 @@ namespace VisualPinball.Engine.VPT.Flipper
 		}
 
 		public IMoverObject GetMover() => _hit.GetMoverObject();
+		public FlipperMover FlipperMover => _hit.GetMoverObject();
+
 		public bool IsCollidable => true;
 		public HitObject[] GetHitShapes() => new HitObject[] { _hit };
 

--- a/VisualPinball.Engine/VPT/Flipper/FlipperData.cs
+++ b/VisualPinball.Engine/VPT/Flipper/FlipperData.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using VisualPinball.Engine.Common;
 using VisualPinball.Engine.IO;
 using VisualPinball.Engine.Math;
 using VisualPinball.Engine.VPT.Table;
@@ -121,6 +122,77 @@ namespace VisualPinball.Engine.VPT.Flipper
 		[BiffInt("TMIN", Pos = 11)]
 		public int TimerInterval;
 
+		public float OverrideMass;
+		public float OverrideStrength;
+		public float OverrideElasticity;
+		public float OverrideElasticityFalloff;
+		public float OverrideFriction;
+		public float OverrideReturnStrength;
+		public float OverrideCoilRampUp;
+		public float OverrideTorqueDamping;
+		public float OverrideTorqueDampingAngle;
+		public float OverrideScatterAngle;
+
+		public void UpdatePhysicsSettings(Table.Table table)
+		{
+			if (DoOverridePhysics(table)) {
+				var registry = Registry.Instance;
+
+				var idx = OverridePhysics != 0 ? OverridePhysics - 1 : table.Data.OverridePhysics - 1;
+
+				OverrideMass = registry.Get<float>("Player", $"FlipperPhysicsMass${idx}", 1);
+				if (OverrideMass < 0.0) {
+					OverrideMass = Mass;
+				}
+
+				OverrideStrength = registry.Get<float>("Player", $"FlipperPhysicsStrength${idx}", 2200);
+				if (OverrideStrength < 0.0) {
+					OverrideStrength = Strength;
+				}
+
+				OverrideElasticity = registry.Get<float>("Player", $"FlipperPhysicsElasticity${idx}", 0.8f);
+				if (OverrideElasticity < 0.0) {
+					OverrideElasticity = Elasticity;
+				}
+
+				OverrideScatterAngle = registry.Get<float>("Player", $"FlipperPhysicsScatter${idx}", 0);
+				if (OverrideScatterAngle < 0.0) {
+					OverrideScatterAngle = Scatter;
+				}
+
+				OverrideReturnStrength = registry.Get<float>("Player", $"FlipperPhysicsReturnStrength${idx}", 0.058f);
+				if (OverrideReturnStrength < 0.0) {
+					OverrideReturnStrength = Return;
+				}
+
+				OverrideElasticityFalloff =
+					registry.Get<float>("Player", $"FlipperPhysicsElasticityFalloff${idx}", 0.43f);
+				if (OverrideElasticityFalloff < 0.0) {
+					OverrideElasticityFalloff = ElasticityFalloff;
+				}
+
+				OverrideFriction = registry.Get<float>("Player", $"FlipperPhysicsFriction${idx}", 0.6f);
+				if (OverrideFriction < 0.0) {
+					OverrideFriction = Friction;
+				}
+
+				OverrideCoilRampUp = registry.Get<float>("Player", $"FlipperPhysicsCoilRampUp${idx}", 3.0f);
+				if (OverrideCoilRampUp < 0.0) {
+					OverrideCoilRampUp = RampUp;
+				}
+
+				OverrideTorqueDamping = registry.Get<float>("Player", $"FlipperPhysicsEOSTorque${idx}", 0.75f);
+				if (OverrideTorqueDamping < 0.0) {
+					OverrideTorqueDamping = TorqueDamping;
+				}
+
+				OverrideTorqueDampingAngle = registry.Get<float>("Player", $"FlipperPhysicsEOSTorqueAngle${idx}", 6.0f);
+				if (OverrideTorqueDampingAngle < 0.0) {
+					OverrideTorqueDampingAngle = TorqueDampingAngle;
+				}
+			}
+		}
+
 		#region BIFF
 
 		static FlipperData()
@@ -147,5 +219,7 @@ namespace VisualPinball.Engine.VPT.Flipper
 		private static readonly Dictionary<string, List<BiffAttribute>> Attributes = new Dictionary<string, List<BiffAttribute>>();
 
 		#endregion
+
+		public bool DoOverridePhysics(Table.Table table) => OverridePhysics != 0 || table.Data.OverridePhysicsFlipper && table.Data.OverridePhysics != 0;
 	}
 }

--- a/VisualPinball.Engine/VPT/Flipper/FlipperHit.cs
+++ b/VisualPinball.Engine/VPT/Flipper/FlipperHit.cs
@@ -1,0 +1,783 @@
+﻿// ReSharper disable CommentTypo
+// ReSharper disable CompareOfFloatsByEqualityOperator
+
+using VisualPinball.Engine.Game;
+using VisualPinball.Engine.Math;
+using VisualPinball.Engine.Physics;
+using VisualPinball.Engine.VPT.Table;
+
+namespace VisualPinball.Engine.VPT.Flipper
+{
+	public class FlipperHit : HitObject
+	{
+		private readonly FlipperMover _mover;
+		private readonly FlipperData _data;
+		private readonly FlipperState _state;
+		private readonly TableData _tableData;
+		private readonly EventProxy _events;
+		private uint _lastHitTime;                                             // m_last_hittime
+
+		public FlipperHit(FlipperData data, FlipperState state, EventProxy events, Table.Table table)
+		{
+			data.UpdatePhysicsSettings(table);
+			_events = events;
+			_mover = new FlipperMover(data, state, events, table);
+			_data = data;
+			_state = state;
+			_tableData = table.Data;
+			UpdatePhysicsFromFlipper();
+		}
+
+		public override void CalcHitBBox()
+		{
+			// Allow roundoff
+			HitBBox = new Rect3D(
+				_mover.HitCircleBase.Center.X - _mover.FlipperRadius - _mover.EndRadius - 0.1f,
+				_mover.HitCircleBase.Center.X + _mover.FlipperRadius + _mover.EndRadius + 0.1f,
+				_mover.HitCircleBase.Center.Y - _mover.FlipperRadius - _mover.EndRadius - 0.1f,
+				_mover.HitCircleBase.Center.Y + _mover.FlipperRadius + _mover.EndRadius + 0.1f,
+				_mover.HitCircleBase.HitBBox.ZLow,
+				_mover.HitCircleBase.HitBBox.ZHigh
+			);
+		}
+
+		public override float HitTest(Ball.Ball ball, float dTime, CollisionEvent coll, PlayerPhysics physics)
+		{
+			if (!_data.IsEnabled) {
+				return -1.0f;
+			}
+
+			var lastFace = _mover.LastHitFace;
+
+			// for effective computing, adding a last face hit value to speed calculations
+			// a ball can only hit one face never two
+			// also if a ball hits a face then it can not hit either radius
+			// so only check these if a face is not hit
+			// endRadius is more likely than baseRadius ... so check it first
+
+			var hitTime = HitTestFlipperFace(ball, dTime, coll, lastFace); // first face
+			if (hitTime >= 0) {
+				return hitTime;
+			}
+
+			hitTime = HitTestFlipperFace(ball, dTime, coll, !lastFace); //second face
+			if (hitTime >= 0) {
+				_mover.LastHitFace = !lastFace; // change this face to check first // HACK
+				return hitTime;
+			}
+
+			hitTime = HitTestFlipperEnd(ball, dTime, coll); // end radius
+			if (hitTime >= 0) {
+				return hitTime;
+			}
+
+			hitTime = _mover.HitCircleBase.HitTest(ball, dTime, coll, physics);
+			if (hitTime >= 0) {
+				// Tangent velocity of contact point (rotate Normal right)
+				// rad units*d/t (Radians*diameter/time)
+				coll.HitVel.Set(0, 0);
+				coll.HitMomentBit = true;
+				return hitTime;
+			}
+
+			return -1.0f; // no hits
+		}
+
+		public override void Contact(CollisionEvent coll, float dTime, PlayerPhysics physics)
+		{
+			var ball = coll.Ball;
+			var normal = coll.HitNormal;
+
+			//#ifdef PhysicsConstants.EMBEDDED
+			if (coll.HitDistance < -PhysicsConstants.Embedded) {
+				// magic to avoid balls being pushed by each other through resting flippers!
+				ball.Hit.Vel.Add(normal.Clone().MultiplyScalar(0.1f));
+			}
+			//#endif
+
+			var vRel = new Vertex3D();
+			var rB = new Vertex3D();
+			var rF = new Vertex3D();
+			GetRelativeVelocity(normal, ball, vRel, rB, rF);
+
+			// this should be zero, but only up to +/- C_CONTACTVEL
+			var normVel = vRel.Dot(normal);
+
+			// If some collision has changed the ball's velocity, we may not have to do anything.
+			if (normVel <= PhysicsConstants.ContactVel) {
+				// compute accelerations of point on ball and flipper
+				var aB = ball.Hit.SurfaceAcceleration(rB, physics);
+				var aF = _mover.SurfaceAcceleration(rF);
+				var aRel = aB.Clone().Sub(aF);
+
+				// time derivative of the normal vector
+				var normalDeriv = Vertex3D.CrossZ(_mover.AngleSpeed, normal);
+
+				// relative acceleration in the normal direction
+				var normAcc = aRel.Dot(normal) + 2.0f * normalDeriv.Dot(vRel);
+
+				if (normAcc >= 0) {
+					return; // objects accelerating away from each other, nothing to do
+				}
+
+				// hypothetical accelerations arising from a unit contact force in normal direction
+				var aBc = normal.Clone().MultiplyScalar(ball.Hit.InvMass);
+				var pv2 = normal.Clone().MultiplyScalar(-1);
+				var cross = Vertex3D.CrossProduct(rF, pv2);
+				var pv1 = cross.Clone().DivideScalar(_mover.Inertia);
+				var aFc = Vertex3D.CrossProduct(pv1, rF);
+				var contactForceAcc = normal.Dot(aBc.Clone().Sub(aFc));
+
+				// find j >= 0 such that normAcc + j * contactForceAcc >= 0  (bodies should not accelerate towards each other)
+				var j = -normAcc / contactForceAcc;
+
+				// kill any existing normal velocity
+				ball.Hit.Vel.Add(normal.Clone().MultiplyScalar(j * dTime * ball.Hit.InvMass - coll.HitOrgNormalVelocity));
+				_mover.ApplyImpulse(cross.Clone().MultiplyScalar(j * dTime));
+
+				// apply friction
+
+				// first check for slippage
+				var slip = vRel.Clone().Sub(normal.Clone().MultiplyScalar(normVel)); // calc the tangential slip velocity
+				var maxFriction = j * Friction;
+				var slipSpeed = slip.Length();
+				Vertex3D slipDir;
+				Vertex3D crossF;
+				float numer;
+				float denomF;
+				Vertex3D pv13;
+
+				if (slipSpeed < PhysicsConstants.Precision) {
+					// slip speed zero - static friction case
+					var slipAcc = aRel.Clone().Sub(normal.Clone().MultiplyScalar(aRel.Dot(normal))); // calc the tangential slip acceleration
+
+					// neither slip velocity nor slip acceleration? nothing to do here
+					if (slipAcc.LengthSq() < 1e-6) {
+						return;
+					}
+
+					slipDir = slipAcc.Normalize();
+					numer = -slipDir.Dot(aRel);
+					crossF = Vertex3D.CrossProduct(rF, slipDir);
+					pv13 = crossF.Clone().DivideScalar(-_mover.Inertia);
+					denomF = slipDir.Dot(Vertex3D.CrossProduct(pv13, rF));
+
+				} else {
+					// nonzero slip speed - dynamic friction case
+					slipDir = slip.Clone().DivideScalar(slipSpeed);
+
+					numer = -slipDir.Dot(vRel);
+					crossF = Vertex3D.CrossProduct(rF, slipDir);
+					pv13 = crossF.Clone().DivideScalar(_mover.Inertia);
+					denomF = slipDir.Dot(Vertex3D.CrossProduct(pv13, rF));
+				}
+
+				var crossB = Vertex3D.CrossProduct(rB, slipDir);
+				var pv12 = crossB.Clone().DivideScalar(ball.Hit.Inertia);
+				var denomB = ball.Hit.InvMass + slipDir.Dot(Vertex3D.CrossProduct(pv12, rB));
+				var friction = Functions.Clamp(numer / (denomB + denomF), -maxFriction, maxFriction);
+
+				ball.Hit.ApplySurfaceImpulse(
+					crossB.Clone().MultiplyScalar(dTime * friction),
+					slipDir.Clone().MultiplyScalar(dTime * friction)
+				);
+				_mover.ApplyImpulse(crossF.Clone().MultiplyScalar(-dTime * friction));
+			}
+		}
+
+		public override void Collide(CollisionEvent coll, PlayerPhysics physics)
+		{
+			var ball = coll.Ball;
+			var normal = coll.HitNormal;
+			var vRel = new Vertex3D();
+			var rB = new Vertex3D();
+			var rF = new Vertex3D();
+			GetRelativeVelocity(normal, ball, vRel, rB, rF);
+
+			var bnv = normal.Dot(vRel); // relative normal velocity
+
+			if (bnv >= -PhysicsConstants.LowNormVel) {
+				// nearly receding ... make sure of conditions
+				if (bnv > PhysicsConstants.LowNormVel) {
+					// otherwise if clearly approaching .. process the collision
+					// is this velocity clearly receding (i.E must > a minimum)
+					return;
+				}
+
+				//#ifdef PhysicsConstants.EMBEDDED
+				if (coll.HitDistance < -PhysicsConstants.Embedded) {
+					bnv = -PhysicsConstants.EmbedShot; // has ball become embedded???, give it a kick
+
+				} else {
+					return;
+				}
+
+				//#endif
+			}
+
+			//#ifdef PhysicsConstants.DISP_GAIN
+			// correct displacements, mostly from low velocity blindness, an alternative to true acceleration processing
+			var hitDist = -PhysicsConstants.DispGain * coll.HitDistance; // distance found in hit detection
+			if (hitDist > 1.0e-4) {
+				if (hitDist > PhysicsConstants.DispLimit) {
+					hitDist = PhysicsConstants.DispLimit; // crossing ramps, delta noise
+				}
+
+				// push along norm, back to free area; use the norm, but is not correct
+				ball.State.Pos.Add(coll.HitNormal.Clone().MultiplyScalar(hitDist));
+			}
+			//#endif
+
+			// angular response to impulse in normal direction
+			var angResp = Vertex3D.CrossProduct(rF, normal);
+
+			/*
+			 * Check if flipper is in contact with its stopper and the collision impulse
+			 * would push it beyond the stopper. In that case, don"t allow any transfer
+			 * of kinetic energy from ball to flipper. This avoids overly dead bounces
+			 * in that case.
+			 */
+			var angImp = -angResp.Z; // minus because impulse will apply in -normal direction
+			var flipperResponseScaling = 1.0f;
+			if (_mover.IsInContact && _mover.ContactTorque * angImp >= 0f) {
+				// if impulse pushes against stopper, allow no loss of kinetic energy to flipper
+				// (still allow flipper recoil, but a diminished amount)
+				angResp.SetZero();
+				flipperResponseScaling = 0.5f;
+			}
+
+			/*
+			 * Rubber has a coefficient of restitution which decreases with the impact velocity.
+			 * We use a heuristic model which decreases the COR according to a falloff parameter:
+			 * 0 = no falloff, 1 = half the COR at 1 m/s (18.53 speed units)
+			 */
+			var epsilon = Functions.ElasticityWithFalloff(Elasticity, ElasticityFalloff, bnv);
+
+			var pv1 = angResp.Clone().DivideScalar(_mover.Inertia);
+			var impulse = -(1.0f + epsilon) * bnv / (ball.Hit.InvMass + normal.Dot(Vertex3D.CrossProduct(pv1, rF)));
+			var flipperImp = normal.Clone().MultiplyScalar(-(impulse * flipperResponseScaling));
+
+			var rotI = Vertex3D.CrossProduct(rF, flipperImp);
+			if (_mover.IsInContact) {
+				if (rotI.Z * _mover.ContactTorque < 0) {
+					// pushing against the solenoid?
+
+					// Get a bound on the time the flipper needs to return to static conditions.
+					// If it"s too short, we treat the flipper as static during the whole collision.
+					var recoilTime = -rotI.Z / _mover.ContactTorque; // time flipper needs to eliminate this impulse, in 10ms
+
+					// Check ball normal velocity after collision. If the ball rebounded
+					// off the flipper, we need to make sure it does so with full
+					// reflection, i.E., treat the flipper as static, otherwise
+					// we get overly dead bounces.
+					var bnvAfter = bnv + impulse * ball.Hit.InvMass;
+
+					if (recoilTime <= 0.5 || bnvAfter > 0) {
+						// treat flipper as static for this impact
+						impulse = -(1.0f + epsilon) * bnv * ball.Data.Mass;
+						flipperImp.SetZero();
+						rotI.SetZero();
+					}
+				}
+			}
+
+			ball.Hit.Vel.Add(normal.Clone().MultiplyScalar(impulse * ball.Hit.InvMass)); // new velocity for ball after impact
+			_mover.ApplyImpulse(rotI);
+
+			// apply friction
+			var tangent = vRel.Clone().Sub(normal.Clone().MultiplyScalar(vRel.Dot(normal))); // calc the tangential velocity
+
+			var tangentSpSq = tangent.LengthSq();
+			if (tangentSpSq > 1e-6) {
+				tangent.DivideScalar(MathF.Sqrt(tangentSpSq)); // normalize to get tangent direction
+				var vt = vRel.Dot(tangent); // get speed in tangential direction
+
+				// compute friction impulse
+				var crossB = Vertex3D.CrossProduct(rB, tangent);
+				var pv12 = crossB.Clone().DivideScalar(ball.Hit.Inertia);
+				var kt = ball.Hit.InvMass + tangent.Dot(Vertex3D.CrossProduct(pv12, rB));
+
+				var crossF = Vertex3D.CrossProduct(rF, tangent);
+				var pv13 = crossF.Clone().DivideScalar(_mover.Inertia);
+				kt += tangent.Dot(Vertex3D.CrossProduct(pv13, rF)); // flipper only has angular response
+
+				// friction impulse can't be greater than coefficient of friction times collision impulse (Coulomb friction cone)
+				var maxFriction = Friction * impulse;
+				var jt = Functions.Clamp(-vt / kt, -maxFriction, maxFriction);
+
+				ball.Hit.ApplySurfaceImpulse(
+					crossB.Clone().MultiplyScalar(jt),
+					tangent.Clone().MultiplyScalar(jt)
+				);
+				_mover.ApplyImpulse(crossF.Clone().MultiplyScalar(-jt));
+			}
+
+			if (bnv < -0.25 && physics.TimeMsec - _lastHitTime > 250) {
+				// limit rate to 250 milliseconds per event
+				var flipperHit =
+					coll.HitMomentBit ? -1.0 : -bnv; // move event processing to end of collision handler...
+				if (flipperHit < 0) {
+					_events.FireGroupEvent(Event.HitEventsHit); // simple hit event
+
+				} else {
+					// collision velocity (normal to face)
+					_events.FireVoidEventParam(Event.FlipperEventsCollide, flipperHit);
+				}
+			}
+
+			_lastHitTime = physics.TimeMsec; // keep resetting until idle for 250 milliseconds
+		}
+
+		public FlipperMover GetMoverObject()
+		{
+			return _mover;
+		}
+
+		public void UpdatePhysicsFromFlipper()
+		{
+			ElasticityFalloff = _data.OverridePhysics != 0 || _tableData.OverridePhysicsFlipper && _tableData.OverridePhysics != 0
+				? _data.OverrideElasticityFalloff
+				: _data.ElasticityFalloff;
+			Elasticity = _data.OverridePhysics != 0 || _tableData.OverridePhysicsFlipper && _tableData.OverridePhysics != 0
+				? _data.OverrideElasticity
+				: _data.Elasticity;
+			SetFriction(_data.OverridePhysics != 0 || _tableData.OverridePhysicsFlipper && _tableData.OverridePhysics != 0
+				? _data.OverrideFriction
+				: _data.Friction);
+			Scatter = MathF.DegToRad( _data.OverridePhysics != 0 || _tableData.OverridePhysicsFlipper && _tableData.OverridePhysics != 0
+				? _data.OverrideScatterAngle
+				: _data.Scatter);
+		}
+
+		public float HitTestFlipperFace(Ball.Ball ball, float dTime, CollisionEvent coll, bool face1)
+		{
+			var angleCur = _state.Angle;
+			var angleSpeed = _mover.AngleSpeed; // rotation rate
+
+			var flipperBase = _mover.HitCircleBase.Center;
+			var feRadius = _mover.EndRadius;
+
+			var angleMin = MathF.Min(_mover.AngleStart, _mover.AngleEnd);
+			var angleMax = MathF.Max(_mover.AngleStart, _mover.AngleEnd);
+
+			var ballRadius = ball.Data.Radius;
+			var ballVx = ball.Hit.Vel.X;
+			var ballVy = ball.Hit.Vel.Y;
+
+			// flipper positions at zero degrees rotation
+			var ffnx = _mover.ZeroAngNorm.X; // flipper face normal vector //Face2
+			if (face1) {
+				// negative for face1 (left face)
+				ffnx = -ffnx;
+			}
+
+			var ffny = _mover.ZeroAngNorm.Y; // norm y component same for either face
+			var vp = new Vertex2D( // face segment V1 point
+				_mover.HitCircleBase.Radius * ffnx, // face endpoint of line segment on base radius
+				_mover.HitCircleBase.Radius * ffny
+			);
+
+			var faceNormal = new Vertex2D(); // flipper face normal
+
+			float bffnd = 0; // ball flipper face normal distance (negative for normal side)
+			float ballVtx = 0; // new ball position at time t in flipper face coordinate
+			float ballVty = 0;
+			float contactAng = 0;
+
+			// Modified False Position control
+			float t = 0;
+			float t0 = 0;
+			float t1 = 0;
+			float d0 = 0;
+			float d1 = 0;
+			float dp = 0;
+
+			// start first interval ++++++++++++++++++++++++++
+			int k;
+			for (k = 1; k <= PhysicsConstants.Internations; ++k) {
+				// determine flipper rotation direction, limits and parking
+				contactAng = angleCur + angleSpeed * t; // angle at time t
+
+				if (contactAng >= angleMax) {
+					// stop here
+					contactAng = angleMax;
+				}
+				else if (contactAng <= angleMin) {
+					// stop here
+					contactAng = angleMin;
+				}
+
+				var radSin = MathF.Sin(contactAng); // Green"s transform matrix... rotate angle delta
+				var radCos = MathF.Cos(contactAng); // rotational transform from current position to position at time t
+
+				faceNormal.X = ffnx * radCos - ffny * radSin; // rotate to time t, norm and face offset point
+				faceNormal.Y = ffny * radCos + ffnx * radSin;
+
+				var vt = new Vertex2D(
+					vp.X * radCos - vp.Y * radSin + flipperBase.X, // rotate and translate to world position
+					vp.Y * radCos + vp.X * radSin + flipperBase.Y
+				);
+
+				ballVtx = ball.State.Pos.X + ballVx * t - vt.X; // new ball position relative to rotated line segment endpoint
+				ballVty = ball.State.Pos.Y + ballVy * t - vt.Y;
+
+				bffnd = ballVtx * faceNormal.X + ballVty * faceNormal.Y - ballRadius; // normal distance to segment
+
+				if (MathF.Abs(bffnd) <= PhysicsConstants.Precision) {
+					break;
+				}
+
+				// loop control, boundary checks, next estimate, etc.
+				if (k == 1) {
+					// end of pass one ... set full interval pass, t = dtime
+
+					// test for already inside flipper plane, either embedded or beyond the face endpoints
+					if (bffnd < -(ball.Data.Radius + feRadius)) {
+						return -1.0f; // wrong side of face, or too deeply embedded
+					}
+
+					if (bffnd <= PhysicsConstants.PhysTouch) {
+						break; // inside the clearance limits, go check face endpoints
+					}
+
+					t0 = t1 = dTime;
+					d0 = 0;
+					d1 = bffnd; // set for second pass, so t=dtime
+
+				} else if (k == 2) {
+					// end pass two, check if zero crossing on initial interval, exit
+					if (dp * bffnd > 0.0) {
+						return -1.0f; // no solution ... no obvious zero crossing
+					}
+
+					t0 = 0;
+					t1 = dTime;
+					d0 = dp;
+					d1 = bffnd; // testing MFP estimates
+
+				} else {
+					// (k >= 3)                           // MFP root search +++++++++++++++++++++++++++++++++++++++++
+					if (bffnd * d0 <= 0.0) {
+						// zero crossing
+						t1 = t;
+						d1 = bffnd;
+						if (dp * bffnd > 0.0) {
+							d0 *= 0.5f;
+						}
+
+					} else {
+						// move right limits
+						t0 = t;
+						d0 = bffnd;
+						if (dp * bffnd > 0.0) {
+							d1 *= 0.5f;
+						}
+					} // move left limits
+				}
+
+				t = t0 - d0 * (t1 - t0) / (d1 - d0); // next estimate
+				dp = bffnd; // remember
+			}
+
+			// +++ End time iteration loop found time t soultion ++++++
+			if (float.IsNaN(t) || float.IsInfinity(t)
+			                   || t < 0
+			                   || t > dTime // time is outside this frame ... no collision
+			                   || k > PhysicsConstants.Internations && MathF.Abs(bffnd) > ball.Data.Radius * 0.25) {
+				// last ditch effort to accept a near solution
+
+				return -1.0f; // no solution
+			}
+
+			// here ball and flipper face are in contact... past the endpoints, also, don"t forget embedded and near solution
+			var faceTangent = new Vertex2D(); // flipper face tangent
+			if (face1) {
+				// left face?
+				faceTangent.X = -faceNormal.Y;
+				faceTangent.Y = faceNormal.X;
+			}
+			else {
+				// rotate to form Tangent vector
+				faceTangent.X = faceNormal.Y;
+				faceTangent.Y = -faceNormal.X;
+			}
+
+			var bfftd = ballVtx * faceTangent.X + ballVty * faceTangent.Y; // ball to flipper face tangent distance
+
+			var len = _mover.FlipperRadius * _mover.ZeroAngNorm.X; // face segment length ... e.G. same on either face
+			if (bfftd < -PhysicsConstants.ToleranceEndPoints || bfftd > len + PhysicsConstants.ToleranceEndPoints) {
+				return -1.0f; // not in range of touching
+			}
+
+			var hitZ = ball.State.Pos.Z + ball.Hit.Vel.Z * t; // check for a hole, relative to ball rolling point at hittime
+
+			// check limits of object"s height and depth
+			if (hitZ + ballRadius * 0.5 < HitBBox.ZLow || hitZ - ballRadius * 0.5 > HitBBox.ZHigh) {
+				return -1.0f;
+			}
+
+			// ok we have a confirmed contact, calc the stats, remember there are "near" solution, so all
+			// parameters need to be calculated from the actual configuration, i.E contact radius must be calc"ed
+
+			// hit normal is same as line segment normal
+			coll.HitNormal.Set(faceNormal.X, faceNormal.Y, 0);
+
+			var dist = new Vertex2D( // calculate moment from flipper base center
+				ball.State.Pos.X + ballVx * t - ballRadius * faceNormal.X -
+				_mover.HitCircleBase.Center.X, // center of ball + projected radius to contact point
+				ball.State.Pos.Y + ballVy * t - ballRadius * faceNormal.Y -
+				_mover.HitCircleBase.Center.Y // all at time t
+			);
+
+			var distance = MathF.Sqrt(dist.X * dist.X + dist.Y * dist.Y); // distance from base center to contact point
+
+			var invDist = 1.0f / distance;
+			coll.HitVel.Set(-dist.Y * invDist,
+				dist.X * invDist); // Unit Tangent velocity of contact point(rotate Normal clockwise)
+			//coll.Hitvelocity.Z = 0.0f; // used as normal velocity so far, only if isContact is set, see below
+
+			if (contactAng >= angleMax && angleSpeed > 0 || contactAng <= angleMin && angleSpeed < 0) {
+				// hit limits ???
+				angleSpeed = 0.0f; // rotation stopped
+			}
+
+			coll.HitMomentBit = distance == 0;
+
+			var dv = new Vertex2D( // delta velocity ball to face
+				ballVx - coll.HitVel.X * angleSpeed * distance,
+				ballVy - coll.HitVel.Y * angleSpeed * distance
+			);
+
+			var bnv = dv.X * coll.HitNormal.X + dv.Y * coll.HitNormal.Y; // dot Normal to delta v
+
+			if (MathF.Abs(bnv) <= PhysicsConstants.ContactVel && bffnd <= PhysicsConstants.PhysTouch) {
+				coll.IsContact = true;
+				coll.HitOrgNormalVelocity = bnv;
+
+			} else if (bnv > PhysicsConstants.LowNormVel) {
+				return -1.0f; // not hit ... ball is receding from endradius already, must have been embedded
+			}
+
+			coll.HitDistance = bffnd; // normal ...Actual contact distance ...
+			//coll.M_hitRigid = true;                               // collision type
+
+			return t;
+		}
+
+		private void GetRelativeVelocity(Vertex3D normal, Ball.Ball ball, Vertex3D vRel, Vertex3D rB, Vertex3D rF)
+		{
+			rB.Set(normal.Clone().MultiplyScalar(-ball.Data.Radius));
+			var hitPos = ball.State.Pos.Clone().Add(rB);
+
+			var cF = new Vertex3D(
+				_mover.HitCircleBase.Center.X,
+				_mover.HitCircleBase.Center.Y,
+				ball.State.Pos.Z // make sure collision happens in same z plane where ball is
+			);
+
+			rF.Set(hitPos.Clone().Sub(cF)); // displacement relative to flipper center
+			var vB = ball.Hit.SurfaceVelocity(rB);
+			var vF = _mover.SurfaceVelocity(rF);
+			vRel.Set(vB.Clone().Sub(vF));
+		}
+
+		private float HitTestFlipperEnd(Ball.Ball ball, float dTime, CollisionEvent coll)
+		{
+			var angleCur = _state.Angle;
+			var angleSpeed = _mover.AngleSpeed; // rotation rate
+
+			var flipperBase = _mover.HitCircleBase.Center;
+
+			var angleMin = MathF.Min(_mover.AngleStart, _mover.AngleEnd);
+			var angleMax = MathF.Max(_mover.AngleStart, _mover.AngleEnd);
+
+			var ballRadius = ball.Data.Radius;
+			var feRadius = _mover.EndRadius;
+
+			var ballEndRadius = feRadius + ballRadius; // magnititude of (ball - flipperEnd)
+
+			var ballX = ball.State.Pos.X;
+			var ballY = ball.State.Pos.Y;
+
+			var ballVx = ball.Hit.Vel.X;
+			var ballVy = ball.Hit.Vel.Y;
+
+			var vp = new Vertex2D(
+				0.0f, // m_flipperradius * sin(0);
+				-_mover.FlipperRadius // m_flipperradius * (-cos(0));
+			);
+
+			float ballVtx = 0;
+			float ballVty = 0; // new ball position at time t in flipper face coordinate
+			float contactAng = 0;
+			float bFend = 0;
+			float cbceDist = 0;
+			float t0 = 0;
+			float t1 = 0;
+			float d0 = 0;
+			float d1 = 0;
+			float dp = 0;
+
+			// start first interval ++++++++++++++++++++++++++
+			float t = 0;
+			int k;
+			for (k = 1; k <= PhysicsConstants.Internations; ++k) {
+				// determine flipper rotation direction, limits and parking
+				contactAng = angleCur + angleSpeed * t; // angle at time t
+
+				if (contactAng >= angleMax) {
+					contactAng = angleMax; // stop here
+
+				} else if (contactAng <= angleMin) {
+					contactAng = angleMin; // stop here
+				}
+
+				var radSin = MathF.Sin(contactAng); // Green"s transform matrix... rotate angle delta
+				var radCos = MathF.Cos(contactAng); // rotational transform from zero position to position at time t
+
+				// rotate angle delta unit vector, rotates system according to flipper face angle
+				var vt = new Vertex2D(
+					vp.X * radCos - vp.Y * radSin + flipperBase.X, // rotate and translate to world position
+					vp.Y * radCos + vp.X * radSin + flipperBase.Y
+				);
+
+				ballVtx = ballX + ballVx * t - vt.X; // new ball position relative to flipper end radius
+				ballVty = ballY + ballVy * t - vt.Y;
+
+				// center ball to center end radius distance
+				cbceDist = MathF.Sqrt(ballVtx * ballVtx + ballVty * ballVty);
+
+				// ball face-to-radius surface distance
+				bFend = cbceDist - ballEndRadius;
+
+				if (MathF.Abs(bFend) <= PhysicsConstants.Precision) {
+					break;
+				}
+
+				if (k == 1) {
+					// end of pass one ... set full interval pass, t = dtime
+					// test for extreme conditions
+					if (bFend < -(ball.Data.Radius + feRadius)) {
+						// too deeply embedded, ambiguous position
+						return -1.0f;
+					}
+
+					if (bFend <= PhysicsConstants.PhysTouch) {
+						// inside the clearance limits
+						break;
+					}
+
+					// set for second pass, force t=dtime
+					t0 = t1 = dTime;
+					d0 = 0;
+					d1 = bFend;
+
+				} else if (k == 2) {
+					// end pass two, check if zero crossing on initial interval, exit if none
+					if (dp * bFend > 0.0) {
+						// no solution ... no obvious zero crossing
+						return -1.0f;
+					}
+
+					t0 = 0;
+					t1 = dTime;
+					d0 = dp;
+					d1 = bFend; // set initial boundaries
+
+				} else {
+					// (k >= 3) // MFP root search
+					if (bFend * d0 <= 0.0) {
+						// zero crossing
+						t1 = t;
+						d1 = bFend;
+						if (dp * bFend > 0) {
+							d0 *= 0.5f;
+						}
+
+					} else {
+						t0 = t;
+						d0 = bFend;
+						if (dp * bFend > 0) {
+							d1 *= 0.5f;
+						}
+					} // move left interval limit
+				}
+
+				t = t0 - d0 * (t1 - t0) / (d1 - d0); // estimate next t
+				dp = bFend; // remember
+			}
+
+			//+++ End time interaction loop found time t solution ++++++
+
+			// time is outside this frame ... no collision
+			if (float.IsNaN(t) || float.IsInfinity(t) || t < 0 || t > dTime ||
+			    k > PhysicsConstants.Internations && MathF.Abs(bFend) > ball.Data.Radius * 0.25) {
+				// last ditch effort to accept a solution
+				return -1.0f; // no solution
+			}
+
+			// here ball and flipper end are in contact .. well in most cases, near and embedded solutions need calculations
+			var hitZ = ball.State.Pos.Z + ball.Hit.Vel.Z * t; // check for a hole, relative to ball rolling point at hittime
+
+			// check limits of object"s height and depth
+			if (hitZ + ballRadius * 0.5 < HitBBox.ZLow || hitZ - ballRadius * 0.5 > HitBBox.ZHigh) {
+				return -1.0f;
+			}
+
+			// ok we have a confirmed contact, calc the stats, remember there are "near" solution, so all
+			// parameters need to be calculated from the actual configuration, i.E. contact radius must be calc"ed
+			var invCbceDist = 1.0f / cbceDist;
+			coll.HitNormal.Set(
+				ballVtx * invCbceDist, // normal vector from flipper end to ball
+				ballVty * invCbceDist,
+				0.0f
+			);
+
+			// vector from base to flipperEnd plus the projected End radius
+			var dist = new Vertex2D(
+				ball.State.Pos.X + ballVx * t - ballRadius * coll.HitNormal.X - _mover.HitCircleBase.Center.X,
+				ball.State.Pos.Y + ballVy * t - ballRadius * coll.HitNormal.Y - _mover.HitCircleBase.Center.Y
+			);
+
+			// distance from base center to contact point
+			var distance = MathF.Sqrt(dist.X * dist.X + dist.Y * dist.Y);
+
+			// hit limits ???
+			if (contactAng >= angleMax && angleSpeed > 0 || contactAng <= angleMin && angleSpeed < 0) {
+				angleSpeed = 0; // rotation stopped
+			}
+
+			// Unit Tangent vector velocity of contact point(rotate normal right)
+			var invDistance = 1.0f / distance;
+			coll.HitVel.Set(-dist.Y * invDistance, dist.X * invDistance);
+			coll.HitMomentBit = distance == 0;
+
+			// recheck using actual contact angle of velocity direction
+			var dv = new Vertex2D(
+				ballVx - coll.HitVel.X * angleSpeed * distance, // delta velocity ball to face
+				ballVy - coll.HitVel.Y * angleSpeed * distance
+			);
+
+			var bnv = dv.X * coll.HitNormal.X + dv.Y * coll.HitNormal.Y; // dot Normal to delta v
+
+			if (bnv >= 0) {
+				// not hit ... ball is receding from face already, must have been embedded or shallow angled
+				return -1.0f;
+			}
+
+			if (MathF.Abs(bnv) <= PhysicsConstants.ContactVel && bFend <= PhysicsConstants.PhysTouch) {
+				coll.IsContact = true;
+				coll.HitOrgNormalVelocity = bnv;
+			}
+
+			coll.HitDistance = bFend; // actual contact distance ..
+
+			return t;
+		}
+
+		public float GetHitTime()
+		{
+			return _mover.GetHitTime();
+		}
+	}
+}

--- a/VisualPinball.Engine/VPT/Flipper/FlipperMover.cs
+++ b/VisualPinball.Engine/VPT/Flipper/FlipperMover.cs
@@ -1,0 +1,330 @@
+﻿// ReSharper disable CommentTypo
+// ReSharper disable CompareOfFloatsByEqualityOperator
+
+using NLog;
+using VisualPinball.Engine.Game;
+using VisualPinball.Engine.Math;
+using VisualPinball.Engine.Physics;
+using VisualPinball.Engine.VPT.Table;
+
+namespace VisualPinball.Engine.VPT.Flipper
+{
+	public class FlipperMover : IMoverObject
+	{
+		private readonly FlipperData _data;
+		private readonly FlipperState _state;
+		private readonly EventProxy _events;
+		private readonly TableData _tableData;
+
+		public readonly HitCircle HitCircleBase;                               // m_hitcircleBase
+		public readonly float EndRadius;                                       // m_endradius
+		public readonly float FlipperRadius;                                   // m_flipperradius
+
+		/// <summary>
+		/// Moment of inertia
+		/// </summary>
+		public float Inertia;                                                  // m_inertia
+
+		/// <summary>
+		/// base norms at zero degrees
+		/// </summary>
+		public readonly Vertex2D ZeroAngNorm = new Vertex2D();                 // m_zeroAngNorm
+
+		/// <summary>
+		/// -1,0,1
+		/// </summary>
+		public short EnableRotateEvent;                                        // m_enableRotateEvent
+
+		public float AngleStart;                                               // m_angleStart
+		public float AngleEnd;                                                 // m_angleEnd
+		public float AngleSpeed;                                               // m_angleSpeed
+		public float ContactTorque;                                            // m_contactTorque
+
+		public bool IsInContact;                                               // m_isInContact
+		public bool LastHitFace;                                               // m_lastHitFace
+
+		private readonly bool _direction;                                      // m_direction
+		private float _angularMomentum;                                        // m_angularMomentum
+		private float _angularAcceleration;                                    // m_angularAcceleration
+		private float _curTorque;                                              // m_curTorque
+
+		/// <summary>
+		/// is solenoid enabled?
+		/// </summary>
+		private bool _solState; // m_solState
+
+		public float GetReturnRatio() => DoOverridePhysics() ? _data.OverrideReturnStrength : _data.Return;
+		public float GetStrength() => DoOverridePhysics() ? _data.OverrideStrength : _data.Strength;
+		public float GetTorqueDampingAngle() => DoOverridePhysics() ? _data.OverrideTorqueDampingAngle : _data.TorqueDampingAngle;
+		public float GetFlipperMass() => DoOverridePhysics() ? _data.OverrideMass : _data.Mass;
+		public float GetTorqueDamping() => DoOverridePhysics() ? _data.OverrideTorqueDamping : _data.TorqueDamping;
+		public float GetRampUpSpeed() => DoOverridePhysics() ? _data.OverrideCoilRampUp : _data.RampUp;
+
+
+		public FlipperMover(FlipperData data, FlipperState state, EventProxy events, Table.Table table)
+		{
+			_data = data;
+			_state = state;
+			_events = events;
+			_tableData = table.Data;
+
+			if (data.FlipperRadiusMin > 0 && data.FlipperRadiusMax > data.FlipperRadiusMin) {
+				data.FlipperRadius = data.FlipperRadiusMax - (data.FlipperRadiusMax - data.FlipperRadiusMin) /* m_ptable->m_globalDifficulty*/;
+				data.FlipperRadius = MathF.Max(data.FlipperRadius, data.BaseRadius - data.EndRadius + 0.05f);
+
+			} else {
+				data.FlipperRadius = data.FlipperRadiusMax;
+			}
+
+			EndRadius = MathF.Max(data.EndRadius, 0.01f); // radius of flipper end
+			FlipperRadius = MathF.Max(data.FlipperRadius, 0.01f); // radius of flipper arc, center-to-center radius
+			AngleStart = MathF.DegToRad(data.StartAngle);
+			AngleEnd = MathF.DegToRad(data.EndAngle);
+
+			if (AngleEnd == AngleStart) {
+				// otherwise hangs forever in collisions/updates
+				AngleEnd += 0.0001f;
+			}
+
+			var height = table.GetSurfaceHeight(data.Surface, data.Center.X, data.Center.Y);
+			var baseRadius = MathF.Max(data.BaseRadius, 0.01f);
+			HitCircleBase = new HitCircle(data.Center, baseRadius, height, height + data.Height);
+
+			IsInContact = false;
+			EnableRotateEvent = 0;
+			AngleSpeed = 0;
+
+			_direction = AngleEnd >= AngleStart;
+			_solState = false;
+			_curTorque = 0.0f;
+			_state.Angle = AngleStart;
+			_angularMomentum = 0;
+			_angularAcceleration = 0;
+
+			var ratio = (baseRadius - EndRadius) / FlipperRadius;
+
+			// model inertia of flipper as that of rod of length flipr around its end
+			var mass = GetFlipperMass();
+			Inertia = (float) (1.0 / 3.0) * mass * (FlipperRadius * FlipperRadius);
+
+			LastHitFace = false; // used to optimize hit face search order
+
+			// F2 Norm, used in Green's transform, in FPM time search  // =  sinf(faceNormOffset)
+			ZeroAngNorm.X = MathF.Sqrt(1.0f - ratio * ratio);
+			// F1 norm, change sign of x component, i.E -zeroAngNorm.X // = -cosf(faceNormOffset)
+			ZeroAngNorm.Y = -ratio;
+		}
+
+		public void UpdateDisplacements(float dTime)
+		{
+			_state.Angle += AngleSpeed * dTime; // move flipper angle
+
+			var angleMin = MathF.Min(AngleStart, AngleEnd);
+			var angleMax = MathF.Max(AngleStart, AngleEnd);
+
+			if (_state.Angle > angleMax) {
+				_state.Angle = angleMax;
+			}
+
+			if (_state.Angle < angleMin) {
+				_state.Angle = angleMin;
+			}
+
+			if (MathF.Abs(AngleSpeed) < 0.0005) {
+				// avoids "jumping balls" when two or more balls held on flipper (and more other balls are in play) //!! make dependent on physics update rate
+				return;
+			}
+
+			var handleEvent = false;
+
+			if (_state.Angle == angleMax) {
+				// hit stop?
+				if (AngleSpeed > 0) {
+					handleEvent = true;
+				}
+
+			} else if (_state.Angle == angleMin) {
+				if (AngleSpeed < 0) {
+					handleEvent = true;
+				}
+			}
+
+			if (handleEvent) {
+				var angleSpeed = MathF.Abs(MathF.RadToDeg(AngleSpeed));
+				_angularMomentum *= -0.3f; // make configurable?
+				AngleSpeed = _angularMomentum / Inertia;
+
+				if (EnableRotateEvent > 0) {
+					Logger.Info("[{0}] Flipper is up", _data.GetName());
+					_events.FireVoidEventParam(Event.LimitEventsEOS, angleSpeed); // send EOS event
+
+				} else if (EnableRotateEvent < 0) {
+					Logger.Info("[{0}] Flipper is down", _data.GetName());
+					_events.FireVoidEventParam(Event.LimitEventsBOS, angleSpeed); // send Beginning of Stroke/Park event
+				}
+
+				EnableRotateEvent = 0;
+			}
+		}
+
+		public void UpdateVelocities(PlayerPhysics physics)
+		{
+			var desiredTorque = GetStrength();
+			if (!_solState) {
+				// this.True solState = button pressed, false = released
+				desiredTorque *= -GetReturnRatio();
+			}
+
+			// hold coil is weaker
+			var eosAngle = MathF.DegToRad(GetTorqueDampingAngle());
+			if (MathF.Abs(_state.Angle - AngleEnd) < eosAngle) {
+				// fade in/out damping, depending on angle to end
+				var lerp = MathF.Sqrt(MathF.Sqrt(MathF.Abs(_state.Angle - AngleEnd) / eosAngle));
+				desiredTorque *= lerp + GetTorqueDamping() * (1 - lerp);
+			}
+
+			if (!_direction) {
+				desiredTorque = -desiredTorque;
+			}
+
+			var torqueRampUpSpeed = GetRampUpSpeed();
+			if (torqueRampUpSpeed <= 0) {
+				// set very high for instant coil response
+				torqueRampUpSpeed = 1e6f;
+
+			} else {
+				torqueRampUpSpeed = MathF.Min(GetStrength() / torqueRampUpSpeed, 1e6f);
+			}
+
+			// update current torque linearly towards desired torque
+			// (simple model for coil hysteresis)
+			if (desiredTorque >= _curTorque) {
+				_curTorque = MathF.Min(_curTorque + torqueRampUpSpeed * PhysicsConstants.PhysFactor, desiredTorque);
+
+			} else {
+				_curTorque = MathF.Max(_curTorque - torqueRampUpSpeed * PhysicsConstants.PhysFactor, desiredTorque);
+			}
+
+			// resolve contacts with stoppers
+			var torque = _curTorque;
+			IsInContact = false;
+			if (MathF.Abs(AngleSpeed) <= 1e-2) {
+				var angleMin = MathF.Min(AngleStart, AngleEnd);
+				var angleMax = MathF.Max(AngleStart, AngleEnd);
+
+				if (_state.Angle >= angleMax - 1e-2 && torque > 0) {
+					_state.Angle = angleMax;
+					IsInContact = true;
+					ContactTorque = torque;
+					_angularMomentum = 0;
+					torque = 0;
+
+				} else if (_state.Angle <= angleMin + 1e-2 && torque < 0) {
+					_state.Angle = angleMin;
+					IsInContact = true;
+					ContactTorque = torque;
+					_angularMomentum = 0;
+					torque = 0;
+				}
+			}
+
+			_angularMomentum += PhysicsConstants.PhysFactor * torque;
+			AngleSpeed = _angularMomentum / Inertia;
+			_angularAcceleration = torque / Inertia;
+		}
+
+		public void SetSolenoidState(bool s)
+		{
+			_solState = s;
+		}
+
+		// rigid body functions
+		public Vertex3D SurfaceVelocity(Vertex3D surfP)
+		{
+			return Vertex3D.CrossZ(AngleSpeed, surfP);
+		}
+
+		public float GetHitTime()
+		{
+			if (AngleSpeed == 0) {
+				return -1.0f;
+			}
+
+			var angleMin = MathF.Min(AngleStart, AngleEnd);
+			var angleMax = MathF.Max(AngleStart, AngleEnd);
+			var dist = AngleSpeed > 0
+				? angleMax - _state.Angle // >= 0
+				: angleMin - _state.Angle; // <= 0
+
+			var hitTime = dist / AngleSpeed;
+
+			if (float.IsNaN(hitTime) || float.IsInfinity(hitTime) || hitTime < 0) {
+				return -1.0f;
+			}
+
+			return hitTime;
+		}
+
+		public void ApplyImpulse(Vertex3D rotI)
+		{
+			_angularMomentum += rotI.Z;                    // only rotation about z axis
+			AngleSpeed = _angularMomentum / Inertia;       // figure TODO out moment of inertia
+		}
+
+		public Vertex3D SurfaceAcceleration(Vertex3D surfP)
+		{
+			// tangential acceleration = (0, 0, omega) x surfP
+			var tangAcc = Vertex3D.CrossZ(_angularAcceleration, surfP);
+
+			// centripetal acceleration = (0,0,omega) x ( (0,0,omega) x surfP )
+			var av2 = AngleSpeed * AngleSpeed;
+			var centrAcc = new Vertex3D(-av2 * surfP.X, -av2 * surfP.Y, 0);
+
+			return tangAcc.Add(centrAcc);
+		}
+
+		public void SetStartAngle(float r)
+		{
+			AngleStart = r;
+			var angleMin = MathF.Min(AngleStart, AngleEnd);
+			var angleMax = MathF.Max(AngleStart, AngleEnd);
+			if (_state.Angle > angleMax) {
+				_state.Angle = angleMax;
+			}
+
+			if (_state.Angle < angleMin) {
+				_state.Angle = angleMin;
+			}
+		}
+
+		public void SetEndAngle(float r)
+		{
+			AngleEnd = r;
+			var angleMin = MathF.Min(AngleStart, AngleEnd);
+			var angleMax = MathF.Max(AngleStart, AngleEnd);
+			if (_state.Angle > angleMax) {
+				_state.Angle = angleMax;
+			}
+
+			if (_state.Angle < angleMin) {
+				_state.Angle = angleMin;
+			}
+		}
+
+		public float GetMass()
+		{
+			//!! also change if wiring of moment of inertia happens (see ctor)
+			return 3.0f * Inertia / (FlipperRadius * FlipperRadius);
+		}
+
+		public void SetMass(float m)
+		{
+			//!! also change if wiring of moment of inertia happens (see ctor)
+			Inertia = (float) (1.0 / 3.0) * m * (FlipperRadius * FlipperRadius);
+		}
+
+		private bool DoOverridePhysics() => _data.OverridePhysics != 0 || _tableData.OverridePhysicsFlipper && _tableData.OverridePhysics != 0;
+
+		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+	}
+}

--- a/VisualPinball.Engine/VPT/Flipper/FlipperState.cs
+++ b/VisualPinball.Engine/VPT/Flipper/FlipperState.cs
@@ -1,0 +1,22 @@
+﻿using VisualPinball.Engine.Math;
+
+namespace VisualPinball.Engine.VPT.Flipper
+{
+	public class FlipperState : ItemState
+	{
+		public float Angle;
+		public Vertex2D Center;
+		public string Material;
+		public string Texture;
+		public string RubberMaterial;
+
+		public FlipperState(string name, bool isVisible, float angle, Vertex2D center, string material, string texture, string rubberMaterial) : base(name, isVisible)
+		{
+			Angle = angle;
+			Center = center;
+			Material = material;
+			Texture = texture;
+			RubberMaterial = rubberMaterial;
+		}
+	}
+}

--- a/VisualPinball.Engine/VPT/ItemState.cs
+++ b/VisualPinball.Engine/VPT/ItemState.cs
@@ -1,0 +1,14 @@
+﻿namespace VisualPinball.Engine.VPT
+{
+	public abstract class ItemState
+	{
+		public string Name;
+		public bool IsVisible;
+
+		protected ItemState(string name, bool isVisible)
+		{
+			Name = name;
+			IsVisible = isVisible;
+		}
+	}
+}

--- a/VisualPinball.Engine/VPT/Table/Table.cs
+++ b/VisualPinball.Engine/VPT/Table/Table.cs
@@ -87,9 +87,14 @@ namespace VisualPinball.Engine.VPT.Table
 			.Concat(Timers.Values.Select(i => i.Data))
 			.Concat(Triggers.Values.Select(i => i.Data));
 
-		public IEnumerable<IMovable> Movables => new IMovable[0];
-		public IEnumerable<IHittable> Hittables => new IHittable[0];
-		public IEnumerable<IPlayable> Playables => new IPlayable[0];
+		public IEnumerable<IMovable> Movables => new IMovable[0]
+			.Concat(Flippers.Values);
+
+		public IEnumerable<IHittable> Hittables => new IHittable[0]
+			.Concat(Flippers.Values);
+
+		public IEnumerable<IPlayable> Playables => new IPlayable[0]
+			.Concat(Flippers.Values);
 
 		#endregion
 

--- a/VisualPinball.Engine/VPT/Table/TableData.cs
+++ b/VisualPinball.Engine/VPT/Table/TableData.cs
@@ -36,8 +36,8 @@ namespace VisualPinball.Engine.VPT.Table
 		[BiffBool("EFSS", Pos = 15)]
 		public bool BgEnableFss;
 
-		[BiffBool("ORRP", Pos = 36)]
-		public bool OverridePhysics;
+		[BiffInt("ORRP", Pos = 36)]
+		public int OverridePhysics;
 
 		[BiffBool("ORPF", Pos = 37)]
 		public bool OverridePhysicsFlipper;
@@ -326,10 +326,10 @@ namespace VisualPinball.Engine.VPT.Table
 
 		public Rect3D BoundingBox => new Rect3D(Left, Right, Top, Bottom, TableHeight, GlassHeight);
 
-		public float GetFriction() => OverridePhysics ? OverrideContactFriction : Friction;
-		public float GetElasticity() => OverridePhysics ? OverrideElasticity : Elasticity;
-		public float GetElasticityFalloff() => OverridePhysics ? OverrideElasticityFalloff : ElasticityFalloff;
-		public float GetScatter() => OverridePhysics ? OverrideScatterAngle : Scatter;
+		public float GetFriction() => OverridePhysics != 0 ? OverrideContactFriction : Friction;
+		public float GetElasticity() => OverridePhysics != 0 ? OverrideElasticity : Elasticity;
+		public float GetElasticityFalloff() => OverridePhysics != 0 ? OverrideElasticityFalloff : ElasticityFalloff;
+		public float GetScatter() => OverridePhysics != 0 ? OverrideScatterAngle : Scatter;
 
 		protected override bool SkipWrite(BiffAttribute attr)
 		{

--- a/VisualPinball.Engine/VisualPinball.Engine.csproj
+++ b/VisualPinball.Engine/VisualPinball.Engine.csproj
@@ -90,6 +90,7 @@
   <ItemGroup>
     <Compile Include="Common\Logging.cs" />
     <Compile Include="Common\Profiler.cs" />
+    <Compile Include="Common\Registry.cs" />
     <Compile Include="Common\StringExtensions.cs" />
     <Compile Include="Game\Event.cs" />
     <Compile Include="Game\EventProxy.cs" />
@@ -134,6 +135,7 @@
     <Compile Include="Physics\CollisionEvent.cs" />
     <Compile Include="Physics\CollisionType.cs" />
     <Compile Include="Physics\Hit3DPoly.cs" />
+    <Compile Include="Physics\HitCircle.cs" />
     <Compile Include="Physics\HitKd.cs" />
     <Compile Include="Physics\HitKdNode.cs" />
     <Compile Include="Physics\HitObject.cs" />
@@ -163,7 +165,10 @@
     <Compile Include="VPT\Flasher\FlasherData.cs" />
     <Compile Include="VPT\Flipper\Flipper.cs" />
     <Compile Include="VPT\Flipper\FlipperData.cs" />
+    <Compile Include="VPT\Flipper\FlipperHit.cs" />
     <Compile Include="VPT\Flipper\FlipperMeshGenerator.cs" />
+    <Compile Include="VPT\Flipper\FlipperMover.cs" />
+    <Compile Include="VPT\Flipper\FlipperState.cs" />
     <Compile Include="VPT\Font.cs" />
     <Compile Include="VPT\Gate\Gate.cs" />
     <Compile Include="VPT\Gate\GateData.cs" />
@@ -173,6 +178,7 @@
     <Compile Include="VPT\HitTarget\HitTargetMeshGenerator.cs" />
     <Compile Include="VPT\Item.cs" />
     <Compile Include="VPT\ItemData.cs" />
+    <Compile Include="VPT\ItemState.cs" />
     <Compile Include="VPT\Kicker\Kicker.cs" />
     <Compile Include="VPT\Kicker\KickerData.cs" />
     <Compile Include="VPT\Kicker\KickerMeshGenerator.cs" />

--- a/VisualPinball.Unity/Components/VisualPinballTable.cs
+++ b/VisualPinball.Unity/Components/VisualPinballTable.cs
@@ -67,7 +67,7 @@ namespace VisualPinball.Unity.Components
 			return RecreateTable();
 		}
 
-		public Table RecreateTable()
+		public Table CreateTable()
 		{
 			Logger.Info("Restoring table...");
 			// restore table data
@@ -90,7 +90,6 @@ namespace VisualPinball.Unity.Components
 			Restore(flashers, table.Flashers, d => new Flasher(d));
 			Restore(lightSeqs, table.LightSeqs, d => new LightSeq(d));
 			Restore(plungers, table.Plungers, d => new Plunger(d));
-			Restore(sounds, table.Sounds, d => new Sound(d));
 			Restore(textBoxes, table.TextBoxes, d => new TextBox(d));
 			Restore(timers, table.Timers, d => new Timer(d));
 
@@ -108,6 +107,15 @@ namespace VisualPinball.Unity.Components
 			Restore<VisualPinballSpinner, Spinner, SpinnerData>(table.Spinners);
 			Restore<VisualPinballSurface, Surface, SurfaceData>(table.Surfaces);
 			Restore<VisualPinballTrigger, Trigger, TriggerData>(table.Triggers);
+
+			return table;
+		}
+
+		public Table RecreateTable()
+		{
+			var table = CreateTable();
+
+			Restore(sounds, table.Sounds, d => new Sound(d));
 
 			// restore textures
 			Logger.Info("Restoring textures...");

--- a/VisualPinball.Unity/Editor/VisualPinballFlipperInspector.cs
+++ b/VisualPinball.Unity/Editor/VisualPinballFlipperInspector.cs
@@ -90,6 +90,10 @@ namespace VisualPinball.Unity.Editor
 				_flipper.data.TorqueDampingAngle = EditorGUILayout.FloatField("EOS Torque Angle", _flipper.data.TorqueDampingAngle);
 				EditorGUI.indentLevel--;
 			}
+
+			if (GUILayout.Button("Flip Up")) {
+
+			}
 		}
 	}
 }

--- a/VisualPinball.Unity/Editor/VisualPinballFlipperInspector.cs
+++ b/VisualPinball.Unity/Editor/VisualPinballFlipperInspector.cs
@@ -88,10 +88,6 @@ namespace VisualPinball.Unity.Editor
 				_flipper.data.TorqueDampingAngle = EditorGUILayout.FloatField("EOS Torque Angle", _flipper.data.TorqueDampingAngle);
 				EditorGUI.indentLevel--;
 			}
-
-			if (GUILayout.Button("Flip Up")) {
-
-			}
 		}
 	}
 }

--- a/VisualPinball.Unity/Editor/VisualPinballFlipperInspector.cs
+++ b/VisualPinball.Unity/Editor/VisualPinballFlipperInspector.cs
@@ -25,8 +25,6 @@ namespace VisualPinball.Unity.Editor
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 		private VisualPinballSurface _surface;
 
-
-
 		private void OnEnable()
 		{
 			_flipper = (VisualPinballFlipper) target;

--- a/VisualPinball.Unity/Game/TablePlayer.cs
+++ b/VisualPinball.Unity/Game/TablePlayer.cs
@@ -28,28 +28,38 @@ namespace VisualPinball.Unity.Game
 
 		private void Update()
 		{
-			if (Input.GetKeyDown("left shift")) {
-				_table.Flippers["LeftFlipper"].RotateToEnd();
-			}
-			if (Input.GetKeyUp("left shift")) {
-				_table.Flippers["LeftFlipper"].RotateToStart();
+			// all of this is hacky and only serves as proof of concept.
+			// flippers will obviously be handled via script later.
+			if (_table.Flippers.ContainsKey("LeftFlipper")) {
+				if (Input.GetKeyDown("left shift")) {
+					_table.Flippers["LeftFlipper"].RotateToEnd();
+				}
+				if (Input.GetKeyUp("left shift")) {
+					_table.Flippers["LeftFlipper"].RotateToStart();
+				}
 			}
 
-			if (Input.GetKeyDown("right shift")) {
-				_table.Flippers["RightFlipper"].RotateToEnd();
-			}
-			if (Input.GetKeyUp("right shift")) {
-				_table.Flippers["RightFlipper"].RotateToStart();
+			if (_table.Flippers.ContainsKey("RightFlipper")) {
+				if (Input.GetKeyDown("right shift")) {
+					_table.Flippers["RightFlipper"].RotateToEnd();
+				}
+				if (Input.GetKeyUp("right shift")) {
+					_table.Flippers["RightFlipper"].RotateToStart();
+				}
 			}
 
 			_player.UpdatePhysics();
 
-			var rotL = _leftFlipper.transform.localRotation.eulerAngles;
-			var rotR = _rightFlipper.transform.localRotation.eulerAngles;
-			rotL.z = MathF.RadToDeg(_table.Flippers["LeftFlipper"].State.Angle);
-			rotR.z = MathF.RadToDeg(_table.Flippers["RightFlipper"].State.Angle);
-			_leftFlipper.transform.localRotation = Quaternion.Euler(rotL);
-			_rightFlipper.transform.localRotation = Quaternion.Euler(rotR);
+			if (_table.Flippers.ContainsKey("LeftFlipper")) {
+				var rotL = _leftFlipper.transform.localRotation.eulerAngles;
+				rotL.z = MathF.RadToDeg(_table.Flippers["LeftFlipper"].State.Angle);
+				_leftFlipper.transform.localRotation = Quaternion.Euler(rotL);
+			}
+			if (_table.Flippers.ContainsKey("RightFlipper")) {
+				var rotR = _rightFlipper.transform.localRotation.eulerAngles;
+				rotR.z = MathF.RadToDeg(_table.Flippers["RightFlipper"].State.Angle);
+				_rightFlipper.transform.localRotation = Quaternion.Euler(rotR);
+			}
 		}
 	}
 }

--- a/VisualPinball.Unity/Game/TablePlayer.cs
+++ b/VisualPinball.Unity/Game/TablePlayer.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using UnityEngine;
+using VisualPinball.Engine.Game;
+using VisualPinball.Engine.Math;
+using VisualPinball.Engine.VPT.Table;
+using VisualPinball.Unity.Components;
+
+namespace VisualPinball.Unity.Game
+{
+	public class TablePlayer : MonoBehaviour
+	{
+
+		private Table _table;
+		private Player _player;
+
+		private Transform _leftFlipper;
+		private Transform _rightFlipper;
+
+		private void Start()
+		{
+			var tableComponent = gameObject.GetComponent<VisualPinballTable>();
+			_table = tableComponent.CreateTable();
+			_player = new Player(_table).Init();
+
+			_leftFlipper  = transform.Find("Flippers/LeftFlipper");
+			_rightFlipper  = transform.Find("Flippers/RightFlipper");
+		}
+
+		private void Update()
+		{
+			if (Input.GetKeyDown("left shift")) {
+				_table.Flippers["LeftFlipper"].RotateToEnd();
+			}
+			if (Input.GetKeyUp("left shift")) {
+				_table.Flippers["LeftFlipper"].RotateToStart();
+			}
+
+			if (Input.GetKeyDown("right shift")) {
+				_table.Flippers["RightFlipper"].RotateToEnd();
+			}
+			if (Input.GetKeyUp("right shift")) {
+				_table.Flippers["RightFlipper"].RotateToStart();
+			}
+
+			_player.UpdatePhysics();
+
+			var rotL = _leftFlipper.transform.localRotation.eulerAngles;
+			var rotR = _rightFlipper.transform.localRotation.eulerAngles;
+			rotL.z = MathF.RadToDeg(_table.Flippers["LeftFlipper"].State.Angle);
+			rotR.z = MathF.RadToDeg(_table.Flippers["RightFlipper"].State.Angle);
+			_leftFlipper.transform.localRotation = Quaternion.Euler(rotL);
+			_rightFlipper.transform.localRotation = Quaternion.Euler(rotR);
+		}
+	}
+}

--- a/VisualPinball.Unity/Importer/VpxImporter.cs
+++ b/VisualPinball.Unity/Importer/VpxImporter.cs
@@ -21,6 +21,7 @@ using VisualPinball.Engine.VPT.Table;
 using VisualPinball.Engine.VPT.Trigger;
 using VisualPinball.Unity.Components;
 using VisualPinball.Unity.Extensions;
+using VisualPinball.Unity.Game;
 using VisualPinball.Unity.Importer.AssetHandler;
 using VisualPinball.Unity.Importer.Job;
 using Logger = NLog.Logger;
@@ -76,6 +77,9 @@ namespace VisualPinball.Unity.Importer
 			//ScaleNormalizer.Normalize(go, GlobalScale);
 
 			MakeSerializable(go, table, assetHandler);
+
+			// finally, add the player script
+			go.AddComponent<TablePlayer>();
 		}
 
 		private void ImportTextures()

--- a/VisualPinball.Unity/VisualPinball.Unity.csproj
+++ b/VisualPinball.Unity/VisualPinball.Unity.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Extensions\Matrix3D.cs" />
     <Compile Include="Extensions\Mesh.cs" />
     <Compile Include="Extensions\Texture.cs" />
+    <Compile Include="Game\TablePlayer.cs" />
     <Compile Include="Importer\AssetHandler\AssetDatabaseHandler.cs" />
     <Compile Include="Importer\AssetHandler\AssetMemoryHandler.cs" />
     <Compile Include="Importer\AssetHandler\AssetUtility.cs" />


### PR DESCRIPTION
This PR adds collision and rigid body physics to the flippers. Closes #23 and closes #33.

It adds the collider (`FlipperHit`) and a resolver (`FlipperMover`). We also introduce a `FlipperState`, which holds the runtime data, although that might change in the future.

There were a few minor additional changes:

- Added a registry stub that always returns the fallback value. This is used when retrieving the flipper physics properties.
- Unit tests now use [Fluent Assertions](https://fluentassertions.com/) that are much more intuitive and extensive that xUnit's assertion library.
- When importing a table into Unity, a `TablePlayer` script is attached to the root `GameObject`, which runs the physics loop at each frame, listens to shift key presses and triggers `LeftFlipper` and `RightFlipper` flippers if they exist, and applies the new state to the flipper's transform component.