### PR TITLE
Bumper Collisions and Animations

### DIFF
--- a/VisualPinball.Engine/VPT/Bumper/Bumper.cs
+++ b/VisualPinball.Engine/VPT/Bumper/Bumper.cs
@@ -1,11 +1,17 @@
 using System.IO;
 using VisualPinball.Engine.Game;
+using VisualPinball.Engine.Physics;
 
 namespace VisualPinball.Engine.VPT.Bumper
 {
-	public class Bumper : Item<BumperData>, IRenderable
+	public class Bumper : Item<BumperData>, IRenderable, IHittable
 	{
+		public bool IsCollidable => true;
+		public EventProxy EventProxy { get; private set; }
+
 		private readonly BumperMeshGenerator _meshGenerator;
+
+		private HitObject[] _hits;
 
 		public Bumper(BumperData data) : base(data)
 		{
@@ -14,9 +20,17 @@ namespace VisualPinball.Engine.VPT.Bumper
 
 		public Bumper(BinaryReader reader, string itemName) : this(new BumperData(reader, itemName)) { }
 
+		public void SetupPlayer(Player player, Table.Table table)
+		{
+			var height = table.GetSurfaceHeight(Data.Surface, Data.Center.X, Data.Center.Y);
+			_hits = new HitObject[] {new BumperHit(Data.Center, Data.Radius, height, height + Data.HeightScale)};
+		}
+
 		public RenderObjectGroup GetRenderObjects(Table.Table table, Origin origin = Origin.Global, bool asRightHanded = true)
 		{
 			return _meshGenerator.GetRenderObjects(table, origin, asRightHanded);
 		}
+
+		public HitObject[] GetHitShapes() => _hits;
 	}
 }

--- a/VisualPinball.Engine/VPT/Bumper/BumperHit.cs
+++ b/VisualPinball.Engine/VPT/Bumper/BumperHit.cs
@@ -1,0 +1,12 @@
+﻿using VisualPinball.Engine.Math;
+using VisualPinball.Engine.Physics;
+
+namespace VisualPinball.Engine.VPT.Bumper
+{
+	public class BumperHit : HitCircle
+	{
+		public BumperHit(Vertex2D center, float radius, float zLow, float zHigh) : base(center, radius, zLow, zHigh)
+		{
+		}
+	}
+}

--- a/VisualPinball.Engine/VPT/Bumper/BumperHit.cs.meta
+++ b/VisualPinball.Engine/VPT/Bumper/BumperHit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86ab5e69bacdb3d49ae6a4c4eecf9f6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Engine/VPT/Table/Table.cs
+++ b/VisualPinball.Engine/VPT/Table/Table.cs
@@ -93,6 +93,7 @@ namespace VisualPinball.Engine.VPT.Table
 			.Concat(Spinners.Values);
 
 		public IEnumerable<IHittable> Hittables => new IHittable[0]
+			.Concat(Bumpers.Values)
 			.Concat(Flippers.Values)
 			.Concat(Gates.Values)
 			.Concat(Rubbers.Values)
@@ -100,6 +101,7 @@ namespace VisualPinball.Engine.VPT.Table
 			.Concat(Surfaces.Values);
 
 		public IEnumerable<IPlayable> Playables => new IPlayable[0]
+			.Concat(Bumpers.Values)
 			.Concat(Flippers.Values)
 			.Concat(Gates.Values)
 			.Concat(Rubbers.Values)

--- a/VisualPinball.Engine/VisualPinball.Engine.csproj
+++ b/VisualPinball.Engine/VisualPinball.Engine.csproj
@@ -165,6 +165,7 @@
 		<Compile Include="VPT\Bitmap.cs" />
 		<Compile Include="VPT\Bumper\Bumper.cs" />
 		<Compile Include="VPT\Bumper\BumperData.cs" />
+		<Compile Include="VPT\Bumper\BumperHit.cs" />
 		<Compile Include="VPT\Bumper\BumperMeshGenerator.cs" />
 		<Compile Include="VPT\Collection\Collection.cs" />
 		<Compile Include="VPT\Collection\CollectionData.cs" />

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
@@ -126,7 +126,7 @@ namespace VisualPinball.Unity.Game
 			}
 
 			if (Input.GetKeyUp("n")) {
-				_player.CreateBall(new DebugBallCreator(200f, 1000f));
+				_player.CreateBall(new DebugBallCreator(517f, 1672f, -90, 3));
 				//_tableApi.Flippers["LeftFlipper"].RotateToEnd();
 			}
 		}
@@ -145,6 +145,9 @@ namespace VisualPinball.Unity.Game
 		private float _x;
 		private float _y;
 
+		private readonly float _kickAngle;
+		private readonly float _kickForce;
+
 		public DebugBallCreator()
 		{
 			_x = -1;
@@ -155,6 +158,14 @@ namespace VisualPinball.Unity.Game
 		{
 			_x = x;
 			_y = y;
+		}
+
+		public DebugBallCreator(float x, float y, float kickAngle, float kickForce)
+		{
+			_x = x;
+			_y = y;
+			_kickAngle = kickAngle;
+			_kickForce = kickForce;
 		}
 
 		public Vertex3D GetBallCreationPosition(Table table)
@@ -168,8 +179,11 @@ namespace VisualPinball.Unity.Game
 
 		public Vertex3D GetBallCreationVelocity(Table table)
 		{
-			// no velocity
-			return new Vertex3D(0f, 0, 0);
+			return new Vertex3D(
+				MathF.Sin(_kickAngle) * _kickForce,
+				-MathF.Cos(_kickAngle) * _kickForce,
+				0
+			);
 		}
 
 		public void OnBallCreated(PlayerPhysics physics, Ball ball)

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
@@ -126,7 +126,7 @@ namespace VisualPinball.Unity.Game
 			}
 
 			if (Input.GetKeyUp("n")) {
-				_player.CreateBall(new DebugBallCreator(376f, 1257f));
+				_player.CreateBall(new DebugBallCreator(200f, 1000f));
 				//_tableApi.Flippers["LeftFlipper"].RotateToEnd();
 			}
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/VisualPinballSimulationSystemGroup.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/VisualPinballSimulationSystemGroup.cs
@@ -32,6 +32,7 @@ namespace VisualPinball.Unity.Game
 		private UpdateVelocitiesSystemGroup _velocitiesSystemGroup;
 		private SimulateCycleSystemGroup _simulateCycleSystemGroup;
 		private BallRingCounterSystem _ballRingCounterSystem;
+		private UpdateAnimationsSystemGroup _updateAnimationsSystemGroup;
 		private TransformMeshesSystemGroup _transformMeshesSystemGroup;
 
 		private const TimingMode Timing = TimingMode.UnityTime;
@@ -47,12 +48,14 @@ namespace VisualPinball.Unity.Game
 			_velocitiesSystemGroup = World.GetOrCreateSystem<UpdateVelocitiesSystemGroup>();
 			_simulateCycleSystemGroup = World.GetOrCreateSystem<SimulateCycleSystemGroup>();
 			_ballRingCounterSystem = World.GetOrCreateSystem<BallRingCounterSystem>();
+			_updateAnimationsSystemGroup = World.GetOrCreateSystem<UpdateAnimationsSystemGroup>();
 			_transformMeshesSystemGroup = World.GetOrCreateSystem<TransformMeshesSystemGroup>();
 
 			_systemsToUpdate.Add(_createBallEntityCommandBufferSystem);
 			_systemsToUpdate.Add(_velocitiesSystemGroup);
 			_systemsToUpdate.Add(_simulateCycleSystemGroup);
 			_systemsToUpdate.Add(_ballRingCounterSystem);
+			_systemsToUpdate.Add(_updateAnimationsSystemGroup);
 			_systemsToUpdate.Add(_transformMeshesSystemGroup);
 			base.OnCreate();
 		}
@@ -90,6 +93,9 @@ namespace VisualPinball.Unity.Game
 			_ballRingCounterSystem.Update();
 
 			_currentPhysicsTime = _currentPhysicsFrameTime;
+
+			// update animations
+			_updateAnimationsSystemGroup.Update();
 
 			// transform all meshes
 			_transformMeshesSystemGroup.Update();

--- a/VisualPinball.Unity/VisualPinball.Unity/Import/VpxImporter.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Import/VpxImporter.cs
@@ -171,7 +171,7 @@ namespace VisualPinball.Unity.Import
 			// add unity component
 			MonoBehaviour ic = null;
 			switch (item) {
-				case Bumper bumper:			ic = obj.AddComponent<BumperBehavior>().SetData(bumper.Data); break;
+				case Bumper bumper:			ic = bumper.SetupGameObject(obj, rog); break;
 				case Flipper flipper:		ic = flipper.SetupGameObject(obj, rog); break;
 				case Gate gate:				ic = gate.SetupGameObject(obj, rog); break;
 				case HitTarget hitTarget:	ic = obj.AddComponent<HitTargetBehavior>().SetData(hitTarget.Data); break;

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/CircleCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/CircleCollider.cs
@@ -23,23 +23,23 @@ namespace VisualPinball.Unity.Physics.Collider
 
 		public ColliderType Type => _header.Type;
 
-		public static void Create(BlobBuilder builder, HitCircle src, ref BlobPtr<Collider> dest)
+		public static void Create(BlobBuilder builder, HitCircle src, ref BlobPtr<Collider> dest, ColliderType type = ColliderType.Circle)
 		{
 			ref var ptr = ref UnsafeUtilityEx.As<BlobPtr<Collider>, BlobPtr<CircleCollider>>(ref dest);
 			ref var collider = ref builder.Allocate(ref ptr);
-			collider.Init(src);
+			collider.Init(src, type);
 		}
 
-		public static CircleCollider Create(HitCircle src)
+		public static CircleCollider Create(HitCircle src, ColliderType type = ColliderType.Circle)
 		{
 			var collider = default(CircleCollider);
-			collider.Init(src);
+			collider.Init(src, type);
 			return collider;
 		}
 
-		private void Init(HitCircle src)
+		private void Init(HitCircle src, ColliderType type)
 		{
-			_header.Init(ColliderType.Circle, src);
+			_header.Init(type, src);
 
 			Center = src.Center.ToUnityFloat2();
 			Radius = src.Radius;

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
@@ -3,6 +3,7 @@ using NLog;
 using Unity.Entities;
 using Unity.Mathematics;
 using VisualPinball.Engine.Physics;
+using VisualPinball.Engine.VPT.Bumper;
 using VisualPinball.Engine.VPT.Flipper;
 using VisualPinball.Engine.VPT.Gate;
 using VisualPinball.Engine.VPT.Spinner;
@@ -40,6 +41,9 @@ namespace VisualPinball.Unity.Physics.Collider
 		public static void Create(BlobBuilder builder, HitObject src, ref BlobPtr<Collider> dest)
 		{
 			switch (src) {
+				case BumperHit bumperHit:
+					CircleCollider.Create(builder, bumperHit, ref dest, ColliderType.Bumper);
+					break;
 				case HitCircle hitCircle:
 					CircleCollider.Create(builder, hitCircle, ref dest);
 					break;
@@ -87,6 +91,7 @@ namespace VisualPinball.Unity.Physics.Collider
 		{
 			fixed (Collider* collider = &coll) {
 				switch (collider->Type) {
+					case ColliderType.Bumper:
 					case ColliderType.Circle:
 						return ((CircleCollider*)collider)->HitTest(ref collEvent, ref insideOf, in ball, dTime);
 					case ColliderType.Gate:

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/ColliderType.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/ColliderType.cs
@@ -3,6 +3,7 @@
 	public enum ColliderType
 	{
 		None,
+		Bumper,
 		Circle,
 		Flipper,
 		Gate,

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
@@ -3,10 +3,12 @@
 using System;
 using Unity.Entities;
 using Unity.Profiling;
+using Unity.Transforms;
 using UnityEngine;
 using VisualPinball.Unity.Physics.Collider;
 using VisualPinball.Unity.Physics.SystemGroup;
 using VisualPinball.Unity.VPT.Ball;
+using VisualPinball.Unity.VPT.Bumper;
 using VisualPinball.Unity.VPT.Flipper;
 using VisualPinball.Unity.VPT.Gate;
 using VisualPinball.Unity.VPT.Spinner;
@@ -63,6 +65,15 @@ namespace VisualPinball.Unity.Physics.Collision
 					fixed (Collider.Collider* collider = &coll) {
 
 						switch (coll.Type) {
+							case ColliderType.Bumper:
+								var bumperStaticData = GetComponent<BumperStaticData>(coll.Entity);
+								var ringData = GetComponent<BumperRingAnimationData>(bumperStaticData.RingEntity);
+								var skirtData = GetComponent<BumperSkirtAnimationData>(bumperStaticData.SkirtEntity);
+								BumperCollider.Collide(ref ballData, ref collEvent, ref ringData, ref skirtData, in coll, bumperStaticData, ref random);
+								SetComponent(bumperStaticData.RingEntity, ringData);
+								SetComponent(bumperStaticData.SkirtEntity, skirtData);
+								break;
+
 							case ColliderType.Flipper:
 								var flipperVelocityData = GetComponent<FlipperVelocityData>(coll.Entity);
 								var flipperMovementData = GetComponent<FlipperMovementData>(coll.Entity);

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/SystemGroup/UpdateAnimationsSystemGroup.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/SystemGroup/UpdateAnimationsSystemGroup.cs
@@ -1,0 +1,10 @@
+﻿using Unity.Entities;
+
+namespace VisualPinball.Unity.Physics.SystemGroup
+{
+	[DisableAutoCreation]
+	public class UpdateAnimationsSystemGroup : ComponentSystemGroup
+	{
+
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/SystemGroup/UpdateAnimationsSystemGroup.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/SystemGroup/UpdateAnimationsSystemGroup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6d9ca61b61c9d04b857eb9dc132882a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperBehavior.cs
@@ -4,6 +4,7 @@
 // ReSharper disable MemberCanBePrivate.Global
 #endregion
 
+using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Bumper;
 using VisualPinball.Unity.Extensions;
@@ -11,9 +12,19 @@ using VisualPinball.Unity.Extensions;
 namespace VisualPinball.Unity.VPT.Bumper
 {
 	[AddComponentMenu("Visual Pinball/Bumper")]
-	public class BumperBehavior : ItemBehavior<Engine.VPT.Bumper.Bumper, BumperData>
+	public class BumperBehavior : ItemBehavior<Engine.VPT.Bumper.Bumper, BumperData>, IConvertGameObjectToEntity
 	{
 		protected override string[] Children => new []{"Base", "Cap", "Ring", "Skirt"};
+
+		public void Convert(Entity entity, EntityManager dstManager, GameObjectConversionSystem conversionSystem)
+		{
+			Convert(entity, dstManager);
+			dstManager.AddComponentData(entity, new BumperStaticData {
+				Force = data.Force,
+				HitEvent = data.HitEvent,
+				Threshold = data.Threshold
+			});
+		}
 
 		protected override Engine.VPT.Bumper.Bumper GetItem()
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperCollider.cs
@@ -1,0 +1,34 @@
+﻿using Unity.Mathematics;
+using VisualPinball.Unity.Physics.Collider;
+using VisualPinball.Unity.Physics.Collision;
+using VisualPinball.Unity.VPT.Ball;
+
+namespace VisualPinball.Unity.VPT.Bumper
+{
+	public static class BumperCollider
+	{
+		public static void Collide(ref BallData ball, ref CollisionEventData collEvent,
+			ref BumperRingAnimationData ringData, ref BumperSkirtAnimationData skirtData,
+			in Collider collider, in BumperStaticData data, ref Random random)
+		{
+			// todo
+			// if (!m_enabled) return;
+
+			var dot = math.dot(collEvent.HitNormal, ball.Velocity); // needs to be computed before Collide3DWall()!
+			var material = collider.Material;
+			BallCollider.Collide3DWall(ref ball, in material, in collEvent, in collEvent.HitNormal, ref random); // reflect ball from wall
+
+			if (data.HitEvent && dot <= -data.Threshold) { // if velocity greater than threshold level
+
+				ball.Velocity += collEvent.HitNormal * data.Force; // add a chunk of velocity to drive ball away
+
+				ringData.IsHit = true;
+				skirtData.IsHit = true;
+				skirtData.BallPosition = ball.Position;
+
+				// todo event
+				// m_pbumper->FireGroupEvent(DISPID_HitEvents_Hit);
+			}
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperCollider.cs
@@ -23,7 +23,7 @@ namespace VisualPinball.Unity.VPT.Bumper
 				ball.Velocity += collEvent.HitNormal * data.Force; // add a chunk of velocity to drive ball away
 
 				ringData.IsHit = true;
-				skirtData.IsHit = true;
+				skirtData.HitEvent = true;
 				skirtData.BallPosition = ball.Position;
 
 				// todo event

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperCollider.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperCollider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b80334580435cdb45be6b9087681904e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperExtensions.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperExtensions.cs
@@ -1,0 +1,23 @@
+﻿using Unity.Entities;
+using UnityEngine;
+using VisualPinball.Engine.Game;
+
+namespace VisualPinball.Unity.VPT.Bumper
+{
+	public static class BumperExtensions
+	{
+		public static BumperBehavior SetupGameObject(this Engine.VPT.Bumper.Bumper bumper, GameObject obj, RenderObjectGroup rog)
+		{
+			var ic = obj.AddComponent<BumperBehavior>().SetData(bumper.Data);
+			obj.AddComponent<ConvertToEntity>();
+
+			var ring = obj.transform.Find("Ring").gameObject;
+			var skirt = obj.transform.Find("Skirt").gameObject;
+
+			ring.AddComponent<BumperRingBehavior>();
+			skirt.AddComponent<BumperSkirtBehavior>();
+
+			return ic as BumperBehavior;
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperExtensions.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3110d96b579ac27498e53299a839f489
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationData.cs
@@ -1,0 +1,9 @@
+﻿using Unity.Entities;
+
+namespace VisualPinball.Unity.VPT.Bumper
+{
+	public struct BumperRingAnimationData : IComponentData
+	{
+		public bool IsHit;
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationData.cs
@@ -5,5 +5,12 @@ namespace VisualPinball.Unity.VPT.Bumper
 	public struct BumperRingAnimationData : IComponentData
 	{
 		public bool IsHit;
+		public float DropOffset;
+		public float HeightScale;
+		public float ScaleZ;
+		public bool DoAnimate;
+		public bool AnimateDown;
+		public float Speed;
+		public float Offset;
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationData.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f247ceaae40d7224281f631a0fb7901c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationSystem.cs
@@ -1,6 +1,5 @@
 ﻿using Unity.Entities;
 using Unity.Profiling;
-using VisualPinball.Unity.Game;
 using VisualPinball.Unity.Physics.SystemGroup;
 
 namespace VisualPinball.Unity.VPT.Bumper
@@ -8,20 +7,20 @@ namespace VisualPinball.Unity.VPT.Bumper
 	[UpdateInGroup(typeof(UpdateAnimationsSystemGroup))]
 	public class BumperRingAnimationSystem : SystemBase
 	{
-		private VisualPinballSimulationSystemGroup _visualPinballSimulationSystemGroup;
 		private static readonly ProfilerMarker PerfMarker = new ProfilerMarker("BumperRingAnimationSystem");
-
-		protected override void OnCreate()
-		{
-			_visualPinballSimulationSystemGroup = World.GetOrCreateSystem<VisualPinballSimulationSystemGroup>();
-		}
 
 		protected override void OnUpdate()
 		{
 			var dTime = Time.DeltaTime * 1000;
+			var marker = PerfMarker;
+
 			Entities
 				.WithName("BumperRingAnimationJob")
 				.ForEach((ref BumperRingAnimationData data) => {
+
+					// todo visibility - skip if invisible
+
+					marker.Begin();
 
 					var limit = data.DropOffset + data.HeightScale * 0.5f * data.ScaleZ;
 					if (data.IsHit) {
@@ -47,6 +46,9 @@ namespace VisualPinball.Unity.VPT.Bumper
 							}
 						}
 					}
+
+					marker.End();
+
 				}).Run();
 		}
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationSystem.cs
@@ -1,0 +1,53 @@
+﻿using Unity.Entities;
+using Unity.Profiling;
+using VisualPinball.Unity.Game;
+using VisualPinball.Unity.Physics.SystemGroup;
+
+namespace VisualPinball.Unity.VPT.Bumper
+{
+	[UpdateInGroup(typeof(UpdateAnimationsSystemGroup))]
+	public class BumperRingAnimationSystem : SystemBase
+	{
+		private VisualPinballSimulationSystemGroup _visualPinballSimulationSystemGroup;
+		private static readonly ProfilerMarker PerfMarker = new ProfilerMarker("BumperRingAnimationSystem");
+
+		protected override void OnCreate()
+		{
+			_visualPinballSimulationSystemGroup = World.GetOrCreateSystem<VisualPinballSimulationSystemGroup>();
+		}
+
+		protected override void OnUpdate()
+		{
+			var dTime = Time.DeltaTime * 1000;
+			Entities
+				.WithName("BumperRingAnimationJob")
+				.ForEach((ref BumperRingAnimationData data) => {
+
+					var limit = data.DropOffset + data.HeightScale * 0.5f * data.ScaleZ;
+					if (data.IsHit) {
+						data.DoAnimate = true;
+						data.AnimateDown = true;
+						data.IsHit = false;
+					}
+					if (data.DoAnimate) {
+						var step = data.Speed * data.ScaleZ;
+						if (data.AnimateDown) {
+							step = -step;
+						}
+						data.Offset += step * dTime;
+						if (data.AnimateDown) {
+							if (data.Offset <= -limit) {
+								data.Offset = -limit;
+								data.AnimateDown = false;
+							}
+						} else {
+							if (data.Offset >= 0.0f) {
+								data.Offset = 0.0f;
+								data.DoAnimate = false;
+							}
+						}
+					}
+				}).Run();
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationSystem.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4d0d69dcd6b5c0408ca34cc6e1d77db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingBehavior.cs
@@ -1,5 +1,6 @@
 ﻿using Unity.Entities;
 using UnityEngine;
+using VisualPinball.Unity.VPT.Table;
 
 namespace VisualPinball.Unity.VPT.Bumper
 {
@@ -7,6 +8,7 @@ namespace VisualPinball.Unity.VPT.Bumper
 	{
 		public void Convert(Entity entity, EntityManager dstManager, GameObjectConversionSystem conversionSystem)
 		{
+			var table = gameObject.GetComponentInParent<TableBehavior>().Item;
 			var bumper = transform.parent.gameObject.GetComponent<BumperBehavior>().Item;
 			var bumperEntity = new Entity {Index = bumper.Index, Version = bumper.Version};
 
@@ -17,7 +19,18 @@ namespace VisualPinball.Unity.VPT.Bumper
 
 			// add ring data
 			dstManager.AddComponentData(entity, new BumperRingAnimationData {
-				IsHit = false
+
+				// dynamic
+				IsHit = false,
+				Offset = 0,
+				AnimateDown = false,
+				DoAnimate = false,
+
+				// static
+				DropOffset = bumper.Data.RingDropOffset,
+				HeightScale = bumper.Data.HeightScale,
+				Speed = bumper.Data.RingSpeed,
+				ScaleZ = table.GetScaleZ()
 			});
 		}
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingBehavior.cs
@@ -1,0 +1,24 @@
+﻿using Unity.Entities;
+using UnityEngine;
+
+namespace VisualPinball.Unity.VPT.Bumper
+{
+	public class BumperRingBehavior : MonoBehaviour, IConvertGameObjectToEntity
+	{
+		public void Convert(Entity entity, EntityManager dstManager, GameObjectConversionSystem conversionSystem)
+		{
+			var bumper = transform.parent.gameObject.GetComponent<BumperBehavior>().Item;
+			var bumperEntity = new Entity {Index = bumper.Index, Version = bumper.Version};
+
+			// update parent
+			var bumperStaticData = dstManager.GetComponentData<BumperStaticData>(bumperEntity);
+			bumperStaticData.RingEntity = entity;
+			dstManager.SetComponentData(bumperEntity, bumperStaticData);
+
+			// add ring data
+			dstManager.AddComponentData(entity, new BumperRingAnimationData {
+				IsHit = false
+			});
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingBehavior.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98f861677a4442f41b00b26f63d3053e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingMovementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingMovementSystem.cs
@@ -1,0 +1,27 @@
+﻿using Unity.Entities;
+using Unity.Profiling;
+using Unity.Transforms;
+using VisualPinball.Unity.Physics.SystemGroup;
+
+namespace VisualPinball.Unity.VPT.Bumper
+{
+	[UpdateInGroup(typeof(TransformMeshesSystemGroup))]
+	public class BumperRingMovementSystem : SystemBase
+	{
+		private static readonly ProfilerMarker PerfMarker = new ProfilerMarker("BumperRingMovementSystem");
+
+		protected override void OnUpdate()
+		{
+			var marker = PerfMarker;
+			Entities.WithName("BumperRingMovementJob").ForEach((ref Translation trans, in BumperRingAnimationData data) => {
+
+				marker.Begin();
+
+				trans.Value.z = data.Offset;
+
+				marker.End();
+
+			}).Run();
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingMovementSystem.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingMovementSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2fe2aa90c1a61424dbb3032607d2d277
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationData.cs
@@ -1,0 +1,11 @@
+﻿using Unity.Entities;
+using Unity.Mathematics;
+
+namespace VisualPinball.Unity.VPT.Bumper
+{
+	public struct BumperSkirtAnimationData : IComponentData
+	{
+		public bool IsHit;
+		public float3 BallPosition;
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationData.cs
@@ -6,7 +6,7 @@ namespace VisualPinball.Unity.VPT.Bumper
 	public struct BumperSkirtAnimationData : IComponentData
 	{
 		// dynamic
-		public bool IsHit;
+		public bool HitEvent;
 		public float3 BallPosition;
 		public bool EnableAnimation;
 		public float AnimationCounter;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationData.cs
@@ -5,7 +5,17 @@ namespace VisualPinball.Unity.VPT.Bumper
 {
 	public struct BumperSkirtAnimationData : IComponentData
 	{
+		// dynamic
 		public bool IsHit;
 		public float3 BallPosition;
+		public bool EnableAnimation;
+		public float AnimationCounter;
+		public bool DoAnimate;
+		public bool DoUpdate;
+		public float2 Rotation;
+
+		// static
+		public float2 Center;
+
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationData.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 763cf045db0d0444b9ba0b9c074711e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationSystem.cs
@@ -1,0 +1,78 @@
+﻿using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Profiling;
+using VisualPinball.Unity.Physics.SystemGroup;
+
+namespace VisualPinball.Unity.VPT.Bumper
+{
+	[UpdateInGroup(typeof(UpdateAnimationsSystemGroup))]
+	public class BumperSkirtAnimationSystem : SystemBase
+	{
+		private static readonly ProfilerMarker PerfMarker = new ProfilerMarker("BumperSkirtAnimationSystem");
+
+		protected override void OnUpdate()
+		{
+			var dTime = Time.DeltaTime * 1000;
+			var marker = PerfMarker;
+
+			Entities
+				.WithName("BumperSkirtAnimationJob")
+				.ForEach((ref BumperSkirtAnimationData data) => {
+
+					// todo visibility - skip if invisible
+
+					marker.Begin();
+
+					if (data.EnableAnimation) {
+						if (data.IsHit) {
+							data.DoAnimate = true;
+							UpdateSkirt(ref data);
+							data.AnimationCounter = 0.0f;
+						}
+						if (data.DoAnimate) {
+							data.AnimationCounter += dTime;
+							if (data.AnimationCounter > 160.0f) {
+								data.DoAnimate = false;
+								ResetSkirt(ref data);
+							}
+						}
+					} else if (data.DoUpdate) { // do a single update if the animation was turned off via script
+						data.DoUpdate = false;
+						ResetSkirt(ref data);
+					}
+
+					marker.End();
+
+				}).Run();
+		}
+
+		private static void UpdateSkirt(ref BumperSkirtAnimationData data)
+		{
+			const float skirtTilt = 5.0f;
+
+			var hitX = data.BallPosition.x;
+			var hitY = data.BallPosition.y;
+			var dy = math.abs(hitY - data.Center.y);
+			if (dy == 0.0f) {
+				dy = 0.000001f;
+			}
+
+			var dx = math.abs(hitX - data.Center.x);
+			var skirtA = math.atan(dx / dy);
+			data.Rotation.x = math.cos(skirtA) * skirtTilt;
+			data.Rotation.y = math.sin(skirtA) * skirtTilt;
+			if (data.Center.y < hitY) {
+				data.Rotation.x = -data.Rotation.x;
+			}
+
+			if (data.Center.x > hitX) {
+				data.Rotation.y = -data.Rotation.y;
+			}
+		}
+
+		private static void ResetSkirt(ref BumperSkirtAnimationData data)
+		{
+			data.Rotation = new float2(0, 0);
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationSystem.cs
@@ -23,8 +23,11 @@ namespace VisualPinball.Unity.VPT.Bumper
 
 					marker.Begin();
 
+					var isHit = data.HitEvent;
+					data.HitEvent = false;
+
 					if (data.EnableAnimation) {
-						if (data.IsHit) {
+						if (isHit) {
 							data.DoAnimate = true;
 							UpdateSkirt(ref data);
 							data.AnimationCounter = 0.0f;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationSystem.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 677a074f65655e34480323f7ce6b956e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtBehavior.cs
@@ -1,0 +1,26 @@
+﻿using Unity.Entities;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace VisualPinball.Unity.VPT.Bumper
+{
+	public class BumperSkirtBehavior : MonoBehaviour, IConvertGameObjectToEntity
+	{
+		public void Convert(Entity entity, EntityManager dstManager, GameObjectConversionSystem conversionSystem)
+		{
+			var bumper = transform.parent.gameObject.GetComponent<BumperBehavior>().Item;
+			var bumperEntity = new Entity {Index = bumper.Index, Version = bumper.Version};
+
+			// update parent
+			var bumperStaticData = dstManager.GetComponentData<BumperStaticData>(bumperEntity);
+			bumperStaticData.SkirtEntity = entity;
+			dstManager.SetComponentData(bumperEntity, bumperStaticData);
+
+			// add ring data
+			dstManager.AddComponentData(entity, new BumperSkirtAnimationData {
+				IsHit = false,
+				BallPosition = default
+			});
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtBehavior.cs
@@ -19,13 +19,13 @@ namespace VisualPinball.Unity.VPT.Bumper
 
 			// add ring data
 			dstManager.AddComponentData(entity, new BumperSkirtAnimationData {
-				IsHit = false,
 				BallPosition = default,
 				AnimationCounter = 0f,
 				DoAnimate = false,
 				DoUpdate = false,
-				EnableAnimation = false,
+				EnableAnimation = true,
 				Rotation = new float2(0, 0),
+				HitEvent = bumper.Data.HitEvent,
 				Center = bumper.Data.Center.ToUnityFloat2()
 			});
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtBehavior.cs
@@ -1,6 +1,7 @@
 ﻿using Unity.Entities;
 using Unity.Mathematics;
 using UnityEngine;
+using VisualPinball.Unity.Extensions;
 
 namespace VisualPinball.Unity.VPT.Bumper
 {
@@ -19,7 +20,13 @@ namespace VisualPinball.Unity.VPT.Bumper
 			// add ring data
 			dstManager.AddComponentData(entity, new BumperSkirtAnimationData {
 				IsHit = false,
-				BallPosition = default
+				BallPosition = default,
+				AnimationCounter = 0f,
+				DoAnimate = false,
+				DoUpdate = false,
+				EnableAnimation = false,
+				Rotation = new float2(0, 0),
+				Center = bumper.Data.Center.ToUnityFloat2()
 			});
 		}
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtBehavior.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b7b5a04064bbc584d8ac59bc6da0e0cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtMovementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtMovementSystem.cs
@@ -1,0 +1,28 @@
+﻿using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Profiling;
+using Unity.Transforms;
+using VisualPinball.Unity.Physics.SystemGroup;
+
+namespace VisualPinball.Unity.VPT.Bumper
+{
+	[UpdateInGroup(typeof(TransformMeshesSystemGroup))]
+	public class BumperSkirtMovementSystem : SystemBase
+	{
+		private static readonly ProfilerMarker PerfMarker = new ProfilerMarker("BumperSkirtMovementSystem");
+
+		protected override void OnUpdate()
+		{
+			var marker = PerfMarker;
+			Entities.WithName("BumperSkirtMovementJob").ForEach((ref Rotation rot, in BumperSkirtAnimationData data) => {
+
+				marker.Begin();
+
+				rot.Value = quaternion.Euler(data.Rotation.x, data.Rotation.y, 0f);
+
+				marker.End();
+
+			}).Run();
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtMovementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtMovementSystem.cs
@@ -18,7 +18,7 @@ namespace VisualPinball.Unity.VPT.Bumper
 
 				marker.Begin();
 
-				rot.Value = quaternion.Euler(data.Rotation.x, data.Rotation.y, 0f);
+				rot.Value = quaternion.EulerXYZ(math.radians(data.Rotation.x), math.radians(data.Rotation.y), 0f);
 
 				marker.End();
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtMovementSystem.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtMovementSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3890dfd771cce314a8949d8cc9bc5cf7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperStaticData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperStaticData.cs
@@ -1,0 +1,13 @@
+﻿using Unity.Entities;
+
+namespace VisualPinball.Unity.VPT.Bumper
+{
+	public struct BumperStaticData : IComponentData
+	{
+		public float Force;
+		public float Threshold;
+		public bool HitEvent;
+		public Entity RingEntity;
+		public Entity SkirtEntity;
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperStaticData.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperStaticData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e0c88d47ab1257499977c31f15fb37b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VisualPinball.Unity.csproj
+++ b/VisualPinball.Unity/VisualPinball.Unity/VisualPinball.Unity.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Physics\SystemGroup\SimulateCycleSystemGroup.cs" />
     <Compile Include="Physics\SystemGroup\CreateBallEntityCommandBufferSystem.cs" />
     <Compile Include="Physics\SystemGroup\TransformMeshesSystemGroup.cs" />
+    <Compile Include="Physics\SystemGroup\UpdateAnimationsSystemGroup.cs" />
     <Compile Include="Physics\SystemGroup\UpdateDisplacementSystemGroup.cs" />
     <Compile Include="Physics\SystemGroup\UpdateVelocitiesSystemGroup.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -170,10 +171,12 @@
     <Compile Include="VPT\Bumper\BumperCollider.cs" />
     <Compile Include="VPT\Bumper\BumperExtensions.cs" />
     <Compile Include="VPT\Bumper\BumperRingAnimationData.cs" />
+    <Compile Include="VPT\Bumper\BumperRingAnimationSystem.cs" />
     <Compile Include="VPT\Bumper\BumperRingBehavior.cs" />
     <Compile Include="VPT\Bumper\BumperSkirtAnimationData.cs" />
     <Compile Include="VPT\Bumper\BumperSkirtBehavior.cs" />
     <Compile Include="VPT\Bumper\BumperStaticData.cs" />
+    <Compile Include="VPT\Bumper\BumperRingMovementSystem.cs" />
     <Compile Include="VPT\Flipper\FlipperApi.cs" />
     <Compile Include="VPT\Flipper\FlipperCollider.cs" />
     <Compile Include="VPT\Flipper\FlipperDisplacementSystem.cs" />

--- a/VisualPinball.Unity/VisualPinball.Unity/VisualPinball.Unity.csproj
+++ b/VisualPinball.Unity/VisualPinball.Unity/VisualPinball.Unity.csproj
@@ -167,6 +167,13 @@
     <Compile Include="VPT\Ball\BallDisplacementSystem.cs" />
     <Compile Include="VPT\Ball\BallInsideOfBufferElement.cs" />
     <Compile Include="VPT\Bumper\BumperBehavior.cs" />
+    <Compile Include="VPT\Bumper\BumperCollider.cs" />
+    <Compile Include="VPT\Bumper\BumperExtensions.cs" />
+    <Compile Include="VPT\Bumper\BumperRingAnimationData.cs" />
+    <Compile Include="VPT\Bumper\BumperRingBehavior.cs" />
+    <Compile Include="VPT\Bumper\BumperSkirtAnimationData.cs" />
+    <Compile Include="VPT\Bumper\BumperSkirtBehavior.cs" />
+    <Compile Include="VPT\Bumper\BumperStaticData.cs" />
     <Compile Include="VPT\Flipper\FlipperApi.cs" />
     <Compile Include="VPT\Flipper\FlipperCollider.cs" />
     <Compile Include="VPT\Flipper\FlipperDisplacementSystem.cs" />

--- a/VisualPinball.Unity/VisualPinball.Unity/VisualPinball.Unity.csproj
+++ b/VisualPinball.Unity/VisualPinball.Unity/VisualPinball.Unity.csproj
@@ -174,7 +174,9 @@
     <Compile Include="VPT\Bumper\BumperRingAnimationSystem.cs" />
     <Compile Include="VPT\Bumper\BumperRingBehavior.cs" />
     <Compile Include="VPT\Bumper\BumperSkirtAnimationData.cs" />
+    <Compile Include="VPT\Bumper\BumperSkirtAnimationSystem.cs" />
     <Compile Include="VPT\Bumper\BumperSkirtBehavior.cs" />
+    <Compile Include="VPT\Bumper\BumperSkirtMovementSystem.cs" />
     <Compile Include="VPT\Bumper\BumperStaticData.cs" />
     <Compile Include="VPT\Bumper\BumperRingMovementSystem.cs" />
     <Compile Include="VPT\Flipper\FlipperApi.cs" />


### PR DESCRIPTION
This PR adds bumper collisions as well as animations of the bumper ring and socket (a.k.a "skirt") and closes #28 .

As a collider we re-use `CircleCollider` for broad- and nearphase and just a static method in `BumperCollider` for resolving.

For the animation we have a few new things. First of all the animation is not physics-based, so it's updated just once a frame. For this we now have a `UpdateAnimationsSystemGroup` that is run just before updating the meshes.

Secondly, we need to animate two meshes. In the past (i.e. spinner and gate), we got away by just putting all the data components on the moving child, but here we have two moving children (ring and skirt).

What we do now is putting the animation-relevant data on the children, and the collision data on the parent. The parent also contains the entities of the children, so we easily fetch their data, update it in the collision, and later `Entities.ForEach` just on the children to calculate the new transformation.

[Here's a video](https://www.youtube.com/watch?v=veadt9vaTRM).
