### PR TITLE
Engine fixes

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/Import/VpxImporter.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Import/VpxImporter.cs
@@ -185,6 +185,7 @@ namespace VisualPinball.Unity.Import
 				case Table table:			ic = table.SetupGameObject(obj, rog); break;
 				case Trigger trigger:		ic = obj.AddComponent<TriggerBehavior>().SetData(trigger.Data); break;
 			}
+#if UNITY_EDITOR
 			// for convenience move item behavior to the top of the list
 			if (ic != null) {
 				int numComp = obj.GetComponents<MonoBehaviour>().Length;
@@ -192,8 +193,8 @@ namespace VisualPinball.Unity.Import
 					UnityEditorInternal.ComponentUtility.MoveComponentUp(ic);
 				}
 			}
+#endif
 		}
-
 		private void ImportRenderObject(IRenderable item, RenderObject ro, GameObject obj)
 		{
 			if (ro.Mesh == null) {

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Engine/DefaultPhysicsEngine.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Engine/DefaultPhysicsEngine.cs
@@ -113,7 +113,7 @@ namespace VisualPinball.Unity.Physics.Engine
 		public void UpdateDebugFlipperStates()
 		{
 			// for each flipper
-			var entities = _flipperDataQuery.ToEntityArray(Allocator.Temp);
+			var entities = _flipperDataQuery.ToEntityArray(Allocator.TempJob);
 			if (_flipperStates.Length == 0) {
 				_flipperStates = new DebugFlipperState[entities.Length];
 			}

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Engine/IPhysicsEngine.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Engine/IPhysicsEngine.cs
@@ -33,8 +33,7 @@ namespace VisualPinball.Unity.Physics.Engine
 		/// <param name="scale">Scale relative to ball mesh</param>
 		/// <param name="mass">Physics mass</param>
 		/// <param name="radius">Radius in local space</param>
-		/// <returns></returns>
-		Entity BallCreate(Mesh mesh, Material material, in float3 worldPos, in float3 localPos, in float3 localVel,
+		void BallCreate(Mesh mesh, Material material, in float3 worldPos, in float3 localPos, in float3 localVel,
 			in float scale, in float mass, in float radius);
 
 		/// <summary>

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/SystemGroup/SimulateCycleSystemGroup.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/SystemGroup/SimulateCycleSystemGroup.cs
@@ -73,12 +73,12 @@ namespace VisualPinball.Unity.Physics.SystemGroup
 			_systemsToUpdate.Add(_dynamicCollisionSystem);
 			_systemsToUpdate.Add(_contactSystem);
 			_systemsToUpdate.Add(_ballSpinHackSystem);
-
-			_simulationTime.Start();
 		}
 
 		protected override void OnUpdate()
 		{
+			_simulationTime.Restart();
+
 			var sim = World.GetExistingSystem<VisualPinballSimulationSystemGroup>();
 
 			_staticCounts = PhysicsConstants.StaticCnts;
@@ -112,6 +112,7 @@ namespace VisualPinball.Unity.Physics.SystemGroup
 			// debug ui update
 			if (EngineProvider<IDebugUI>.Exists) {
 				PhysicsEngine.UpdateDebugFlipperStates();
+				PhysicsEngine.PushPendingCreateBallNotifications();
 				EngineProvider<IDebugUI>.Get().OnPhysicsUpdate(numSteps, (float)_simulationTime.Elapsed.TotalMilliseconds);
 			}
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallBehavior.cs
@@ -11,6 +11,7 @@ namespace VisualPinball.Unity.VPT.Ball
 	public class BallBehavior : MonoBehaviour, IConvertGameObjectToEntity
 	{
 		private static int _id;
+		public static int NumBallsCreated { get => _id; }
 
 		public float3 Position;
 		public float3 Velocity;
@@ -41,7 +42,7 @@ namespace VisualPinball.Unity.VPT.Ball
 			dstManager.AddBuffer<BallInsideOfBufferElement>(entity);
 		}
 
-		public static Entity CreateEntity(EntityManager entityManager, Mesh mesh, Material material,
+		public static void CreateEntity(EntityManager entityManager, Mesh mesh, Material material,
 			float3 worldPos, float scale, float3 localPos, float3 velocity, float radius, float mass)
 		{
 			var ecbs = World.DefaultGameObjectInjectionWorld.GetOrCreateSystem<CreateBallEntityCommandBufferSystem>();
@@ -106,8 +107,6 @@ namespace VisualPinball.Unity.VPT.Ball
 					{ Value = new float3(float.MaxValue, float.MaxValue, float.MaxValue) }
 				);
 			}
-
-			return entity;
 		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallManager.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallManager.cs
@@ -54,11 +54,8 @@ namespace VisualPinball.Unity.VPT.Ball
 			var mesh = GetSphereMesh();
 
 			// create ball entity
-			var entity = EngineProvider<IPhysicsEngine>.Get()
+			EngineProvider<IPhysicsEngine>.Get()
 				.BallCreate(mesh, material, worldPos, localPos, localVel, scale, mass, radius);
-			if (EngineProvider<IDebugUI>.Exists) {
-				EngineProvider<IDebugUI>.Get().OnCreateBall(entity);
-			}
 
 			return null;
 		}
@@ -99,11 +96,11 @@ namespace VisualPinball.Unity.VPT.Ball
 			return entity;
 		}
 
-		public static Entity CreateEntity(Mesh mesh, Material material, in float3 worldPos, in float3 localPos,
+		public static void CreateEntity(Mesh mesh, Material material, in float3 worldPos, in float3 localPos,
 			in float3 localVel, in float scale, in float mass, in float radius)
 		{
 			var entityManager = World.DefaultGameObjectInjectionWorld.EntityManager;
-			return BallBehavior.CreateEntity(entityManager,
+			BallBehavior.CreateEntity(entityManager,
 				mesh, material, worldPos, scale, localPos,
 					localVel, radius, mass);
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableBehavior.cs
@@ -84,8 +84,8 @@ namespace VisualPinball.Unity.VPT.Table
 		{
 			base.Awake();
 			EngineProvider<IPhysicsEngine>.Set(physicsEngineId);
-			EngineProvider<IDebugUI>.Set(debugUiId);
 			EngineProvider<IPhysicsEngine>.Get().Init(this);
+			EngineProvider<IDebugUI>.Set(debugUiId);
 		}
 
 		private void Start()

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableBehavior.cs
@@ -85,11 +85,11 @@ namespace VisualPinball.Unity.VPT.Table
 			base.Awake();
 			EngineProvider<IPhysicsEngine>.Set(physicsEngineId);
 			EngineProvider<IDebugUI>.Set(debugUiId);
+			EngineProvider<IPhysicsEngine>.Get().Init(this);
 		}
 
 		private void Start()
 		{
-			EngineProvider<IPhysicsEngine>.Get().Init(this);
 			if (EngineProvider<IDebugUI>.Exists) {
 				EngineProvider<IDebugUI>.Get().Init(this);
 			}


### PR DESCRIPTION
- changed return value to void in `IPhysicsEngine.CreateBall`. VPX return useless entity value. Now PhysicsEngine is responsible to notify DebugUI about new ball. Same way it works with flippers: physics engine sent notification.
- now `DebugUI` will get notifications about new ball and this makes manual ball roller work.
- i moved physics engine `Init` before DebugUI setup. For testing i removed DebugUI package (end user may do same thing). In DebugUI setup there is exeption trow and this prevent physics engine initialization.

ToDo: maybe we need way to disable DebugUI by selection "disabled" same way as we can disable bullet by selecting "default"

Minor changes:
- added once `#if UNITY_EDITOR` to make build possible