### PR TITLE
Update fixture tests to run on MacOS

### DIFF
--- a/VisualPinball.Engine.Test/Test/Fixtures.cs
+++ b/VisualPinball.Engine.Test/Test/Fixtures.cs
@@ -74,13 +74,12 @@ namespace VisualPinball.Engine.Test.Test
 
 		private static string GetTestPath()
 		{
-			var codeBase = Assembly.GetExecutingAssembly().CodeBase;
+			var codeBase = new System.Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath;
 			return codeBase.Contains("/Library/ScriptAssemblies/")
 				? Path.GetFullPath("Packages/org.visualpinball.engine.unity/VisualPinball.Engine.Test")
 				: Path.GetFullPath(
 					Path.Combine(
-						Path.GetDirectoryName(Assembly.GetExecutingAssembly().CodeBase)
-							.Replace(@"file:" + Path.DirectorySeparatorChar, string.Empty),
+						Path.GetDirectoryName(codeBase),
 						"..",
 						".."
 					)


### PR DESCRIPTION
This fixes `GetTestPath()` to return the correct folder on MacOS and also Windows.

MacOS was returning: 

`file:///Users/jmillard/_/VisualPinball.Engine/VisualPinball.Engine.Test/.build/Debug`

Windows was returning:

`file://\C:\dev\VisualPinball.Engine\VisualPinball.Engine.Test\.build\Debug`

`System.Uri(<path>).LocalPath` returns the correct platform specific path.
