### PR TITLE
Update IDebugUI interface for generic properties tree in debug window.

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/DebugUI/IDebugUI.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/DebugUI/IDebugUI.cs
@@ -40,19 +40,19 @@ namespace VisualPinball.Unity.Physics.DebugUI
 		/// <typeparam name="T">Data type, like Vector3, float, int, ...</typeparam>
 		/// <param name="parentIdx">index to parent. If =-1 it means root.</param>
 		/// <param name="name">Label or name of group.</param>
-		/// <param name="currentValue">Initial value.</param>
+		/// <param name="value">Initial value.</param>
 		/// <param name="tip">Message to display as tooltip.</param>
 		/// <returns>Index of property. Use it as parentIdx or propIdx.</returns>
-		int AddProperty<T>(int parentIdx, string name, T currentValue, string tip = null);
+		int AddProperty<T>(int parentIdx, string name, T value, string tip = null);
 
 		/// <summary>
 		/// Get property value from DebugUI.
 		/// </summary>
 		/// <typeparam name="T">Data type, like Vector3, float, int, ...</typeparam>
 		/// <param name="propIdx"></param>
-		/// <param name="val">Output where new value will be writen.</param>
+		/// <param name="value">Output where new value will be writen.</param>
 		/// <returns>true if value is changed.</returns>
-		bool GetProperty<T>(int propIdx, ref T val);
+		bool GetProperty<T>(int propIdx, ref T value);
 
 
 		/// <summary>
@@ -62,5 +62,16 @@ namespace VisualPinball.Unity.Physics.DebugUI
 		/// <param name="propIdx">Index of property.</param>
 		/// <param name="value">New value for property.</param>
 		void SetProperty<T>(int propIdx, T value);
+
+		/// <summary>
+		/// One line to add property (to Quick group) and sync value.
+		/// Property is recognized base on name & type. So, you can use same name for different types
+		/// </summary>
+		/// <typeparam name="T">Data type, like Vector3, float, int, ...</typeparam>
+		/// <param name="name">Label for property.</param>
+		/// <param name="value">Current value as input. Can be updated.</param>
+		/// <param name="tip">Message to display as tooltip.</param>
+		/// <returns>true if value is changed.</returns>
+		bool QuickPropertySync<T>(string name, ref T value, string tip = null);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/DebugUI/IDebugUI.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/DebugUI/IDebugUI.cs
@@ -32,5 +32,35 @@ namespace VisualPinball.Unity.Physics.DebugUI
 		/// </summary>
 		/// <param name="entity">Ball entity</param>
 		void OnCreateBall(Entity entity);
+
+		/// <summary>
+		/// Add new property to debug window.
+		/// If type T is not recognized it is treated as beginning of new group.
+		/// </summary>
+		/// <typeparam name="T">Data type, like Vector3, float, int, ...</typeparam>
+		/// <param name="parentIdx">index to parent. If =-1 it means root.</param>
+		/// <param name="name">Label or name of group.</param>
+		/// <param name="currentValue">Initial value.</param>
+		/// <param name="tip">Message to display as tooltip.</param>
+		/// <returns>Index of property. Use it as parentIdx or propIdx.</returns>
+		int AddProperty<T>(int parentIdx, string name, T currentValue, string tip = null);
+
+		/// <summary>
+		/// Get property value from DebugUI.
+		/// </summary>
+		/// <typeparam name="T">Data type, like Vector3, float, int, ...</typeparam>
+		/// <param name="propIdx"></param>
+		/// <param name="val">Output where new value will be writen.</param>
+		/// <returns>true if value is changed.</returns>
+		bool GetProperty<T>(int propIdx, ref T val);
+
+
+		/// <summary>
+		/// Set property value in  DebugUI.
+		/// </summary>
+		/// <typeparam name="T">Data type, like Vector3, float, int, ...</typeparam>
+		/// <param name="propIdx">Index of property.</param>
+		/// <param name="value">New value for property.</param>
+		void SetProperty<T>(int propIdx, T value);
 	}
 }


### PR DESCRIPTION
In my ImGUI there is debug window. Now it is possible to build simple property tree with banch of params and use it to modify values after build.
Here is example how it looks in use:
![DebugUI-sample](https://user-images.githubusercontent.com/3882838/85223367-f560a380-b3c2-11ea-9896-a1433070f183.gif)

Code use to add "Flipper Props":
```
static int dbgFlippersRoot = -1;
int dbgThisFlipper = -1;
int dbgPropStartAngle = -1;
int dbgPropEndAngle = -1;

void _AddDebugProperties()
{
    var dbg = EngineProvider<IDebugUI>.Get();
    if (dbgFlippersRoot == -1)
        dbgFlippersRoot = dbg.AddProperty(-1, "Flippers Props", this);

    dbgThisFlipper = dbg.AddProperty(dbgFlippersRoot, base.name, this);
    dbgPropStartAngle = dbg.AddProperty(dbgThisFlipper, "Start Angle", _startAngle * 180.0f / Mathf.PI);
    dbgPropEndAngle = dbg.AddProperty(dbgThisFlipper, "End Angle", _endAngle * 180.0f / Mathf.PI);
}
```
To add one method is used to add node in three or property. If type of passed value is not recognized, it is interpreted as new group.

Here is code used to read value modified by user:
```
var dbg = EngineProvider<IDebugUI>.Get();
bool isChanged = false;
float sa = phyFlipper._startAngle * 180.0f / Mathf.PI;
float se = phyFlipper._endAngle * 180.0f / Mathf.PI;

isChanged |= dbg.GetProperty(phyFlipper.dbgPropStartAngle, ref sa);
isChanged |= dbg.GetProperty(phyFlipper.dbgPropEndAngle, ref se);

if (isChanged)
{
    phyFlipper._startAngle = sa * Mathf.PI / 180.0f;
    phyFlipper._endAngle = se * Mathf.PI / 180.0f;
}
```

If you want to quickly add one parame to DebugUI, you can do it with one line:
`dbg.QuickPropertySync("Local to World matrix", ref td.localToWorld))`
This line will add propery and read value.

Here is bigger example:
```
public static void dbg(EntityManager entityManager)
{
    if (lastGate != Entity.Null && entityManager.HasComponent<BulletPhysicsTransformData>(lastGate))
    {
        var dbg = EngineProvider<IDebugUI>.Get();

        var td = entityManager.GetComponentData<BulletPhysicsTransformData>(lastGate);
        if (dbg.QuickPropertySync("diag", ref td.localToWorld))
        {
            entityManager.SetComponentData(lastGate, td);
        }

        float damp = phyGate.body.AngularDamping;                
        if (dbg.QuickPropertySync("damping", ref damp))
        {
            phyGate.body.SetDamping(damp, damp);
        }

    }
}
```

Right now ImGUI accept following types: int, float, float3, Vector3, Quaternion, Matrix4x4.
That last one will add 2 lines: Position and Rotation, scale is preserved.
