### PR TITLE
Remove same path prefix from nuget repositoryPath

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<config>
-		<add key="repositoryPath" value=".\.packages"/>
+		<add key="repositoryPath" value=".packages"/>
 	</config>
 	<packageSources>
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />


### PR DESCRIPTION
On macOS, the nuget packages directory was physically being created with the filename `.\.packages`. This was causing build errors on macOS:

`
/Users/jmillard/git/VisualPinball.Engine/VisualPinball.Engine/VisualPinball.Engine.csproj(3,3): Error: This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is ../.packages/Microsoft.Net.Compilers.Toolset.3.1.0/build/Microsoft.Net.Compilers.Toolset.props. (VisualPinball.Engine)
`