### PR TITLE
Duplicate project guid fix

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Engine.Unity.sln
+++ b/VisualPinball.Unity/VisualPinball.Engine.Unity.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualPinball.Engine", "..\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualPinball.Engine.Test", "..\VisualPinball.Engine.Test\VisualPinball.Engine.Test.csproj", "{9902C758-AB1F-4A15-9F77-51FB08642EF6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualPinball.Resources", "..\VisualPinball.Resources\VisualPinball.Resources.csproj", "{F7C27E2C-8931-46F3-968E-F1103E975074}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualPinball.Unity", "VisualPinball.Unity\VisualPinball.Unity.csproj", "{89DC7792-2AC2-4A69-8605-D3A14CC7B6B0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualPinball.Unity.Editor", "VisualPinball.Unity.Editor\VisualPinball.Unity.Editor.csproj", "{6A784FF4-FAC5-4BCF-9E77-E1337CE570CF}"
@@ -34,6 +36,12 @@ Global
 		{9902C758-AB1F-4A15-9F77-51FB08642EF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9902C758-AB1F-4A15-9F77-51FB08642EF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9902C758-AB1F-4A15-9F77-51FB08642EF6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F7C27E2C-8931-46F3-968E-F1103E975074}.Debug Unity|Any CPU.ActiveCfg = Debug Unity|Any CPU
+		{F7C27E2C-8931-46F3-968E-F1103E975074}.Debug Unity|Any CPU.Build.0 = Debug Unity|Any CPU
+		{F7C27E2C-8931-46F3-968E-F1103E975074}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7C27E2C-8931-46F3-968E-F1103E975074}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7C27E2C-8931-46F3-968E-F1103E975074}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7C27E2C-8931-46F3-968E-F1103E975074}.Release|Any CPU.Build.0 = Release|Any CPU
 		{89DC7792-2AC2-4A69-8605-D3A14CC7B6B0}.Debug Unity|Any CPU.ActiveCfg = Debug Unity|Any CPU
 		{89DC7792-2AC2-4A69-8605-D3A14CC7B6B0}.Debug Unity|Any CPU.Build.0 = Debug Unity|Any CPU
 		{89DC7792-2AC2-4A69-8605-D3A14CC7B6B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/VisualPinball.Unity/VisualPinball.Engine.Unity.sln
+++ b/VisualPinball.Unity/VisualPinball.Engine.Unity.sln
@@ -9,9 +9,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualPinball.Engine.Test",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualPinball.Unity", "VisualPinball.Unity\VisualPinball.Unity.csproj", "{89DC7792-2AC2-4A69-8605-D3A14CC7B6B0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualPinball.Unity.Editor", "VisualPinball.Unity.Editor\VisualPinball.Unity.Editor.csproj", "{89DC7792-2AC2-4A69-8605-D3A14CC7B6B0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualPinball.Unity.Editor", "VisualPinball.Unity.Editor\VisualPinball.Unity.Editor.csproj", "{6A784FF4-FAC5-4BCF-9E77-E1337CE570CF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualPinball.Unity.Patcher", "VisualPinball.Unity.Patcher\VisualPinball.Unity.Patcher.csproj", "{89DC7792-2AC2-4A69-8605-D3A14CC7B6B0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualPinball.Unity.Patcher", "VisualPinball.Unity.Patcher\VisualPinball.Unity.Patcher.csproj", "{38507534-0C23-412C-88D9-E1E6F1534C70}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualPinball.Unity.Test", "VisualPinball.Unity.Test\VisualPinball.Unity.Test.csproj", "{D54D9710-FD25-47AB-973F-C8C83B26D6B7}"
 EndProject
@@ -40,8 +40,18 @@ Global
 		{89DC7792-2AC2-4A69-8605-D3A14CC7B6B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{89DC7792-2AC2-4A69-8605-D3A14CC7B6B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{89DC7792-2AC2-4A69-8605-D3A14CC7B6B0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{89DC7792-2AC2-4A69-8605-D3A14CC7B6B0}.Debug Unity|Any CPU.ActiveCfg = Debug|Any CPU
-		{89DC7792-2AC2-4A69-8605-D3A14CC7B6B0}.Debug Unity|Any CPU.Build.0 = Debug|Any CPU
+		{6A784FF4-FAC5-4BCF-9E77-E1337CE570CF}.Debug Unity|Any CPU.ActiveCfg = Debug Unity|Any CPU
+		{6A784FF4-FAC5-4BCF-9E77-E1337CE570CF}.Debug Unity|Any CPU.Build.0 = Debug Unity|Any CPU
+		{6A784FF4-FAC5-4BCF-9E77-E1337CE570CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A784FF4-FAC5-4BCF-9E77-E1337CE570CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A784FF4-FAC5-4BCF-9E77-E1337CE570CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A784FF4-FAC5-4BCF-9E77-E1337CE570CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{38507534-0C23-412C-88D9-E1E6F1534C70}.Debug Unity|Any CPU.ActiveCfg = Debug Unity|Any CPU
+		{38507534-0C23-412C-88D9-E1E6F1534C70}.Debug Unity|Any CPU.Build.0 = Debug Unity|Any CPU
+		{38507534-0C23-412C-88D9-E1E6F1534C70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{38507534-0C23-412C-88D9-E1E6F1534C70}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{38507534-0C23-412C-88D9-E1E6F1534C70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{38507534-0C23-412C-88D9-E1E6F1534C70}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D54D9710-FD25-47AB-973F-C8C83B26D6B7}.Debug Unity|Any CPU.ActiveCfg = Debug|Any CPU
 		{D54D9710-FD25-47AB-973F-C8C83B26D6B7}.Debug Unity|Any CPU.Build.0 = Debug|Any CPU
 		{D54D9710-FD25-47AB-973F-C8C83B26D6B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VisualPinball.Unity.Editor.csproj
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VisualPinball.Unity.Editor.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{89DC7792-2AC2-4A69-8605-D3A14CC7B6B0}</ProjectGuid>
+    <ProjectGuid>{6A784FF4-FAC5-4BCF-9E77-E1337CE570CF}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>VisualPinball.Unity.Editor</RootNamespace>

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/VisualPinball.Unity.Patcher.csproj
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/VisualPinball.Unity.Patcher.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{89DC7792-2AC2-4A69-8605-D3A14CC7B6B0}</ProjectGuid>
+    <ProjectGuid>{38507534-0C23-412C-88D9-E1E6F1534C70}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>VisualPinball.Unity.Patcher</RootNamespace>

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<config>
-		<add key="repositoryPath" value=".\.packages"/>
+		<add key="repositoryPath" value=".packages"/>
 	</config>
 	<packageSources>
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />


### PR DESCRIPTION
When trying to open `VisualPinball.Engine.Unity.sln` with Visual Studio, the following errors are displayed:

`Invalid solution. There are two projects with the same GUID. The project ` ... `VisualPinball.Unity.Patcher.csproj will be ignored.`

`Invalid solution. There are two projects with the same GUID. The project ` ... `VisualPinball.Unity.csproj will be ignored.`

I generated unique guids for these projects and updated the `sln` files accordingly.

Finally, I also added the `VisualPinball.Resources` project as it was a dependency for `VisualPinball.Engine`

Note, this PR still does not allow successful compiling on macOS, as there are still assembly errors:

`
/Users/jmillard/git/jsm174/VisualPinball.Engine/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallBehavior.cs(13,13): Error CS0012: The type 'Bounds' is defined in an assembly that is not referenced. You must add a reference to assembly 'UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. (CS0012) (VisualPinball.Unity)`