### PR TITLE
Updated fixture tests to be cross platform.

### DIFF
--- a/.github/workflows/VisualPinball.Engine.yml
+++ b/.github/workflows/VisualPinball.Engine.yml
@@ -1,0 +1,15 @@
+on: [push, pull_request]
+
+jobs:
+    vpe-win-x64:
+      runs-on: windows-latest
+      steps:
+        - uses: actions/checkout@v2
+        - uses: nuget/setup-nuget@v1
+        - name: Build
+          run: |
+             nuget restore
+             dotnet build -c Release
+        - name: Test
+          run: |
+             .packages/xunit.runner.console.2.1.0/tools/xunit.console.exe VisualPinball.Engine.Test/.build/Release/VisualPinball.Engine.Test.dll

--- a/VisualPinball.Engine.Test/Test/Fixtures.cs
+++ b/VisualPinball.Engine.Test/Test/Fixtures.cs
@@ -1,62 +1,69 @@
+using System.IO;
+
 namespace VisualPinball.Engine.Test.Test
 {
+	public static class FixturesPath
+	{
+		public static readonly string Base = $"..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}Fixtures~{Path.DirectorySeparatorChar}";
+	}
+
 	public static class VpxPath
 	{
-		public const string Bumper = @"..\..\Fixtures~\BumperTest.vpx";
-		public const string Collection = @"..\..\Fixtures~\CollectionTest.vpx";
-		public const string Decal = @"..\..\Fixtures~\DecalTest.vpx";
-		public const string DispReel = @"..\..\Fixtures~\DispReelTest.vpx";
-		public const string Flasher = @"..\..\Fixtures~\FlasherTest.vpx";
-		public const string Flipper = @"..\..\Fixtures~\FlipperTest.vpx";
-		public const string Gate = @"..\..\Fixtures~\GateTest.vpx";
-		public const string HitTarget = @"..\..\Fixtures~\HitTargetTest.vpx";
-		public const string Kicker = @"..\..\Fixtures~\KickerTest.vpx";
-		public const string Light = @"..\..\Fixtures~\LightTest.vpx";
-		public const string LightSeq = @"..\..\Fixtures~\LightSeqTest.vpx";
-		public const string Material = @"..\..\Fixtures~\MaterialTest.vpx";
-		public const string MaterialTexture = @"..\..\Fixtures~\MaterialTextureTest.vpx";
-		public const string Plunger = @"..\..\Fixtures~\PlungerTest.vpx";
-		public const string Primitive = @"..\..\Fixtures~\PrimitiveTest.vpx";
-		public const string PrimitiveCompressed = @"..\..\Fixtures~\PrimitiveCompressed.vpx";
-		public const string Ramp = @"..\..\Fixtures~\RampTest.vpx";
-		public const string Rubber = @"..\..\Fixtures~\RubberTest.vpx";
-		public const string Sound = @"..\..\Fixtures~\SoundTest.vpx";
-		public const string Spinner = @"..\..\Fixtures~\SpinnerTest.vpx";
-		public const string Surface = @"..\..\Fixtures~\SurfaceTest.vpx";
-		public const string Table = @"..\..\Fixtures~\TableTest.vpx";
-		public const string TableChecksum = @"..\..\Fixtures~\TableChecksumTest.vpx";
-		public const string TextBox = @"..\..\Fixtures~\TextboxTest.vpx";
-		public const string Texture = @"..\..\Fixtures~\TextureTest.vpx";
-		public const string Timer = @"..\..\Fixtures~\TimerTest.vpx";
-		public const string Trigger = @"..\..\Fixtures~\TriggerTest.vpx";
+		public static readonly string Bumper = FixturesPath.Base + "BumperTest.vpx";
+		public static readonly string Collection = FixturesPath.Base + "CollectionTest.vpx";
+		public static readonly string Decal = FixturesPath.Base + "DecalTest.vpx";
+		public static readonly string DispReel = FixturesPath.Base + "DispReelTest.vpx";
+		public static readonly string Flasher = FixturesPath.Base + "FlasherTest.vpx";
+		public static readonly string Flipper = FixturesPath.Base + "FlipperTest.vpx";
+		public static readonly string Gate = FixturesPath.Base + "GateTest.vpx";
+		public static readonly string HitTarget = FixturesPath.Base + "HitTargetTest.vpx";
+		public static readonly string Kicker = FixturesPath.Base + "KickerTest.vpx";
+		public static readonly string Light = FixturesPath.Base + "LightTest.vpx";
+		public static readonly string LightSeq = FixturesPath.Base + "LightSeqTest.vpx";
+		public static readonly string Material = FixturesPath.Base + "MaterialTest.vpx";
+		public static readonly string MaterialTexture = FixturesPath.Base + "MaterialTextureTest.vpx";
+		public static readonly string Plunger = FixturesPath.Base + "PlungerTest.vpx";
+		public static readonly string Primitive = FixturesPath.Base + "PrimitiveTest.vpx";
+		public static readonly string PrimitiveCompressed = FixturesPath.Base + "PrimitiveCompressed.vpx";
+		public static readonly string Ramp = FixturesPath.Base + "RampTest.vpx";
+		public static readonly string Rubber = FixturesPath.Base + "RubberTest.vpx";
+		public static readonly string Sound = FixturesPath.Base + "SoundTest.vpx";
+		public static readonly string Spinner = FixturesPath.Base + "SpinnerTest.vpx";
+		public static readonly string Surface = FixturesPath.Base + "SurfaceTest.vpx";
+		public static readonly string Table = FixturesPath.Base + "TableTest.vpx";
+		public static readonly string TableChecksum = FixturesPath.Base + "TableChecksumTest.vpx";
+		public static readonly string TextBox = FixturesPath.Base + "TextboxTest.vpx";
+		public static readonly string Texture = FixturesPath.Base + "TextureTest.vpx";
+		public static readonly string Timer = FixturesPath.Base + "TimerTest.vpx";
+		public static readonly string Trigger = FixturesPath.Base + "TriggerTest.vpx";
 	}
 
 	public static class ObjPath
 	{
-		public const string Bumper = @"..\..\Fixtures~\BumperTest.obj";
-		public const string Flipper = @"..\..\Fixtures~\FlipperTest.obj";
-		public const string Gate = @"..\..\Fixtures~\GateTest.obj";
-		public const string HitTarget = @"..\..\Fixtures~\HitTargetTest.obj";
-		public const string Kicker = @"..\..\Fixtures~\KickerTest.obj";
-		public const string Primitive = @"..\..\Fixtures~\PrimitiveTest.obj";
-		public const string PrimitiveCompressed = @"..\..\Fixtures~\PrimitiveCompressed.obj";
-		public const string Ramp = @"..\..\Fixtures~\RampTest.obj";
-		public const string Rubber = @"..\..\Fixtures~\RubberTest.obj";
-		public const string Spinner = @"..\..\Fixtures~\SpinnerTest.obj";
-		public const string Surface = @"..\..\Fixtures~\SurfaceTest.obj";
-		public const string Table = @"..\..\Fixtures~\TableTest.obj";
-		public const string Trigger = @"..\..\Fixtures~\TriggerTest.obj";
+		public static readonly string Bumper = FixturesPath.Base + "BumperTest.obj";
+		public static readonly string Flipper = FixturesPath.Base + "FlipperTest.obj";
+		public static readonly string Gate = FixturesPath.Base + "GateTest.obj";
+		public static readonly string HitTarget = FixturesPath.Base + "HitTargetTest.obj";
+		public static readonly string Kicker = FixturesPath.Base + "KickerTest.obj";
+		public static readonly string Primitive = FixturesPath.Base + "PrimitiveTest.obj";
+		public static readonly string PrimitiveCompressed = FixturesPath.Base + "PrimitiveCompressed.obj";
+		public static readonly string Ramp = FixturesPath.Base + "RampTest.obj";
+		public static readonly string Rubber = FixturesPath.Base + "RubberTest.obj";
+		public static readonly string Spinner = FixturesPath.Base + "SpinnerTest.obj";
+		public static readonly string Surface = FixturesPath.Base + "SurfaceTest.obj";
+		public static readonly string Table = FixturesPath.Base + "TableTest.obj";
+		public static readonly string Trigger = FixturesPath.Base + "TriggerTest.obj";
 	}
 
 	public static class TexturePath
 	{
-		public const string Exr = @"..\..\Fixtures~\comp_piz.exr";
-		public const string Bmp = @"..\..\Fixtures~\test_pattern.bmp";
-		public const string BmpArgb = @"..\..\Fixtures~\test_pattern_argb.bmp";
-		public const string BmpXrgb = @"..\..\Fixtures~\test_pattern_xrgb.bmp";
-		public const string Jpg = @"..\..\Fixtures~\test_pattern.jpg";
-		public const string Png = @"..\..\Fixtures~\test_pattern.png";
-		public const string PngTransparent = @"..\..\Fixtures~\test_pattern_transparent.png";
-		public const string Hdr = @"..\..\Fixtures~\test_pattern_hdr.hdr";
+		public static readonly string Exr = FixturesPath.Base + "comp_piz.exr";
+		public static readonly string Bmp = FixturesPath.Base + "test_pattern.bmp";
+		public static readonly string BmpArgb = FixturesPath.Base + "test_pattern_argb.bmp";
+		public static readonly string BmpXrgb = FixturesPath.Base + "test_pattern_xrgb.bmp";
+		public static readonly string Jpg = FixturesPath.Base + "test_pattern.jpg";
+		public static readonly string Png = FixturesPath.Base + "test_pattern.png";
+		public static readonly string PngTransparent = FixturesPath.Base + "test_pattern_transparent.png";
+		public static readonly string Hdr = FixturesPath.Base + "test_pattern_hdr.hdr";
 	}
 }


### PR DESCRIPTION
This PR allows the `VisualPinball.Engine.Test` `xUnit` test cases to run on both Windows and MacOS.

Since `Path.DirectorySeparatorChar` is a `static readonly` we needed to change from `public const` to `public static readonly`.

This PR also adds a basic github workflow, that matches AppVeyor, and shows that the test cases continue to pass on Windows.

