### PR TITLE
Gate Collisions

### DIFF
--- a/VisualPinball.Engine/Common/Constants.cs
+++ b/VisualPinball.Engine/Common/Constants.cs
@@ -18,6 +18,11 @@ namespace VisualPinball.Engine.Common
 		public const float ContactVel = 0.099f;                                // C_CONTACTVEL
 
 		/// <summary>
+		/// seems like this mimics the radius of the ball -> replace with radius where possible?
+		/// </summary>
+		public const float PhysSkin = 25.0f;
+
+		/// <summary>
 		/// Layer outside object which increases it's size for contact measurements. Used to determine clearances.
 		/// Setting this value during testing to 0.1 will insure clearance. After testing set the value to 0.005
 		/// Default 0.01
@@ -94,8 +99,5 @@ namespace VisualPinball.Engine.Common
 		/// Precision level and cycles for interative calculations // acceptable contact time ... near zero time
 		/// </summary>
 		public const int Internations = 20;                                    // C_INTERATIONS
-
-
-
 	}
 }

--- a/VisualPinball.Engine/Physics/HitTriangle.cs
+++ b/VisualPinball.Engine/Physics/HitTriangle.cs
@@ -38,11 +38,13 @@ namespace VisualPinball.Engine.Physics
 
 		public override float HitTest(Ball ball, float dTime, CollisionEvent coll, PlayerPhysics physics)
 		{
+			// not needed in unity ECS
 			throw new System.NotImplementedException();
 		}
 
 		public override void Collide(CollisionEvent coll, PlayerPhysics physics)
 		{
+			// not needed in unity ECS
 			throw new System.NotImplementedException();
 		}
 	}

--- a/VisualPinball.Engine/VPT/Flipper/Flipper.cs
+++ b/VisualPinball.Engine/VPT/Flipper/Flipper.cs
@@ -4,10 +4,11 @@ using VisualPinball.Engine.Physics;
 
 namespace VisualPinball.Engine.VPT.Flipper
 {
-	public class Flipper : Item<FlipperData>, IRenderable, IPlayable, IMovable, IHittable
+	public class Flipper : Item<FlipperData>, IRenderable, IMovable, IHittable
 	{
 		public FlipperState State { get; }
 		public EventProxy EventProxy { get; private set; }
+		public bool IsCollidable => true;
 
 		private readonly FlipperMeshGenerator _meshGenerator;
 		private FlipperHit _hit;
@@ -20,23 +21,24 @@ namespace VisualPinball.Engine.VPT.Flipper
 
 		public Flipper(BinaryReader reader, string itemName) : this(new FlipperData(reader, itemName)) { }
 
-		public RenderObjectGroup GetRenderObjects(Table.Table table, Origin origin = Origin.Global, bool asRightHanded = true)
-		{
-			return _meshGenerator.GetRenderObjects(table, origin, asRightHanded);
-		}
-
 		public void SetupPlayer(Player player, Table.Table table)
 		{
 			EventProxy = new EventProxy(this);
 			_hit = new FlipperHit(Data, State, EventProxy, table);
 		}
 
+		public RenderObjectGroup GetRenderObjects(Table.Table table, Origin origin = Origin.Global, bool asRightHanded = true)
+		{
+			return _meshGenerator.GetRenderObjects(table, origin, asRightHanded);
+		}
+
 		public IMoverObject GetMover() => _hit.GetMoverObject();
+
 		public FlipperMover FlipperMover => _hit.GetMoverObject();
 
-		public bool IsCollidable => true;
 		public HitObject[] GetHitShapes() => new HitObject[] { _hit };
 
+		#region API
 		// todo move to api
 		public void RotateToEnd() {
 			_hit.GetMoverObject().EnableRotateEvent = 1;
@@ -48,5 +50,6 @@ namespace VisualPinball.Engine.VPT.Flipper
 			_hit.GetMoverObject().EnableRotateEvent = -1;
 			_hit.GetMoverObject().SetSolenoidState(false);
 		}
+		#endregion
 	}
 }

--- a/VisualPinball.Engine/VPT/Gate/Gate.cs
+++ b/VisualPinball.Engine/VPT/Gate/Gate.cs
@@ -52,6 +52,7 @@ namespace VisualPinball.Engine.VPT.Gate
 
 		public IMoverObject GetMover()
 		{
+			// not needed in unity ECS
 			throw new System.NotImplementedException();
 		}
 	}

--- a/VisualPinball.Engine/VPT/Gate/Gate.cs
+++ b/VisualPinball.Engine/VPT/Gate/Gate.cs
@@ -1,5 +1,7 @@
 ﻿using System.IO;
+using System.Linq;
 using VisualPinball.Engine.Game;
+using VisualPinball.Engine.Math;
 using VisualPinball.Engine.Physics;
 
 namespace VisualPinball.Engine.VPT.Gate
@@ -10,17 +12,29 @@ namespace VisualPinball.Engine.VPT.Gate
 		public bool IsCollidable => true;
 
 		private readonly GateMeshGenerator _meshGenerator;
+		private readonly GateHitGenerator _hitGenerator;
+		private GateHit _hitGate;
+		private LineSeg[] _hitLines;
+		private HitCircle[] _hitCircles;
 
 		public Gate(GateData data) : base(data)
 		{
 			_meshGenerator = new GateMeshGenerator(Data);
+			_hitGenerator = new GateHitGenerator(Data);
 		}
 
 		public Gate(BinaryReader reader, string itemName) : this(new GateData(reader, itemName)) { }
 
 		public void SetupPlayer(Player player, Table.Table table)
 		{
-			throw new System.NotImplementedException();
+			var height = table.GetSurfaceHeight(Data.Surface, Data.Center.X, Data.Center.Y);
+			var radAngle = MathF.DegToRad(Data.Rotation);
+			var tangent = new Vertex2D(MathF.Cos(radAngle), MathF.Sin(radAngle));
+
+			EventProxy = new EventProxy(this);
+			_hitGate = _hitGenerator.GenerateGateHit(EventProxy, height);
+			_hitLines = _hitGenerator.GenerateLineSegs(height, tangent);
+			_hitCircles = _hitGenerator.GenerateBracketHits(height, tangent);
 		}
 
 		public RenderObjectGroup GetRenderObjects(Table.Table table, Origin origin = Origin.Global, bool asRightHanded = true)
@@ -28,12 +42,15 @@ namespace VisualPinball.Engine.VPT.Gate
 			return _meshGenerator.GetRenderObjects(table, origin, asRightHanded);
 		}
 
-		public IMoverObject GetMover()
+		public HitObject[] GetHitShapes()
 		{
-			throw new System.NotImplementedException();
+			return new HitObject[] {_hitGate}
+				.Concat(_hitLines)
+				.Concat(_hitCircles)
+				.ToArray();
 		}
 
-		public HitObject[] GetHitShapes()
+		public IMoverObject GetMover()
 		{
 			throw new System.NotImplementedException();
 		}

--- a/VisualPinball.Engine/VPT/Gate/Gate.cs
+++ b/VisualPinball.Engine/VPT/Gate/Gate.cs
@@ -1,10 +1,14 @@
 ﻿using System.IO;
 using VisualPinball.Engine.Game;
+using VisualPinball.Engine.Physics;
 
 namespace VisualPinball.Engine.VPT.Gate
 {
-	public class Gate : Item<GateData>, IRenderable
+	public class Gate : Item<GateData>, IRenderable, IMovable, IHittable
 	{
+		public EventProxy EventProxy { get; private set; }
+		public bool IsCollidable => true;
+
 		private readonly GateMeshGenerator _meshGenerator;
 
 		public Gate(GateData data) : base(data)
@@ -14,9 +18,24 @@ namespace VisualPinball.Engine.VPT.Gate
 
 		public Gate(BinaryReader reader, string itemName) : this(new GateData(reader, itemName)) { }
 
+		public void SetupPlayer(Player player, Table.Table table)
+		{
+			throw new System.NotImplementedException();
+		}
+
 		public RenderObjectGroup GetRenderObjects(Table.Table table, Origin origin = Origin.Global, bool asRightHanded = true)
 		{
 			return _meshGenerator.GetRenderObjects(table, origin, asRightHanded);
+		}
+
+		public IMoverObject GetMover()
+		{
+			throw new System.NotImplementedException();
+		}
+
+		public HitObject[] GetHitShapes()
+		{
+			throw new System.NotImplementedException();
 		}
 	}
 }

--- a/VisualPinball.Engine/VPT/Gate/GateHit.cs
+++ b/VisualPinball.Engine/VPT/Gate/GateHit.cs
@@ -1,7 +1,65 @@
-﻿namespace VisualPinball.Engine.VPT.Gate
-{
-	public class GateHit
-	{
+﻿using VisualPinball.Engine.Common;
+using VisualPinball.Engine.Game;
+using VisualPinball.Engine.Math;
+using VisualPinball.Engine.Physics;
 
+namespace VisualPinball.Engine.VPT.Gate
+{
+	public class GateHit : HitObject
+	{
+		public LineSeg LineSeg0;
+		public LineSeg LineSeg1;
+		public bool TwoWay;
+
+		public GateHit(GateData data, float height)
+		{
+			var data1 = data;
+			var height1 = height;
+
+			var halfLength = data1.Length * 0.5f;
+			var radAngle = MathF.DegToRad(data1.Rotation);
+			var sn = MathF.Sin(radAngle);
+			var cs = MathF.Cos(radAngle);
+
+			LineSeg0 = new LineSeg(
+				new Vertex2D(
+					data1.Center.X - cs * (halfLength + PhysicsConstants.PhysSkin),
+					data1.Center.Y - sn * (halfLength + PhysicsConstants.PhysSkin)
+				),
+				new Vertex2D(
+					data1.Center.X + cs * (halfLength + PhysicsConstants.PhysSkin),
+					data1.Center.Y + sn * (halfLength + PhysicsConstants.PhysSkin)
+				),
+				height1,
+				height1 + 2.0f * PhysicsConstants.PhysSkin,
+				CollisionType.Gate
+			);
+
+			LineSeg1 = new LineSeg(
+				new Vertex2D(LineSeg0.V2.X, LineSeg0.V2.Y),
+				new Vertex2D(LineSeg0.V1.X, LineSeg0.V1.Y),
+				height,
+				height + 2.0f * PhysicsConstants.PhysSkin,
+				CollisionType.Gate
+			);
+
+			TwoWay = false;
+		}
+
+		public override void CalcHitBBox()
+		{
+			LineSeg0.CalcHitBBox();
+			HitBBox = LineSeg0.HitBBox;
+		}
+
+		public override float HitTest(Ball.Ball ball, float dTime, CollisionEvent coll, PlayerPhysics physics)
+		{
+			throw new System.NotImplementedException();
+		}
+
+		public override void Collide(CollisionEvent coll, PlayerPhysics physics)
+		{
+			throw new System.NotImplementedException();
+		}
 	}
 }

--- a/VisualPinball.Engine/VPT/Gate/GateHit.cs
+++ b/VisualPinball.Engine/VPT/Gate/GateHit.cs
@@ -1,0 +1,7 @@
+﻿namespace VisualPinball.Engine.VPT.Gate
+{
+	public class GateHit
+	{
+
+	}
+}

--- a/VisualPinball.Engine/VPT/Gate/GateHit.cs
+++ b/VisualPinball.Engine/VPT/Gate/GateHit.cs
@@ -54,11 +54,13 @@ namespace VisualPinball.Engine.VPT.Gate
 
 		public override float HitTest(Ball.Ball ball, float dTime, CollisionEvent coll, PlayerPhysics physics)
 		{
+			// not needed in unity ECS
 			throw new System.NotImplementedException();
 		}
 
 		public override void Collide(CollisionEvent coll, PlayerPhysics physics)
 		{
+			// not needed in unity ECS
 			throw new System.NotImplementedException();
 		}
 	}

--- a/VisualPinball.Engine/VPT/Gate/GateHit.cs.meta
+++ b/VisualPinball.Engine/VPT/Gate/GateHit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b1d2f096dba94e409e0310b4161581d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Engine/VPT/Gate/GateHitGenerator.cs
+++ b/VisualPinball.Engine/VPT/Gate/GateHitGenerator.cs
@@ -32,8 +32,7 @@ namespace VisualPinball.Engine.VPT.Gate
 				_gateData.Center.Clone().Add(tangent.Clone().MultiplyScalar(halfLength + PhysicsConstants.PhysSkin)),
 				_gateData.Center.Clone().Sub(tangent.Clone().MultiplyScalar(halfLength + PhysicsConstants.PhysSkin)),
 			};
-			var lineSeg =
-				new LineSeg(rgv[0], rgv[1], height, height + 2.0f * PhysicsConstants.PhysSkin); //!! = ball diameter
+			var lineSeg = new LineSeg(rgv[0], rgv[1], height, height + 2.0f * PhysicsConstants.PhysSkin); //!! = ball diameter
 
 			lineSeg.SetElasticity(_gateData.Elasticity);
 			lineSeg.SetFriction(_gateData.Friction);

--- a/VisualPinball.Engine/VPT/Gate/GateHitGenerator.cs
+++ b/VisualPinball.Engine/VPT/Gate/GateHitGenerator.cs
@@ -14,7 +14,7 @@ namespace VisualPinball.Engine.VPT.Gate
 			_gateData = gateData;
 		}
 
-		public LineSeg[] GenerateLineSegs(EventProxy events, float height, Vertex2D tangent)
+		public LineSeg[] GenerateLineSegs(float height, Vertex2D tangent)
 		{
 			if (_gateData.TwoWay) {
 				return new LineSeg[0];
@@ -28,7 +28,7 @@ namespace VisualPinball.Engine.VPT.Gate
 			_gateData.AngleMax = angleMax;
 
 			// oversize by the ball's radius to prevent the ball from clipping through
-			var rgv = new Vertex2D[] {
+			var rgv = new[] {
 				_gateData.Center.Clone().Add(tangent.Clone().MultiplyScalar(halfLength + PhysicsConstants.PhysSkin)),
 				_gateData.Center.Clone().Sub(tangent.Clone().MultiplyScalar(halfLength + PhysicsConstants.PhysSkin)),
 			};
@@ -41,15 +41,16 @@ namespace VisualPinball.Engine.VPT.Gate
 			return new[] {lineSeg};
 		}
 
-		// public GateHit GenerateGateHit(GateState state, EventProxy events, float height)
-		// {
-		// 	var hit = new GateHit(_gateData, state, events, height);
-		// 	hit.TwoWay = _gateData.TwoWay;
-		// 	hit.Obj = events;
-		// 	hit.Fe = true;
-		// 	hit.IsEnabled = _gateData.IsCollidable;
-		// 	return hit;
-		// }
+		public GateHit GenerateGateHit(EventProxy events, float height)
+		{
+			var hit = new GateHit(_gateData, height) {
+				TwoWay = _gateData.TwoWay,
+				Obj = events,
+				FireEvents = true,
+				IsEnabled = _gateData.IsCollidable
+			};
+			return hit;
+		}
 
 		public HitCircle[] GenerateBracketHits(float height, Vertex2D tangent)
 		{

--- a/VisualPinball.Engine/VPT/Gate/GateHitGenerator.cs
+++ b/VisualPinball.Engine/VPT/Gate/GateHitGenerator.cs
@@ -1,0 +1,69 @@
+﻿using VisualPinball.Engine.Common;
+using VisualPinball.Engine.Game;
+using VisualPinball.Engine.Math;
+using VisualPinball.Engine.Physics;
+
+namespace VisualPinball.Engine.VPT.Gate
+{
+	public class GateHitGenerator
+	{
+		private readonly GateData _gateData;
+
+		public GateHitGenerator(GateData gateData)
+		{
+			_gateData = gateData;
+		}
+
+		public LineSeg[] GenerateLineSegs(EventProxy events, float height, Vertex2D tangent)
+		{
+			if (_gateData.TwoWay) {
+				return new LineSeg[0];
+			}
+
+			var halfLength = _gateData.Length * 0.5f;
+			var angleMin = MathF.Min(_gateData.AngleMin, _gateData.AngleMax); // correct angle inversions
+			var angleMax = MathF.Max(_gateData.AngleMin, _gateData.AngleMax);
+
+			_gateData.AngleMin = angleMin;
+			_gateData.AngleMax = angleMax;
+
+			// oversize by the ball's radius to prevent the ball from clipping through
+			var rgv = new Vertex2D[] {
+				_gateData.Center.Clone().Add(tangent.Clone().MultiplyScalar(halfLength + PhysicsConstants.PhysSkin)),
+				_gateData.Center.Clone().Sub(tangent.Clone().MultiplyScalar(halfLength + PhysicsConstants.PhysSkin)),
+			};
+			var lineSeg =
+				new LineSeg(rgv[0], rgv[1], height, height + 2.0f * PhysicsConstants.PhysSkin); //!! = ball diameter
+
+			lineSeg.SetElasticity(_gateData.Elasticity);
+			lineSeg.SetFriction(_gateData.Friction);
+
+			return new[] {lineSeg};
+		}
+
+		// public GateHit GenerateGateHit(GateState state, EventProxy events, float height)
+		// {
+		// 	var hit = new GateHit(_gateData, state, events, height);
+		// 	hit.TwoWay = _gateData.TwoWay;
+		// 	hit.Obj = events;
+		// 	hit.Fe = true;
+		// 	hit.IsEnabled = _gateData.IsCollidable;
+		// 	return hit;
+		// }
+
+		public HitCircle[] GenerateBracketHits(float height, Vertex2D tangent)
+		{
+			var halfLength = _gateData.Length * 0.5f;
+			if (_gateData.ShowBracket) {
+				return new[] {
+					new HitCircle(_gateData.Center.Clone().Add(tangent.Clone().MultiplyScalar(halfLength)), 0.01f,
+						height, height + _gateData.Height),
+					new HitCircle(_gateData.Center.Clone().Sub(tangent.Clone().MultiplyScalar(halfLength)), 0.01f,
+						height, height + _gateData.Height),
+				};
+			}
+
+			return new HitCircle[0];
+		}
+	}
+}

--- a/VisualPinball.Engine/VPT/Gate/GateHitGenerator.cs.meta
+++ b/VisualPinball.Engine/VPT/Gate/GateHitGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da8a6fae9f158f9408f644f4d1371cb9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Engine/VPT/Table/Table.cs
+++ b/VisualPinball.Engine/VPT/Table/Table.cs
@@ -89,7 +89,7 @@ namespace VisualPinball.Engine.VPT.Table
 
 		public IEnumerable<IMovable> Movables => new IMovable[0]
 			.Concat(Flippers.Values)
-			.Concat(Gates.Values);
+			/*.Concat(Gates.Values)*/;
 
 		public IEnumerable<IHittable> Hittables => new IHittable[0]
 			.Concat(Flippers.Values)

--- a/VisualPinball.Engine/VPT/Table/Table.cs
+++ b/VisualPinball.Engine/VPT/Table/Table.cs
@@ -89,7 +89,7 @@ namespace VisualPinball.Engine.VPT.Table
 
 		public IEnumerable<IMovable> Movables => new IMovable[0]
 			.Concat(Flippers.Values)
-			/*.Concat(Gates.Values)*/;
+			.Concat(Gates.Values);
 
 		public IEnumerable<IHittable> Hittables => new IHittable[0]
 			.Concat(Flippers.Values)

--- a/VisualPinball.Engine/VPT/Table/Table.cs
+++ b/VisualPinball.Engine/VPT/Table/Table.cs
@@ -88,15 +88,18 @@ namespace VisualPinball.Engine.VPT.Table
 			.Concat(Triggers.Values.Select(i => i.Data));
 
 		public IEnumerable<IMovable> Movables => new IMovable[0]
-			.Concat(Flippers.Values);
+			.Concat(Flippers.Values)
+			.Concat(Gates.Values);
 
 		public IEnumerable<IHittable> Hittables => new IHittable[0]
 			.Concat(Flippers.Values)
+			.Concat(Gates.Values)
 			.Concat(Rubbers.Values)
 			.Concat(Surfaces.Values);
 
 		public IEnumerable<IPlayable> Playables => new IPlayable[0]
 			.Concat(Flippers.Values)
+			.Concat(Gates.Values)
 			.Concat(Rubbers.Values)
 			.Concat(Surfaces.Values);
 

--- a/VisualPinball.Engine/VisualPinball.Engine.csproj
+++ b/VisualPinball.Engine/VisualPinball.Engine.csproj
@@ -187,6 +187,8 @@
 		<Compile Include="VPT\Font.cs" />
 		<Compile Include="VPT\Gate\Gate.cs" />
 		<Compile Include="VPT\Gate\GateData.cs" />
+		<Compile Include="VPT\Gate\GateHit.cs" />
+		<Compile Include="VPT\Gate\GateHitGenerator.cs" />
 		<Compile Include="VPT\Gate\GateMeshGenerator.cs" />
 		<Compile Include="VPT\HitTarget\HitTarget.cs" />
 		<Compile Include="VPT\HitTarget\HitTargetData.cs" />

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
@@ -126,8 +126,8 @@ namespace VisualPinball.Unity.Game
 			}
 
 			if (Input.GetKeyUp("n")) {
-				_player.CreateBall(new DebugBallCreator(375f, 1700f));
-				_tableApi.Flippers["LeftFlipper"].RotateToEnd();
+				_player.CreateBall(new DebugBallCreator(376f, 1257f));
+				//_tableApi.Flippers["LeftFlipper"].RotateToEnd();
 			}
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Import/VpxImporter.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Import/VpxImporter.cs
@@ -173,7 +173,7 @@ namespace VisualPinball.Unity.Import
 			switch (item) {
 				case Bumper bumper:			ic = obj.AddComponent<BumperBehavior>().SetData(bumper.Data); break;
 				case Flipper flipper:		ic = flipper.SetupGameObject(obj, rog); break;
-				case Gate gate:				ic = obj.AddComponent<GateBehavior>().SetData(gate.Data); break;
+				case Gate gate:				ic = gate.SetupGameObject(obj, rog); break;
 				case HitTarget hitTarget:	ic = obj.AddComponent<HitTargetBehavior>().SetData(hitTarget.Data); break;
 				case Kicker kicker:			ic = obj.AddComponent<KickerBehavior>().SetData(kicker.Data); break;
 				case Primitive primitive:	ic = obj.AddComponent<PrimitiveBehavior>().SetData(primitive.Data); break;

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
@@ -4,10 +4,12 @@ using Unity.Entities;
 using Unity.Mathematics;
 using VisualPinball.Engine.Physics;
 using VisualPinball.Engine.VPT.Flipper;
+using VisualPinball.Engine.VPT.Gate;
 using VisualPinball.Unity.Physics.Collision;
 using VisualPinball.Unity.VPT;
 using VisualPinball.Unity.VPT.Ball;
 using VisualPinball.Unity.VPT.Flipper;
+using VisualPinball.Unity.VPT.Gate;
 using Random = Unity.Mathematics.Random;
 
 namespace VisualPinball.Unity.Physics.Collider
@@ -45,6 +47,9 @@ namespace VisualPinball.Unity.Physics.Collider
 				case FlipperHit flipperHit:
 					FlipperCollider.Create(builder, flipperHit, ref dest);
 					break;
+				case GateHit gateHit:
+					GateCollider.Create(builder, gateHit, ref dest);
+					break;
 				case LineSeg lineSeg:
 					LineCollider.Create(builder, lineSeg, ref dest);
 					break;
@@ -79,6 +84,8 @@ namespace VisualPinball.Unity.Physics.Collider
 				switch (collider->Type) {
 					case ColliderType.Circle:
 						return ((CircleCollider*)collider)->HitTest(ref collEvent, ref insideOf, in ball, dTime);
+					case ColliderType.Gate:
+						return ((GateCollider*)collider)->HitTest(ref collEvent, in ball, dTime);
 					case ColliderType.Line:
 						return ((LineCollider*)collider)->HitTest(ref collEvent, in ball, dTime);
 					case ColliderType.LineZ:

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
@@ -85,9 +85,9 @@ namespace VisualPinball.Unity.Physics.Collider
 					case ColliderType.Circle:
 						return ((CircleCollider*)collider)->HitTest(ref collEvent, ref insideOf, in ball, dTime);
 					case ColliderType.Gate:
-						return ((GateCollider*)collider)->HitTest(ref collEvent, in ball, dTime);
+						return ((GateCollider*)collider)->HitTest(ref collEvent, ref insideOf, in ball, dTime);
 					case ColliderType.Line:
-						return ((LineCollider*)collider)->HitTest(ref collEvent, in ball, dTime);
+						return ((LineCollider*)collider)->HitTest(ref collEvent, ref insideOf, in ball, dTime);
 					case ColliderType.LineZ:
 						return ((LineZCollider*)collider)->HitTest(ref collEvent, in ball, dTime);
 					case ColliderType.Line3D:

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/LineCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/LineCollider.cs
@@ -86,10 +86,9 @@ namespace VisualPinball.Unity.Physics.Collider
 			var bcpd = (ballX - coll._v1.x) * coll._normal.x + (ballY - coll._v1.y) * coll._normal.y; // ball center to plane distance
 			var bnd = bcpd - rollingRadius;
 
-			// todo for a spinner add the ball radius otherwise the ball goes half through the spinner until it moves
-			// if (ObjType == CollisionType.Spinner || ObjType == CollisionType.Gate) {
-			// 	bnd = bcpd + rollingRadius;
-			// }
+			if (coll.ItemType == ItemType.Spinner || coll.ItemType == ItemType.Gate) {
+				bnd = bcpd + rollingRadius;
+			}
 
 			var inside = bnd <= 0; // in ball inside object volume
 			float hitTime;

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/LineCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/LineCollider.cs
@@ -29,6 +29,13 @@ namespace VisualPinball.Unity.Physics.Collider
 			collider.Init(src);
 		}
 
+		public static LineCollider Create(LineSeg src)
+		{
+			var collider = default(LineCollider);
+			collider.Init(src);
+			return collider;
+		}
+
 		private void Init(LineSeg src)
 		{
 			_header.Init(ColliderType.Line, src);

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/LineCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/LineCollider.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Net.Security;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Entities;
 using Unity.Mathematics;
@@ -124,7 +125,7 @@ namespace VisualPinball.Unity.Physics.Collider
 					    /*todo   || !ball.m_vpVolObjs*/
 					    // is a trigger, so test:
 					    || math.abs(bnd) >= ball.Radius * 0.5f          // not too close ... nor too far away
-					    || inside == insideOfs.Select(x => x.Value).Contains(coll.Entity))   // ...ball outside and hit set or ball inside and no hit set
+					    || inside == BallInsideOf(insideOfs, coll.Entity))   // ...ball outside and hit set or ball inside and no hit set
 					{
 						return -1.0f;
 					}
@@ -188,6 +189,18 @@ namespace VisualPinball.Unity.Physics.Collider
 			// if (dot <= -Threshold) {
 			// 	FireHitEvent(coll.Ball);
 			// }
+
 		}
+
+		private static bool BallInsideOf(in DynamicBuffer<BallInsideOfBufferElement> insideOfs, in Entity ball)
+		{
+			for (var i = 0; i < insideOfs.Length; i++) {
+				if (insideOfs[i].Value == ball) {
+					return true;
+				}
+			}
+			return false;
+		}
+
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/LineSlingshotCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/LineSlingshotCollider.cs
@@ -42,15 +42,15 @@ namespace VisualPinball.Unity.Physics.Collider
 			_force = src.Force;
 		}
 
-		public float HitTest(ref CollisionEventData collEvent, in BallData ball, float dTime)
+		public float HitTest(ref CollisionEventData collEvent, ref DynamicBuffer<BallInsideOfBufferElement> insideOfs, in BallData ball, float dTime)
 		{
-			return HitTest(ref collEvent, ref this, in ball, dTime);
+			return HitTest(ref collEvent, ref this, ref insideOfs, in ball, dTime);
 		}
 
-		private static float HitTest(ref CollisionEventData collEvent, ref LineSlingshotCollider coll, in BallData ball, float dTime)
+		private static float HitTest(ref CollisionEventData collEvent, ref LineSlingshotCollider coll, ref DynamicBuffer<BallInsideOfBufferElement> insideOfs, in BallData ball, float dTime)
 		{
 			ref var lineColl = ref UnsafeUtilityEx.As<LineSlingshotCollider, LineCollider>(ref coll);
-			return LineCollider.HitTestBasic(ref collEvent, in lineColl, in ball, dTime, true, true, true);
+			return LineCollider.HitTestBasic(ref collEvent, ref insideOfs, in lineColl, in ball, dTime, true, true, true);
 		}
 
 		public void Collide(ref BallData ball, in LineSlingshotData slingshotData, in CollisionEventData collEvent, ref Random random)

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/ColliderType.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/ColliderType.cs
@@ -5,6 +5,7 @@
 		None,
 		Circle,
 		Flipper,
+		Gate,
 		Line,
 		Line3D,
 		LineSlingShot,

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/ContactSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/ContactSystem.cs
@@ -1,4 +1,6 @@
-﻿using NLog;
+﻿// ReSharper disable ClassNeverInstantiated.Global
+
+using NLog;
 using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Profiling;
@@ -51,7 +53,6 @@ namespace VisualPinball.Unity.Physics.Collision
 				ref var colliders = ref collData.Value.Value.Colliders;
 
 				//if (rnd.NextBool()) { // swap order of contact handling randomly
-					// tslint:disable-next-line:prefer-for-of
 				for (var i = 0; i < contacts.Length; i++) {
 					var contact = contacts[i];
 					if (contact.ColliderId > -1) {
@@ -59,6 +60,7 @@ namespace VisualPinball.Unity.Physics.Collision
 						unsafe {
 							fixed (Collider.Collider* collider = &coll) {
 								switch (coll.Type) {
+
 									case ColliderType.Flipper:
 										var flipperMovementData = GetComponent<FlipperMovementData>(coll.Entity);
 										var flipperMaterialData = GetComponent<FlipperStaticData>(coll.Entity);

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
@@ -85,8 +85,9 @@ namespace VisualPinball.Unity.Physics.Collision
 
 							case ColliderType.LineSlingShot:
 								var slingshotData = GetComponent<LineSlingshotData>(coll.Entity);
-								((LineSlingshotCollider*) collider)->Collide(ref ballData, in slingshotData, in collEvent,
-									ref random);
+								((LineSlingshotCollider*) collider)->Collide(
+									ref ballData, in slingshotData,
+									in collEvent, ref random);
 								break;
 
 							case ColliderType.Line:

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
@@ -76,8 +76,8 @@ namespace VisualPinball.Unity.Physics.Collision
 							case ColliderType.Gate:
 								var gateMovementData = GetComponent<GateMovementData>(coll.Entity);
 								var gateStaticData = GetComponent<GateStaticData>(coll.Entity);
-								((GateCollider*) collider)->Collide(
-									ref ballData, ref collEvent, ref gateMovementData,
+								GateCollider.Collide(
+									in ballData, ref collEvent, ref gateMovementData,
 									in gateStaticData
 								);
 								SetComponent(coll.Entity, gateMovementData);

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
@@ -3,6 +3,7 @@
 using System;
 using Unity.Entities;
 using Unity.Profiling;
+using UnityEngine;
 using VisualPinball.Unity.Physics.Collider;
 using VisualPinball.Unity.Physics.SystemGroup;
 using VisualPinball.Unity.VPT.Ball;
@@ -74,6 +75,7 @@ namespace VisualPinball.Unity.Physics.Collision
 								break;
 
 							case ColliderType.Gate:
+								Debug.Log("Static collision with " + coll.Entity);
 								var gateMovementData = GetComponent<GateMovementData>(coll.Entity);
 								var gateStaticData = GetComponent<GateStaticData>(coll.Entity);
 								GateCollider.Collide(

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
@@ -7,6 +7,7 @@ using VisualPinball.Unity.Physics.Collider;
 using VisualPinball.Unity.Physics.SystemGroup;
 using VisualPinball.Unity.VPT.Ball;
 using VisualPinball.Unity.VPT.Flipper;
+using VisualPinball.Unity.VPT.Gate;
 using Random = Unity.Mathematics.Random;
 
 namespace VisualPinball.Unity.Physics.Collision
@@ -70,6 +71,16 @@ namespace VisualPinball.Unity.Physics.Collision
 									in flipperMaterialData, in flipperVelocityData
 								);
 								SetComponent(coll.Entity, flipperMovementData);
+								break;
+
+							case ColliderType.Gate:
+								var gateMovementData = GetComponent<GateMovementData>(coll.Entity);
+								var gateStaticData = GetComponent<GateStaticData>(coll.Entity);
+								((GateCollider*) collider)->Collide(
+									ref ballData, ref collEvent, ref gateMovementData,
+									in gateStaticData
+								);
+								SetComponent(coll.Entity, gateMovementData);
 								break;
 
 							case ColliderType.LineSlingShot:

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
@@ -75,7 +75,6 @@ namespace VisualPinball.Unity.Physics.Collision
 								break;
 
 							case ColliderType.Gate:
-								Debug.Log("Static collision with " + coll.Entity);
 								var gateMovementData = GetComponent<GateMovementData>(coll.Entity);
 								var gateStaticData = GetComponent<GateStaticData>(coll.Entity);
 								GateCollider.Collide(

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticNarrowPhaseSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticNarrowPhaseSystem.cs
@@ -62,7 +62,7 @@ using VisualPinball.Unity.VPT.Flipper;
 							switch (coll.Type) {
 
 								case ColliderType.LineSlingShot:
-									newTime = ((LineSlingshotCollider*) collider)->HitTest(ref newCollEvent, in ballData, collEvent.HitTime);
+									newTime = ((LineSlingshotCollider*) collider)->HitTest(ref newCollEvent, ref insideOfs, in ballData, collEvent.HitTime);
 									break;
 
 								case ColliderType.Flipper:

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticNarrowPhaseSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticNarrowPhaseSystem.cs
@@ -5,6 +5,7 @@ using VisualPinball.Unity.Physics.Collider;
 using VisualPinball.Unity.Physics.SystemGroup;
 using VisualPinball.Unity.VPT.Ball;
 using VisualPinball.Unity.VPT.Flipper;
+ using VisualPinball.Unity.VPT.Gate;
 
  namespace VisualPinball.Unity.Physics.Collision
 {

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateBehavior.cs
@@ -4,7 +4,6 @@
 // ReSharper disable MemberCanBePrivate.Global
 #endregion
 
-using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Gate;
 using VisualPinball.Unity.Extensions;
@@ -12,29 +11,9 @@ using VisualPinball.Unity.Extensions;
 namespace VisualPinball.Unity.VPT.Gate
 {
 	[AddComponentMenu("Visual Pinball/Gate")]
-	public class GateBehavior : ItemBehavior<Engine.VPT.Gate.Gate, GateData>, IConvertGameObjectToEntity
+	public class GateBehavior : ItemBehavior<Engine.VPT.Gate.Gate, GateData>
 	{
 		protected override string[] Children => new []{"Wire", "Bracket"};
-
-		public void Convert(Entity entity, EntityManager dstManager, GameObjectConversionSystem conversionSystem)
-		{
-			Convert(entity, dstManager);
-
-			dstManager.AddComponentData(entity, new GateStaticData {
-				AngleMin = data.AngleMin,
-				AngleMax = data.AngleMax,
-				Height = data.Height,
-				Damping = data.Damping,
-				GravityFactor = data.GravityFactor,
-				TwoWay = data.TwoWay
-			});
-			dstManager.AddComponentData(entity, new GateMovementData {
-				Angle = data.AngleMin,
-				AngleSpeed = 0,
-				ForcedMove = false,
-				IsOpen = false
-			});
-		}
 
 		protected override Engine.VPT.Gate.Gate GetItem()
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateBehavior.cs
@@ -4,6 +4,7 @@
 // ReSharper disable MemberCanBePrivate.Global
 #endregion
 
+using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Gate;
 using VisualPinball.Unity.Extensions;
@@ -11,9 +12,29 @@ using VisualPinball.Unity.Extensions;
 namespace VisualPinball.Unity.VPT.Gate
 {
 	[AddComponentMenu("Visual Pinball/Gate")]
-	public class GateBehavior : ItemBehavior<Engine.VPT.Gate.Gate, GateData>
+	public class GateBehavior : ItemBehavior<Engine.VPT.Gate.Gate, GateData>, IConvertGameObjectToEntity
 	{
 		protected override string[] Children => new []{"Wire", "Bracket"};
+
+		public void Convert(Entity entity, EntityManager dstManager, GameObjectConversionSystem conversionSystem)
+		{
+			Convert(entity, dstManager);
+
+			dstManager.AddComponentData(entity, new GateStaticData {
+				AngleMin = data.AngleMin,
+				AngleMax = data.AngleMax,
+				Height = data.Height,
+				Damping = data.Damping,
+				GravityFactor = data.GravityFactor,
+				TwoWay = data.TwoWay
+			});
+			dstManager.AddComponentData(entity, new GateMovementData {
+				Angle = data.AngleMin,
+				AngleSpeed = 0,
+				ForcedMove = false,
+				IsOpen = false
+			});
+		}
 
 		protected override Engine.VPT.Gate.Gate GetItem()
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateCollider.cs
@@ -1,0 +1,105 @@
+﻿using Unity.Collections.LowLevel.Unsafe;
+using Unity.Entities;
+using Unity.Mathematics;
+using VisualPinball.Engine.VPT.Gate;
+using VisualPinball.Unity.Physics.Collider;
+using VisualPinball.Unity.Physics.Collision;
+using VisualPinball.Unity.VPT.Ball;
+
+namespace VisualPinball.Unity.VPT.Gate
+{
+	public struct GateCollider : ICollider, ICollidable
+	{
+		private ColliderHeader _header;
+
+		private LineCollider _lineSeg0;
+		private LineCollider _lineSeg1;
+
+		public ColliderType Type => _header.Type;
+
+		public static void Create(BlobBuilder builder, GateHit src, ref BlobPtr<Collider> dest)
+		{
+			ref var ptr = ref UnsafeUtilityEx.As<BlobPtr<Collider>, BlobPtr<GateCollider>>(ref dest);
+			ref var collider = ref builder.Allocate(ref ptr);
+			collider.Init(src);
+		}
+
+		private void Init(GateHit src)
+		{
+			_header.Type = ColliderType.Gate;
+			_header.ItemType = Collider.GetItemType(src.ObjType);
+			_header.Entity = new Entity {Index = src.ItemIndex, Version = src.ItemVersion};
+			_header.Id = src.Id;
+			_header.Material = new PhysicsMaterialData {
+				Elasticity = src.Elasticity,
+				ElasticityFalloff = src.ElasticityFalloff,
+				Friction = src.Friction,
+				Scatter = src.Scatter,
+			};
+
+			_lineSeg0 = LineCollider.Create(src.LineSeg0);
+			_lineSeg1 = LineCollider.Create(src.LineSeg1);
+		}
+
+		#region Narrowphase
+
+		public float HitTest(ref CollisionEventData collEvent, in BallData ball, float dTime)
+		{
+			// todo
+			// if (!this.isEnabled) {
+			// 	return -1.0;
+			// }
+
+			var hitTime = LineCollider.HitTestBasic(ref collEvent, in _lineSeg0, in ball, dTime, false, true, false); // any face, lateral, non-rigid
+			if (hitTime >= 0) {
+				// signal the Collide() function that the hit is on the front or back side
+				collEvent.HitFlag = false;
+				return hitTime;
+			}
+
+			hitTime = LineCollider.HitTestBasic(ref collEvent, in _lineSeg1, in ball, dTime, false, true, false); // any face, lateral, non-rigid
+			if (hitTime >= 0) {
+				collEvent.HitFlag = true;
+				return hitTime;
+			}
+
+			return -1.0f;
+		}
+
+		#endregion
+
+		#region Collision
+
+		public void Collide(ref BallData ball, ref CollisionEventData collEvent, ref GateMovementData movementData, in GateStaticData data)
+		{
+			var hitNormal = collEvent.HitNormal;
+
+			var dot = math.dot(hitNormal, ball.Velocity);
+			var h = data.Height * 0.5f;
+
+			// linear speed = ball speed
+			// angular speed = linear/radius (height of hit)
+			var speed = math.abs(dot);
+			// h is the height of the gate axis.
+			if (math.abs(h) > 1.0) {                           // avoid divide by zero
+				speed /= h;
+			}
+
+			movementData.AngleSpeed = speed;
+			if (!collEvent.HitFlag && !data.TwoWay) {
+				movementData.AngleSpeed *= 1.0f / 8.0f;                // Give a little bounce-back.
+				return;                                        // hit from back doesn't count if not two-way
+			}
+
+			// We encoded which side of the spinner the ball hit
+			if (collEvent.HitFlag && data.TwoWay) {
+				movementData.AngleSpeed = -movementData.AngleSpeed;
+			}
+
+			// todo
+			//this.fireHitEvent(ball);
+		}
+
+		#endregion
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateCollider.cs
@@ -43,21 +43,21 @@ namespace VisualPinball.Unity.VPT.Gate
 
 		#region Narrowphase
 
-		public float HitTest(ref CollisionEventData collEvent, in BallData ball, float dTime)
+		public float HitTest(ref CollisionEventData collEvent, ref DynamicBuffer<BallInsideOfBufferElement> insideOfs, in BallData ball, float dTime)
 		{
 			// todo
 			// if (!this.isEnabled) {
 			// 	return -1.0;
 			// }
 
-			var hitTime = LineCollider.HitTestBasic(ref collEvent, in _lineSeg0, in ball, dTime, false, true, false); // any face, lateral, non-rigid
+			var hitTime = LineCollider.HitTestBasic(ref collEvent, ref insideOfs, in _lineSeg0, in ball, dTime, false, true, false); // any face, lateral, non-rigid
 			if (hitTime >= 0) {
 				// signal the Collide() function that the hit is on the front or back side
 				collEvent.HitFlag = false;
 				return hitTime;
 			}
 
-			hitTime = LineCollider.HitTestBasic(ref collEvent, in _lineSeg1, in ball, dTime, false, true, false); // any face, lateral, non-rigid
+			hitTime = LineCollider.HitTestBasic(ref collEvent, ref insideOfs, in _lineSeg1, in ball, dTime, false, true, false); // any face, lateral, non-rigid
 			if (hitTime >= 0) {
 				collEvent.HitFlag = true;
 				return hitTime;
@@ -72,9 +72,7 @@ namespace VisualPinball.Unity.VPT.Gate
 
 		public static void Collide(in BallData ball, ref CollisionEventData collEvent, ref GateMovementData movementData, in GateStaticData data)
 		{
-			var hitNormal = collEvent.HitNormal;
-
-			var dot = math.dot(hitNormal, ball.Velocity);
+			var dot = math.dot(collEvent.HitNormal, ball.Velocity);
 			var h = data.Height * 0.5f;
 
 			// linear speed = ball speed
@@ -87,7 +85,7 @@ namespace VisualPinball.Unity.VPT.Gate
 
 			movementData.AngleSpeed = speed;
 			if (!collEvent.HitFlag && !data.TwoWay) {
-				movementData.AngleSpeed *= 1.0f / 8.0f;        // Give a little bounce-back.
+				movementData.AngleSpeed *= (float)(1.0 / 8.0); // Give a little bounce-back.
 				return;                                        // hit from back doesn't count if not two-way
 			}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateCollider.cs
@@ -70,7 +70,7 @@ namespace VisualPinball.Unity.VPT.Gate
 
 		#region Collision
 
-		public void Collide(ref BallData ball, ref CollisionEventData collEvent, ref GateMovementData movementData, in GateStaticData data)
+		public static void Collide(in BallData ball, ref CollisionEventData collEvent, ref GateMovementData movementData, in GateStaticData data)
 		{
 			var hitNormal = collEvent.HitNormal;
 
@@ -87,7 +87,7 @@ namespace VisualPinball.Unity.VPT.Gate
 
 			movementData.AngleSpeed = speed;
 			if (!collEvent.HitFlag && !data.TwoWay) {
-				movementData.AngleSpeed *= 1.0f / 8.0f;                // Give a little bounce-back.
+				movementData.AngleSpeed *= 1.0f / 8.0f;        // Give a little bounce-back.
 				return;                                        // hit from back doesn't count if not two-way
 			}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateCollider.cs
@@ -50,7 +50,8 @@ namespace VisualPinball.Unity.VPT.Gate
 			// 	return -1.0;
 			// }
 
-			var hitTime = LineCollider.HitTestBasic(ref collEvent, ref insideOfs, in _lineSeg0, in ball, dTime, false, true, false); // any face, lateral, non-rigid
+			var hitTime = LineCollider.HitTestBasic(ref collEvent, ref insideOfs, in _lineSeg1, in ball, dTime, false, true, false); // any face, lateral, non-rigid
+			hitTime = LineCollider.HitTestBasic(ref collEvent, ref insideOfs, in _lineSeg0, in ball, dTime, false, true, false); // any face, lateral, non-rigid
 			if (hitTime >= 0) {
 				// signal the Collide() function that the hit is on the front or back side
 				collEvent.HitFlag = false;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateCollider.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateCollider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87a2431d80b52264f8acc922a37a1214
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateDisplacementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateDisplacementSystem.cs
@@ -21,7 +21,9 @@ namespace VisualPinball.Unity.VPT.Gate
 			var dTime = _simulateCycleSystemGroup.HitTime;
 			var marker = PerfMarker;
 
-			Entities.WithName("GateDisplacementJob").ForEach((ref GateMovementData movementData, in GateStaticData data) => {
+			Entities
+				.WithName("GateDisplacementJob")
+				.ForEach((ref GateMovementData movementData, in GateStaticData data) => {
 
 				marker.Begin();
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateDisplacementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateDisplacementSystem.cs
@@ -1,0 +1,85 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Profiling;
+using VisualPinball.Unity.Physics.SystemGroup;
+
+namespace VisualPinball.Unity.VPT.Gate
+{
+	[UpdateInGroup(typeof(UpdateDisplacementSystemGroup))]
+	public class GateDisplacementSystem : SystemBase
+	{
+		private SimulateCycleSystemGroup _simulateCycleSystemGroup;
+		private static readonly ProfilerMarker PerfMarker = new ProfilerMarker("GateDisplacementSystem");
+
+		protected override void OnCreate()
+		{
+			_simulateCycleSystemGroup = World.GetOrCreateSystem<SimulateCycleSystemGroup>();
+		}
+
+		protected override void OnUpdate()
+		{
+			var dTime = _simulateCycleSystemGroup.HitTime;
+			var marker = PerfMarker;
+
+			Entities.WithName("GateDisplacementJob").ForEach((ref GateMovementData movementData, in GateStaticData data) => {
+
+				marker.Begin();
+
+				if (data.TwoWay) {
+					if (math.abs(movementData.Angle) > data.AngleMax) {
+						if (movementData.Angle < 0.0) {
+							movementData.Angle = -data.AngleMax;
+						} else {
+							movementData.Angle = data.AngleMax;
+						}
+
+						//todo this.events.fireVoidEventParm(Event.LimitEventsEOS, Math.abs(radToDeg(this.angleSpeed)));    // send EOS event
+						if (!movementData.ForcedMove) {
+							movementData.AngleSpeed = -movementData.AngleSpeed;
+							movementData.AngleSpeed *= data.Damping * 0.8f;           // just some extra damping to reduce the angleSpeed a bit faster
+						} else if (movementData.AngleSpeed > 0.0) {
+							movementData.AngleSpeed = 0.0f;
+						}
+					}
+					if (math.abs(movementData.Angle) < data.AngleMin) {
+						if (movementData.Angle < 0.0) {
+							movementData.Angle = -data.AngleMin;
+						} else {
+							movementData.Angle = data.AngleMin;
+						}
+						if (!movementData.ForcedMove) {
+							movementData.AngleSpeed = -movementData.AngleSpeed;
+							movementData.AngleSpeed *= data.Damping * 0.8f;           // just some extra damping to reduce the angleSpeed a bit faster
+						} else if (movementData.AngleSpeed < 0.0) {
+							movementData.AngleSpeed = 0.0f;
+						}
+					}
+				} else {
+					if (movementData.Angle > data.AngleMax) {
+						movementData.Angle = data.AngleMax;
+						// todo this.events.fireVoidEventParm(Event.LimitEventsEOS, Math.abs(radToDeg(movementData.AngleSpeed)));    // send EOS event
+						if (!movementData.ForcedMove) {
+							movementData.AngleSpeed = -movementData.AngleSpeed;
+							movementData.AngleSpeed *= data.Damping * 0.8f;           // just some extra damping to reduce the angleSpeed a bit faster
+						} else if (movementData.AngleSpeed > 0.0) {
+							movementData.AngleSpeed = 0.0f;
+						}
+					}
+					if (movementData.Angle < data.AngleMin) {
+						movementData.Angle = data.AngleMin;
+						// todo this.events.fireVoidEventParm(Event.LimitEventsBOS, Math.abs(radToDeg(movementData.AngleSpeed)));    // send Park event
+						if (!movementData.ForcedMove) {
+							movementData.AngleSpeed = -movementData.AngleSpeed;
+							movementData.AngleSpeed *= data.Damping * 0.8f;           // just some extra damping to reduce the angleSpeed a bit faster
+						} else if (movementData.AngleSpeed < 0.0) {
+							movementData.AngleSpeed = 0.0f;
+						}
+					}
+				}
+				movementData.Angle += movementData.AngleSpeed * dTime;
+
+				marker.End();
+			}).Run();
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateDisplacementSystem.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateDisplacementSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c1572714cfb69964a9d503d024bf012c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateExtensions.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateExtensions.cs
@@ -1,0 +1,18 @@
+﻿using Unity.Entities;
+using UnityEngine;
+using VisualPinball.Engine.Game;
+using VisualPinball.Engine.VPT.Flipper;
+using VisualPinball.Unity.Extensions;
+
+namespace VisualPinball.Unity.VPT.Gate
+{
+	public static class GateExtensions
+	{
+		public static GateBehavior SetupGameObject(this Engine.VPT.Gate.Gate gate, GameObject obj, RenderObjectGroup rog)
+		{
+			var ic = obj.AddComponent<GateBehavior>().SetData(gate.Data);
+			obj.AddComponent<ConvertToEntity>();
+			return ic as GateBehavior;
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateExtensions.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.Game;
-using VisualPinball.Engine.VPT.Flipper;
-using VisualPinball.Unity.Extensions;
 
 namespace VisualPinball.Unity.VPT.Gate
 {

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateExtensions.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateExtensions.cs
@@ -12,6 +12,10 @@ namespace VisualPinball.Unity.VPT.Gate
 		{
 			var ic = obj.AddComponent<GateBehavior>().SetData(gate.Data);
 			obj.AddComponent<ConvertToEntity>();
+
+			var wire = obj.transform.Find("Wire").gameObject;
+			wire.AddComponent<GateWireBehavior>().SetData(gate.Data);
+
 			return ic as GateBehavior;
 		}
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateExtensions.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9bd782d973faaa3438c2a50091e65071
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateMovementData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateMovementData.cs
@@ -1,0 +1,12 @@
+using Unity.Entities;
+
+namespace VisualPinball.Unity.VPT.Gate
+{
+	public struct GateMovementData : IComponentData
+	{
+		public float Angle;
+		public float AngleSpeed;
+		public bool ForcedMove;
+		public bool IsOpen;
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateMovementData.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateMovementData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b556b43a8fd85104a8bfbac2a0645170
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateMovementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateMovementSystem.cs
@@ -36,6 +36,7 @@ namespace VisualPinball.Unity.VPT.Gate
 
 				marker.Begin();
 
+
 				var rotationX = movementData.Angle - math.radians(data.AngleMin);
 				rot.Value = quaternion.RotateX(rotationX);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateMovementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateMovementSystem.cs
@@ -1,0 +1,47 @@
+﻿using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Profiling;
+using Unity.Transforms;
+using UnityEngine;
+using UnityEngine.Profiling;
+using VisualPinball.Unity.Physics.SystemGroup;
+using VisualPinball.Unity.VPT.Gate;
+using VisualPinball.Unity.VPT.Table;
+
+namespace VisualPinball.Unity.VPT.Gate
+{
+	[UpdateInGroup(typeof(TransformMeshesSystemGroup))]
+	public class GateMovementSystem : SystemBase
+	{
+		private float4x4 _baseTransform;
+		private static readonly ProfilerMarker PerfMarker = new ProfilerMarker("GateMovementSystem");
+
+		protected override void OnStartRunning()
+		{
+			var root = Object.FindObjectOfType<TableBehavior>();
+			var ltw = root.gameObject.transform.localToWorldMatrix;
+			_baseTransform = new float4x4(
+				ltw.m00, ltw.m01, ltw.m02, ltw.m03,
+				ltw.m10, ltw.m11, ltw.m12, ltw.m13,
+				ltw.m20, ltw.m21, ltw.m22, ltw.m23,
+				ltw.m30, ltw.m31, ltw.m32, ltw.m33
+			);
+		}
+
+		protected override void OnUpdate()
+		{
+			var ltw = _baseTransform;
+			var marker = PerfMarker;
+			Entities.WithName("GateMovementJob").ForEach((ref Rotation rot, in GateStaticData data, in GateMovementData movementData) => {
+
+				marker.Begin();
+
+				var rotationX = movementData.Angle - math.radians(data.AngleMin);
+				rot.Value = quaternion.RotateX(rotationX);
+
+				marker.End();
+
+			}).Run();
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateMovementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateMovementSystem.cs
@@ -36,7 +36,6 @@ namespace VisualPinball.Unity.VPT.Gate
 
 				marker.Begin();
 
-
 				var rotationX = movementData.Angle - math.radians(data.AngleMin);
 				rot.Value = quaternion.RotateX(rotationX);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateMovementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateMovementSystem.cs
@@ -2,42 +2,23 @@
 using Unity.Mathematics;
 using Unity.Profiling;
 using Unity.Transforms;
-using UnityEngine;
-using UnityEngine.Profiling;
 using VisualPinball.Unity.Physics.SystemGroup;
-using VisualPinball.Unity.VPT.Gate;
-using VisualPinball.Unity.VPT.Table;
 
 namespace VisualPinball.Unity.VPT.Gate
 {
 	[UpdateInGroup(typeof(TransformMeshesSystemGroup))]
 	public class GateMovementSystem : SystemBase
 	{
-		private float4x4 _baseTransform;
 		private static readonly ProfilerMarker PerfMarker = new ProfilerMarker("GateMovementSystem");
-
-		protected override void OnStartRunning()
-		{
-			var root = Object.FindObjectOfType<TableBehavior>();
-			var ltw = root.gameObject.transform.localToWorldMatrix;
-			_baseTransform = new float4x4(
-				ltw.m00, ltw.m01, ltw.m02, ltw.m03,
-				ltw.m10, ltw.m11, ltw.m12, ltw.m13,
-				ltw.m20, ltw.m21, ltw.m22, ltw.m23,
-				ltw.m30, ltw.m31, ltw.m32, ltw.m33
-			);
-		}
 
 		protected override void OnUpdate()
 		{
-			var ltw = _baseTransform;
 			var marker = PerfMarker;
 			Entities.WithName("GateMovementJob").ForEach((ref Rotation rot, in GateStaticData data, in GateMovementData movementData) => {
 
 				marker.Begin();
 
-				var rotationX = movementData.Angle - math.radians(data.AngleMin);
-				rot.Value = quaternion.RotateX(rotationX);
+				rot.Value = quaternion.RotateX(movementData.Angle);
 
 				marker.End();
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateMovementSystem.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateMovementSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5fecec9bc1c0ce844853a4ab162a7dfd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateStaticData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateStaticData.cs
@@ -1,0 +1,14 @@
+using Unity.Entities;
+
+namespace VisualPinball.Unity.VPT.Gate
+{
+	public struct GateStaticData : IComponentData
+	{
+		public float AngleMin;
+		public float AngleMax;
+		public float Height;
+		public float GravityFactor;
+		public float Damping;
+		public bool TwoWay;
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateStaticData.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateStaticData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65bf9dfb6bbc61748965742b20e21738
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateVelocitySystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateVelocitySystem.cs
@@ -1,0 +1,43 @@
+// ReSharper disable CompareOfFloatsByEqualityOperator
+
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Profiling;
+using VisualPinball.Engine.Common;
+using VisualPinball.Unity.Physics.SystemGroup;
+
+namespace VisualPinball.Unity.VPT.Gate
+{
+	[AlwaysSynchronizeSystem]
+	[UpdateInGroup(typeof(UpdateVelocitiesSystemGroup))]
+	public class GateVelocitySystem : SystemBase
+	{
+		private static readonly ProfilerMarker PerfMarker = new ProfilerMarker("FlipperVelocitySystem");
+
+		protected override void OnUpdate()
+		{
+			var marker = PerfMarker;
+			Entities
+				.WithName("GateVelocityJob")
+				.ForEach((ref GateMovementData movementData, in GateStaticData data) => {
+
+				marker.Begin();
+
+				if (!movementData.IsOpen) {
+					if (math.abs(movementData.Angle) < data.AngleMin + 0.01f && math.abs(movementData.AngleSpeed) < 0.01f) {
+						// stop a bit earlier to prevent a nearly endless animation (especially for slow balls)
+						movementData.Angle = data.AngleMin;
+						movementData.AngleSpeed = 0.0f;
+					}
+					if (math.abs(movementData.AngleSpeed) != 0.0f && movementData.Angle != data.AngleMin) {
+						movementData.AngleSpeed -= math.sin(movementData.Angle) * data.GravityFactor * (PhysicsConstants.PhysFactor / 100.0f); // Center of gravity towards bottom of object, makes it stop vertical
+						movementData.AngleSpeed *= data.Damping;
+					}
+				}
+
+				marker.End();
+
+			}).Run();
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateVelocitySystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateVelocitySystem.cs
@@ -8,7 +8,6 @@ using VisualPinball.Unity.Physics.SystemGroup;
 
 namespace VisualPinball.Unity.VPT.Gate
 {
-	[AlwaysSynchronizeSystem]
 	[UpdateInGroup(typeof(UpdateVelocitiesSystemGroup))]
 	public class GateVelocitySystem : SystemBase
 	{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateVelocitySystem.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateVelocitySystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09bd6aa7985f5e544a6c5752e07bd3f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateWireBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateWireBehavior.cs
@@ -1,0 +1,36 @@
+﻿using Unity.Entities;
+using VisualPinball.Engine.VPT.Gate;
+
+namespace VisualPinball.Unity.VPT.Gate
+{
+	public class GateWireBehavior : ItemBehavior<Engine.VPT.Gate.Gate, GateData>, IConvertGameObjectToEntity
+	{
+		protected override string[] Children => new string[0];
+
+		public void Convert(Entity entity, EntityManager dstManager, GameObjectConversionSystem conversionSystem)
+		{
+			Convert(entity, dstManager);
+
+			dstManager.AddComponentData(entity, new GateStaticData {
+				AngleMin = data.AngleMin,
+				AngleMax = data.AngleMax,
+				Height = data.Height,
+				Damping = data.Damping,
+				GravityFactor = data.GravityFactor,
+				TwoWay = data.TwoWay
+			});
+			dstManager.AddComponentData(entity, new GateMovementData {
+				Angle = data.AngleMin,
+				AngleSpeed = 0,
+				ForcedMove = false,
+				IsOpen = false
+			});
+
+		}
+
+		protected override Engine.VPT.Gate.Gate GetItem()
+		{
+			return transform.parent.gameObject.GetComponent<GateBehavior>().Item;
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateWireBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateWireBehavior.cs
@@ -1,4 +1,6 @@
 ﻿using Unity.Entities;
+using Unity.Mathematics;
+using VisualPinball.Engine.Common;
 using VisualPinball.Engine.VPT.Gate;
 
 namespace VisualPinball.Unity.VPT.Gate
@@ -15,7 +17,7 @@ namespace VisualPinball.Unity.VPT.Gate
 				AngleMin = data.AngleMin,
 				AngleMax = data.AngleMax,
 				Height = data.Height,
-				Damping = data.Damping,
+				Damping = math.pow(data.Damping, PhysicsConstants.PhysFactor),
 				GravityFactor = data.GravityFactor,
 				TwoWay = data.TwoWay
 			});

--- a/VisualPinball.Unity/VisualPinball.Unity/VisualPinball.Unity.csproj
+++ b/VisualPinball.Unity/VisualPinball.Unity/VisualPinball.Unity.csproj
@@ -187,6 +187,7 @@
     <Compile Include="VPT\Gate\GateBehavior.cs" />
     <Compile Include="VPT\Gate\GateMovementData.cs" />
     <Compile Include="VPT\Gate\GateStaticData.cs" />
+    <Compile Include="VPT\Gate\GateWireBehavior.cs" />
     <Compile Include="VPT\HitTarget\HitTargetBehavior.cs" />
     <Compile Include="VPT\IApi.cs" />
     <Compile Include="VPT\IEditableItemBehavior.cs" />

--- a/VisualPinball.Unity/VisualPinball.Unity/VisualPinball.Unity.csproj
+++ b/VisualPinball.Unity/VisualPinball.Unity/VisualPinball.Unity.csproj
@@ -179,6 +179,7 @@
     <Compile Include="VPT\Flipper\FlipperBehavior.cs" />
     <Compile Include="VPT\Flipper\FlipperVelocitySystem.cs" />
     <Compile Include="VPT\Flipper\SolenoidStateData.cs" />
+    <Compile Include="VPT\Gate\GateExtensions.cs" />
     <Compile Include="VPT\Gate\GateMovementSystem.cs" />
     <Compile Include="VPT\Gate\GateVelocitySystem.cs" />
     <Compile Include="VPT\Gate\GateDisplacementSystem.cs" />

--- a/VisualPinball.Unity/VisualPinball.Unity/VisualPinball.Unity.csproj
+++ b/VisualPinball.Unity/VisualPinball.Unity/VisualPinball.Unity.csproj
@@ -179,7 +179,13 @@
     <Compile Include="VPT\Flipper\FlipperBehavior.cs" />
     <Compile Include="VPT\Flipper\FlipperVelocitySystem.cs" />
     <Compile Include="VPT\Flipper\SolenoidStateData.cs" />
+    <Compile Include="VPT\Gate\GateMovementSystem.cs" />
+    <Compile Include="VPT\Gate\GateVelocitySystem.cs" />
+    <Compile Include="VPT\Gate\GateDisplacementSystem.cs" />
+    <Compile Include="VPT\Gate\GateCollider.cs" />
     <Compile Include="VPT\Gate\GateBehavior.cs" />
+    <Compile Include="VPT\Gate\GateMovementData.cs" />
+    <Compile Include="VPT\Gate\GateStaticData.cs" />
     <Compile Include="VPT\HitTarget\HitTargetBehavior.cs" />
     <Compile Include="VPT\IApi.cs" />
     <Compile Include="VPT\IEditableItemBehavior.cs" />


### PR DESCRIPTION
This implements gate collisions and movement. Closes #25.

Spent most time in fixing the line collider, because there were TODO-commented sections I only noticed once debug-stepping through.

Since the gate moves, and the only thing moving is the wire, I've attached all the data components to the wire entity instead of the parent. That seems to work well, and since it's attached to the parent space, we can just do `rot.Value = quaternion.RotateX(movementData.Angle)` when updating the mesh, instead of having to convert from local to world space first. This is the only reason `GateWireBehavior` exists, usually we don't have special behaviors for the item's children.