### PR TITLE
Add trigger collision and animation

### DIFF
--- a/VisualPinball.Engine/VPT/Table/Table.cs
+++ b/VisualPinball.Engine/VPT/Table/Table.cs
@@ -101,7 +101,8 @@ namespace VisualPinball.Engine.VPT.Table
 			.Concat(Ramps.Values)
 			.Concat(Rubbers.Values)
 			.Concat(Spinners.Values)
-			.Concat(Surfaces.Values);
+			.Concat(Surfaces.Values)
+			.Concat(Triggers.Values);
 
 		public IEnumerable<IPlayable> Playables => new IPlayable[0]
 			.Concat(Bumpers.Values)
@@ -111,7 +112,8 @@ namespace VisualPinball.Engine.VPT.Table
 			.Concat(Ramps.Values)
 			.Concat(Rubbers.Values)
 			.Concat(Spinners.Values)
-			.Concat(Surfaces.Values);
+			.Concat(Surfaces.Values)
+			.Concat(Triggers.Values);
 
 		#endregion
 

--- a/VisualPinball.Engine/VPT/Trigger/Trigger.cs
+++ b/VisualPinball.Engine/VPT/Trigger/Trigger.cs
@@ -1,18 +1,32 @@
 using System.IO;
 using VisualPinball.Engine.Game;
+using VisualPinball.Engine.Physics;
 
 namespace VisualPinball.Engine.VPT.Trigger
 {
-	public class Trigger : Item<TriggerData>, IRenderable
+	public class Trigger : Item<TriggerData>, IRenderable, IHittable
 	{
+		public bool IsCollidable => true;
+		public HitObject[] GetHitShapes() => _hits;
+		public EventProxy EventProxy { get; private set; }
+
 		private readonly TriggerMeshGenerator _meshGenerator;
+		private readonly TriggerHitGenerator _hitGenerator;
+		private HitObject[] _hits;
 
 		public Trigger(TriggerData data) : base(data)
 		{
 			_meshGenerator = new TriggerMeshGenerator(Data);
+			_hitGenerator = new TriggerHitGenerator(Data);
 		}
 
 		public Trigger(BinaryReader reader, string itemName) : this(new TriggerData(reader, itemName)) { }
+
+		public void Init(Table.Table table)
+		{
+			EventProxy = new EventProxy(this);
+			_hits = _hitGenerator.GenerateHitObjects(table, EventProxy);
+		}
 
 		public RenderObjectGroup GetRenderObjects(Table.Table table, Origin origin = Origin.Global, bool asRightHanded = true)
 		{

--- a/VisualPinball.Engine/VPT/Trigger/TriggerHitCircle.cs
+++ b/VisualPinball.Engine/VPT/Trigger/TriggerHitCircle.cs
@@ -1,0 +1,12 @@
+using VisualPinball.Engine.Math;
+using VisualPinball.Engine.Physics;
+
+namespace VisualPinball.Engine.VPT.Trigger
+{
+	public class TriggerHitCircle : HitCircle
+	{
+		public TriggerHitCircle(Vertex2D center, float radius, float zLow, float zHigh) : base(center, radius, zLow, zHigh)
+		{
+		}
+	}
+}

--- a/VisualPinball.Engine/VPT/Trigger/TriggerHitCircle.cs.meta
+++ b/VisualPinball.Engine/VPT/Trigger/TriggerHitCircle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d9b5fff1ab3818244947fe99545bf380
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Engine/VPT/Trigger/TriggerHitGenerator.cs
+++ b/VisualPinball.Engine/VPT/Trigger/TriggerHitGenerator.cs
@@ -48,7 +48,7 @@ namespace VisualPinball.Engine.VPT.Trigger
 
 			for (var i = 0; i < count; i++) {
 				rgv[i] = vVertex[i];
-				rgv3D[i] = new Vertex3D(rgv[i].X, rgv[i].Y, height + PhysicsConstants.PhysSkin * 2.0f);
+				rgv3D[i] = new Vertex3D(rgv[i].X, rgv[i].Y, height + (float)(PhysicsConstants.PhysSkin * 2.0));
 			}
 
 			for (var i = 0; i < count; i++) {
@@ -66,10 +66,11 @@ namespace VisualPinball.Engine.VPT.Trigger
 
 		private TriggerHitLineSeg GetLineSeg(Vertex2D pv1, Vertex2D pv2, EventProxy events, float height) {
 			return new TriggerHitLineSeg(
-				new Vertex2D(pv1.X, pv1.Y),
-				new Vertex2D(pv2.X, pv2.Y),
+				pv1.Clone(),
+				pv2.Clone(),
 				height,
-				height + MathF.Max(_data.HitHeight - 8.0f, 0) //adjust for same hit height as circular
+				height + MathF.Max(_data.HitHeight - 8.0f, 0f), // adjust for same hit height as circular
+				CollisionType.Trigger
 			) {
 				Obj = events
 			};

--- a/VisualPinball.Engine/VPT/Trigger/TriggerHitGenerator.cs
+++ b/VisualPinball.Engine/VPT/Trigger/TriggerHitGenerator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Data.Common;
 using VisualPinball.Engine.Common;
 using VisualPinball.Engine.Game;
 using VisualPinball.Engine.Math;
@@ -16,6 +17,26 @@ namespace VisualPinball.Engine.VPT.Trigger
 		}
 
 		public HitObject[] GenerateHitObjects(Table.Table table, EventProxy events)
+		{
+			if (_data.Shape == TriggerShape.TriggerStar || _data.Shape == TriggerShape.TriggerButton) {
+				return GenerateRoundHitObjects(table, events);
+			}
+			return GenerateCurvedHitObjects(table, events);
+		}
+
+		private HitObject[] GenerateRoundHitObjects(Table.Table table, EventProxy events)
+		{
+			var height = table.GetSurfaceHeight(_data.Surface, _data.Center.X, _data.Center.Y);
+			return new HitObject[] {
+				new TriggerHitCircle(_data.Center, _data.Radius, height, height + _data.HitHeight) {
+					Obj = events,
+					IsEnabled = _data.IsEnabled,
+					ObjType = CollisionType.Trigger
+				}
+			};
+		}
+
+		private HitObject[] GenerateCurvedHitObjects(Table.Table table, EventProxy events)
 		{
 			var hitObjects = new List<HitObject>();
 			var height = table.GetSurfaceHeight(_data.Surface, _data.Center.X, _data.Center.Y);

--- a/VisualPinball.Engine/VPT/Trigger/TriggerHitGenerator.cs
+++ b/VisualPinball.Engine/VPT/Trigger/TriggerHitGenerator.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using VisualPinball.Engine.Common;
+using VisualPinball.Engine.Game;
+using VisualPinball.Engine.Math;
+using VisualPinball.Engine.Physics;
+
+namespace VisualPinball.Engine.VPT.Trigger
+{
+	public class TriggerHitGenerator
+	{
+		private readonly TriggerData _data;
+
+		public TriggerHitGenerator(TriggerData data)
+		{
+			_data = data;
+		}
+
+		public HitObject[] GenerateHitObjects(Table.Table table, EventProxy events)
+		{
+			var hitObjects = new List<HitObject>();
+			var height = table.GetSurfaceHeight(_data.Surface, _data.Center.X, _data.Center.Y);
+			var vVertex = DragPoint.GetRgVertex<RenderVertex2D, CatmullCurve2DCatmullCurveFactory>(_data.DragPoints);
+
+			var count = vVertex.Length;
+			var rgv = new RenderVertex2D[count];
+			var rgv3D = new Vertex3D[count];
+
+			for (var i = 0; i < count; i++) {
+				rgv[i] = vVertex[i];
+				rgv3D[i] = new Vertex3D(rgv[i].X, rgv[i].Y, height + PhysicsConstants.PhysSkin * 2.0f);
+			}
+
+			for (var i = 0; i < count; i++) {
+				var pv2 = rgv[i < count - 1 ? i + 1 : 0];
+				var pv3 = rgv[i < count - 2 ? i + 2 : i + 2 - count];
+				hitObjects.Add(GetLineSeg(pv2, pv3, events, height));
+			}
+
+			hitObjects.Add( new Hit3DPoly(rgv3D, CollisionType.Trigger) {
+				Obj = events
+			});
+
+			return hitObjects.ToArray();
+		}
+
+		private TriggerHitLineSeg GetLineSeg(Vertex2D pv1, Vertex2D pv2, EventProxy events, float height) {
+			return new TriggerHitLineSeg(
+				new Vertex2D(pv1.X, pv1.Y),
+				new Vertex2D(pv2.X, pv2.Y),
+				height,
+				height + MathF.Max(_data.HitHeight - 8.0f, 0) //adjust for same hit height as circular
+			) {
+				Obj = events
+			};
+		}
+	}
+}

--- a/VisualPinball.Engine/VPT/Trigger/TriggerHitGenerator.cs.meta
+++ b/VisualPinball.Engine/VPT/Trigger/TriggerHitGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 191384a1ae5381841b727fe443afd6fc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Engine/VPT/Trigger/TriggerHitLineSeg.cs
+++ b/VisualPinball.Engine/VPT/Trigger/TriggerHitLineSeg.cs
@@ -1,0 +1,12 @@
+using VisualPinball.Engine.Math;
+using VisualPinball.Engine.Physics;
+
+namespace VisualPinball.Engine.VPT.Trigger
+{
+	public class TriggerHitLineSeg : LineSeg
+	{
+		public TriggerHitLineSeg(Vertex2D p1, Vertex2D p2, float zLow, float zHigh, string objType = null) : base(p1, p2, zLow, zHigh, objType)
+		{
+		}
+	}
+}

--- a/VisualPinball.Engine/VPT/Trigger/TriggerHitLineSeg.cs.meta
+++ b/VisualPinball.Engine/VPT/Trigger/TriggerHitLineSeg.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a6e639f02a065448a7b19c220a45854
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
@@ -132,7 +132,7 @@ namespace VisualPinball.Unity.Game
 			}
 
 			if (Input.GetKeyUp("n")) {
-				_player.CreateBall(new DebugBallCreator(517f, 1672f, -90, 3));
+				_player.CreateBall(new DebugBallCreator(129f, 1450f));
 				//_tableApi.Flippers["LeftFlipper"].RotateToEnd();
 			}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Import/VpxImporter.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Import/VpxImporter.cs
@@ -174,7 +174,7 @@ namespace VisualPinball.Unity.Import
 				case Spinner spinner:				ic = spinner.SetupGameObject(obj, rog); break;
 				case Surface surface:				ic = surface.SetupGameObject(obj, rog); break;
 				case Table table:					ic = table.SetupGameObject(obj, rog); break;
-				case Trigger trigger:				ic = obj.AddComponent<TriggerBehavior>().SetData(trigger.Data); break;
+				case Trigger trigger:				ic = trigger.SetupGameObject(obj, rog); break;
 			}
 #if UNITY_EDITOR
 			// for convenience move item behavior to the top of the list

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/CircleCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/CircleCollider.cs
@@ -110,7 +110,7 @@ namespace VisualPinball.Unity.Physics.Collider
 
 			// Kicker is special.. handle ball stalled on kicker, commonly hit while receding, knocking back into kicker pocket
 			if (isKicker && bnd <= 0 && bnd >= -Radius && a < PhysicsConstants.ContactVel * PhysicsConstants.ContactVel/* && ball.Hit.IsRealBall()*/) {
-				BallData.SetOutsideOf(ref insideOfs, ref _header.Entity);
+				BallData.SetOutsideOf(ref insideOfs, _header.Entity);
 			}
 
 			// contact positive possible in future ... objects Negative in contact now

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/CircleCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/CircleCollider.cs
@@ -136,7 +136,7 @@ namespace VisualPinball.Unity.Physics.Collider
 				// here if ... ball inside and no hit set .... or ... ball outside and hit set
 				if (math.abs(bnd - Radius) < 0.05) {
 					// if ball appears in center of trigger, then assumed it was gen"ed there
-					BallData.SetInsideOf(ref insideOfs, ref _header.Entity); // special case for trigger overlaying a kicker
+					BallData.SetInsideOf(ref insideOfs, _header.Entity); // special case for trigger overlaying a kicker
 
 				} else {
 					// this will add the ball to the trigger space without a Hit

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
@@ -8,6 +8,7 @@ using VisualPinball.Engine.VPT.Flipper;
 using VisualPinball.Engine.VPT.Gate;
 using VisualPinball.Engine.VPT.Plunger;
 using VisualPinball.Engine.VPT.Spinner;
+using VisualPinball.Engine.VPT.Trigger;
 using VisualPinball.Unity.Physics.Collision;
 using VisualPinball.Unity.VPT;
 using VisualPinball.Unity.VPT.Ball;
@@ -43,6 +44,12 @@ namespace VisualPinball.Unity.Physics.Collider
 		public static void Create(BlobBuilder builder, HitObject src, ref BlobPtr<Collider> dest)
 		{
 			switch (src) {
+				case TriggerHitCircle triggerHitCircle:
+					CircleCollider.Create(builder, triggerHitCircle, ref dest);
+					break;
+				case TriggerHitLineSeg triggerHitLine:
+					LineCollider.Create(builder, triggerHitLine, ref dest);
+					break;
 				case BumperHit bumperHit:
 					CircleCollider.Create(builder, bumperHit, ref dest, ColliderType.Bumper);
 					break;
@@ -117,6 +124,10 @@ namespace VisualPinball.Unity.Physics.Collider
 						return ((SpinnerCollider*)collider)->HitTest(ref collEvent, ref insideOf, in ball, dTime);
 					case ColliderType.Triangle:
 						return ((TriangleCollider*)collider)->HitTest(ref collEvent, in ball, dTime);
+					case ColliderType.TriggerCircle:
+						return ((CircleCollider*)collider)->HitTestBasicRadius(ref collEvent, ref insideOf, in ball, dTime, false, false, false);
+					case ColliderType.TriggerLine:
+						return ((LineCollider*) collider)->HitTestBasic(ref collEvent, ref insideOf, in ball, dTime, false, false, false);
 
 					case ColliderType.Plunger:
 					case ColliderType.Flipper:

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
@@ -45,10 +45,10 @@ namespace VisualPinball.Unity.Physics.Collider
 		{
 			switch (src) {
 				case TriggerHitCircle triggerHitCircle:
-					CircleCollider.Create(builder, triggerHitCircle, ref dest);
+					CircleCollider.Create(builder, triggerHitCircle, ref dest, ColliderType.TriggerCircle);
 					break;
 				case TriggerHitLineSeg triggerHitLine:
-					LineCollider.Create(builder, triggerHitLine, ref dest);
+					LineCollider.Create(builder, triggerHitLine, ref dest, ColliderType.TriggerLine);
 					break;
 				case BumperHit bumperHit:
 					CircleCollider.Create(builder, bumperHit, ref dest, ColliderType.Bumper);

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/LineCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/LineCollider.cs
@@ -167,8 +167,7 @@ namespace VisualPinball.Unity.Physics.Collider
 			}
 
 			if (!rigid) {
-				// todo non rigid body collision? return direction
-				//coll.HitFlag = isUnHit; // UnHit signal is receding from outside target
+				collEvent.HitFlag = isUnHit; // UnHit signal is receding from outside target
 			}
 
 			var ballRadius = ball.Radius;

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/ColliderType.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/ColliderType.cs
@@ -16,6 +16,8 @@
 		Point,
 		Poly3D,
 		Spinner,
-		Triangle
+		Triangle,
+		TriggerCircle,
+		TriggerLine
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
@@ -13,6 +13,7 @@ using VisualPinball.Unity.VPT.Flipper;
 using VisualPinball.Unity.VPT.Gate;
 using VisualPinball.Unity.VPT.Plunger;
 using VisualPinball.Unity.VPT.Spinner;
+using VisualPinball.Unity.VPT.Trigger;
 using Random = Unity.Mathematics.Random;
 
 namespace VisualPinball.Unity.Physics.Collision
@@ -42,7 +43,8 @@ namespace VisualPinball.Unity.Physics.Collision
 
 			Entities
 				.WithName("StaticCollisionJob")
-				.ForEach((ref BallData ballData, ref CollisionEventData collEvent) => {
+				.ForEach((ref BallData ballData, ref CollisionEventData collEvent,
+					ref DynamicBuffer<BallInsideOfBufferElement> insideOfs) => {
 
 				// find balls with hit objects and minimum time
 				if (collEvent.ColliderId < 0 || collEvent.HitTime > hitTime) {
@@ -53,7 +55,6 @@ namespace VisualPinball.Unity.Physics.Collision
 
 				// retrieve static data
 				ref var colliders = ref collData.Value.Value.Colliders;
-
 
 				// pick collider that matched during narrowphase
 				ref var coll = ref colliders[collEvent.ColliderId].Value; // object that ball hit in trials
@@ -121,6 +122,15 @@ namespace VisualPinball.Unity.Physics.Collision
 									in spinnerStaticData
 								);
 								SetComponent(coll.Entity, spinnerMovementData);
+								break;
+
+							case ColliderType.TriggerCircle:
+							case ColliderType.TriggerLine:
+								var triggerAnimationData = GetComponent<TriggerAnimationData>(coll.Entity);
+								TriggerCollider.Collide(
+									ref ballData, ref collEvent, ref insideOfs, ref triggerAnimationData, in coll
+								);
+								SetComponent(coll.Entity, triggerAnimationData);
 								break;
 
 							case ColliderType.Line:

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallData.cs
@@ -76,18 +76,13 @@ namespace VisualPinball.Unity.VPT.Ball
 			       + math.cross(ball.AngularVelocity, math.cross(ball.AngularVelocity, surfP)); // centripetal acceleration
 		}
 
-		public static void SetOutsideOf(ref DynamicBuffer<BallInsideOfBufferElement> insideOfs, ref Entity entity)
+		public static void SetOutsideOf(ref DynamicBuffer<BallInsideOfBufferElement> insideOfs, in Entity entity)
 		{
-			int i;
-			var inside = false;
-			for (i = 0; i < insideOfs.Length; i++) {
+			for (var i = 0; i < insideOfs.Length; i++) {
 				if (insideOfs[i].Value == entity) {
-					inside = true;
-					break;
+					insideOfs.RemoveAt(i);
+					return;
 				}
-			}
-			if (inside) {
-				insideOfs.RemoveAt(i);
 			}
 		}
 
@@ -98,10 +93,10 @@ namespace VisualPinball.Unity.VPT.Ball
 
 		public static bool IsOutsideOf(ref DynamicBuffer<BallInsideOfBufferElement> insideOfs, ref Entity entity)
 		{
-			return !IsInsideOf(ref insideOfs, ref entity);
+			return !IsInsideOf(in insideOfs, in entity);
 		}
 
-		public static bool IsInsideOf(ref DynamicBuffer<BallInsideOfBufferElement> insideOfs, ref Entity entity)
+		public static bool IsInsideOf(in DynamicBuffer<BallInsideOfBufferElement> insideOfs, in Entity entity)
 		{
 			for (var i = 0; i < insideOfs.Length; i++) {
 				if (insideOfs[i].Value == entity) {

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallData.cs
@@ -86,7 +86,7 @@ namespace VisualPinball.Unity.VPT.Ball
 			}
 		}
 
-		public static void SetInsideOf(ref DynamicBuffer<BallInsideOfBufferElement> insideOfs, ref Entity entity)
+		public static void SetInsideOf(ref DynamicBuffer<BallInsideOfBufferElement> insideOfs, Entity entity)
 		{
 			insideOfs.Add(new BallInsideOfBufferElement {Value = entity});
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperCollider.cs
@@ -8,9 +8,9 @@ namespace VisualPinball.Unity.VPT.Bumper
 	public static class BumperCollider
 	{
 		public static void Collide(ref BallData ball, ref CollisionEventData collEvent,
-			ref BumperRingAnimationData ringData, ref BumperSkirtAnimationData skirtData,
-			in Collider collider, in BumperStaticData data, ref Random random)
-		{
+         			ref BumperRingAnimationData ringData, ref BumperSkirtAnimationData skirtData,
+         			in Collider collider, in BumperStaticData data, ref Random random)
+         		{
 			// todo
 			// if (!m_enabled) return;
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerAnimationData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerAnimationData.cs
@@ -1,0 +1,10 @@
+using Unity.Entities;
+
+namespace VisualPinball.Unity.VPT.Trigger
+{
+	public struct TriggerAnimationData : IComponentData
+	{
+		public bool HitEvent;
+		public bool UnHitEvent;
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerAnimationData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerAnimationData.cs
@@ -6,5 +6,9 @@ namespace VisualPinball.Unity.VPT.Trigger
 	{
 		public bool HitEvent;
 		public bool UnHitEvent;
+
+		public float TimeMsec;
+		public bool DoAnimation;
+		public bool MoveDown;
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerAnimationData.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerAnimationData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28edf9ce7aa309f4fb9253681a572ab7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerAnimationSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerAnimationSystem.cs
@@ -1,0 +1,84 @@
+using Unity.Entities;
+using Unity.Profiling;
+using VisualPinball.Engine.VPT;
+using VisualPinball.Unity.Physics.SystemGroup;
+
+namespace VisualPinball.Unity.VPT.Trigger
+{
+	[UpdateInGroup(typeof(UpdateAnimationsSystemGroup))]
+	public class TriggerAnimationSystem : SystemBase
+	{
+		private static readonly ProfilerMarker PerfMarker = new ProfilerMarker("TriggerAnimationSystem");
+
+		protected override void OnUpdate()
+		{
+			var dTime = Time.DeltaTime * 1000;
+			var marker = PerfMarker;
+
+			Entities
+				.WithName("TriggerAnimationJob")
+				.ForEach((ref TriggerAnimationData data, ref TriggerMovementData movementData, in TriggerStaticData staticData) => {
+
+					marker.Begin();
+
+					var oldTimeMsec = data.TimeMsec < dTime ? data.TimeMsec : dTime;
+					data.TimeMsec = dTime;
+					var diffTimeMsec = dTime - oldTimeMsec;
+
+					var animLimit = staticData.Shape == TriggerShape.TriggerStar ? staticData.Radius * (1.0f / 5.0f) : 32.0f;
+					if (staticData.Shape == TriggerShape.TriggerButton) {
+						animLimit = staticData.Radius * (1.0f / 10.0f);
+					}
+					if (staticData.Shape == TriggerShape.TriggerWireC) {
+						animLimit = 60.0f;
+					}
+					if (staticData.Shape == TriggerShape.TriggerWireD) {
+						animLimit = 25.0f;
+					}
+
+					var limit = animLimit * staticData.TableScaleZ;
+
+					if (data.HitEvent) {
+						data.DoAnimation = true;
+						data.HitEvent = false;
+						// unhitEvent = false;   // Bugfix: If HitEvent and unhitEvent happen at the same time, you want to favor the unhit, otherwise the switch gets stuck down.
+						movementData.HeightOffset = 0.0f;
+						data.MoveDown = true;
+					}
+					if (data.UnHitEvent) {
+						data.DoAnimation = true;
+						data.UnHitEvent = false;
+						data.HitEvent = false;
+						movementData.HeightOffset = limit;
+						data.MoveDown = false;
+					}
+
+					if (data.DoAnimation) {
+						var step = diffTimeMsec *staticData.AnimSpeed * staticData.TableScaleZ;
+						if (data.MoveDown) {
+							step = -step;
+						}
+						movementData.HeightOffset += step;
+
+						if (data.MoveDown) {
+							if (movementData.HeightOffset <= -limit) {
+								movementData.HeightOffset = -limit;
+								data.DoAnimation = false;
+								data.MoveDown = false;
+							}
+
+						} else {
+							if (movementData.HeightOffset >= 0.0f) {
+								movementData.HeightOffset = 0.0f;
+								data.DoAnimation = false;
+								data.MoveDown = true;
+							}
+						}
+					}
+
+					marker.End();
+
+				}).Run();
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerAnimationSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerAnimationSystem.cs
@@ -25,9 +25,9 @@ namespace VisualPinball.Unity.VPT.Trigger
 					data.TimeMsec = dTime;
 					var diffTimeMsec = dTime - oldTimeMsec;
 
-					var animLimit = staticData.Shape == TriggerShape.TriggerStar ? staticData.Radius * (1.0f / 5.0f) : 32.0f;
+					var animLimit = staticData.Shape == TriggerShape.TriggerStar ? staticData.Radius * (float)(1.0 / 5.0) : 32.0f;
 					if (staticData.Shape == TriggerShape.TriggerButton) {
-						animLimit = staticData.Radius * (1.0f / 10.0f);
+						animLimit = staticData.Radius * (float)(1.0 / 10.0);
 					}
 					if (staticData.Shape == TriggerShape.TriggerWireC) {
 						animLimit = 60.0f;
@@ -54,7 +54,7 @@ namespace VisualPinball.Unity.VPT.Trigger
 					}
 
 					if (data.DoAnimation) {
-						var step = diffTimeMsec *staticData.AnimSpeed * staticData.TableScaleZ;
+						var step = diffTimeMsec * staticData.AnimSpeed * staticData.TableScaleZ;
 						if (data.MoveDown) {
 							step = -step;
 						}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerAnimationSystem.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerAnimationSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1da2a579bbe97a2429ca76a09a44e69d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerBehavior.cs
@@ -10,6 +10,7 @@ using UnityEngine;
 using VisualPinball.Engine.Math;
 using VisualPinball.Engine.VPT.Trigger;
 using VisualPinball.Unity.Extensions;
+using VisualPinball.Unity.VPT.Table;
 
 namespace VisualPinball.Unity.VPT.Trigger
 {
@@ -21,6 +22,16 @@ namespace VisualPinball.Unity.VPT.Trigger
 		public void Convert(Entity entity, EntityManager dstManager, GameObjectConversionSystem conversionSystem)
 		{
 			Convert(entity, dstManager);
+
+			var table = gameObject.GetComponentInParent<TableBehavior>().Item;
+			dstManager.AddComponentData(entity, new TriggerAnimationData());
+			dstManager.AddComponentData(entity, new TriggerMovementData());
+			dstManager.AddComponentData(entity, new TriggerStaticData {
+				AnimSpeed = data.AnimSpeed,
+				Radius = data.Radius,
+				Shape = data.Shape,
+				TableScaleZ = table.GetScaleZ()
+			});
 		}
 
 		protected override Engine.VPT.Trigger.Trigger GetItem()

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerBehavior.cs
@@ -5,6 +5,7 @@
 #endregion
 
 using System.Collections.Generic;
+using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.Math;
 using VisualPinball.Engine.VPT.Trigger;
@@ -13,9 +14,14 @@ using VisualPinball.Unity.Extensions;
 namespace VisualPinball.Unity.VPT.Trigger
 {
 	[AddComponentMenu("Visual Pinball/Trigger")]
-	public class TriggerBehavior : ItemBehavior<Engine.VPT.Trigger.Trigger, TriggerData>, IDragPointsEditable
+	public class TriggerBehavior : ItemBehavior<Engine.VPT.Trigger.Trigger, TriggerData>, IDragPointsEditable, IConvertGameObjectToEntity
 	{
 		protected override string[] Children => null;
+
+		public void Convert(Entity entity, EntityManager dstManager, GameObjectConversionSystem conversionSystem)
+		{
+			Convert(entity, dstManager);
+		}
 
 		protected override Engine.VPT.Trigger.Trigger GetItem()
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerCollider.cs
@@ -22,7 +22,7 @@ namespace VisualPinball.Unity.VPT.Trigger
 				ball.Position += PhysicsConstants.StaticTime * ball.Velocity; // move ball slightly forward
 
 				if (!insideOf) {
-					insideOfs.Add(new BallInsideOfBufferElement { Value = coll.Entity });
+					BallData.SetInsideOf(ref insideOfs, coll.Entity);
 					animationData.HitEvent = true;
 
 					// todo event

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerCollider.cs
@@ -1,6 +1,6 @@
 using Unity.Entities;
+using UnityEngine;
 using VisualPinball.Engine.Common;
-using VisualPinball.Unity.Physics.Collider;
 using VisualPinball.Unity.Physics.Collision;
 using VisualPinball.Unity.VPT.Ball;
 
@@ -10,7 +10,7 @@ namespace VisualPinball.Unity.VPT.Trigger
 	{
 		public static void Collide(ref BallData ball, ref CollisionEventData collEvent,
 			ref DynamicBuffer<BallInsideOfBufferElement> insideOfs, ref TriggerAnimationData animationData,
-			in Collider coll)
+			in Physics.Collider.Collider coll)
 		{
 			// todo?
 			// if (!ball.isRealBall()) {
@@ -35,6 +35,9 @@ namespace VisualPinball.Unity.VPT.Trigger
 					// todo event
 					//this.obj!.fireGroupEvent(Event.HitEventsUnhit);
 				}
+			}
+			else {
+
 			}
 		}
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerCollider.cs
@@ -1,4 +1,3 @@
-using System;
 using Unity.Entities;
 using VisualPinball.Engine.Common;
 using VisualPinball.Unity.Physics.Collider;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerCollider.cs
@@ -1,0 +1,42 @@
+using System;
+using Unity.Entities;
+using VisualPinball.Engine.Common;
+using VisualPinball.Unity.Physics.Collider;
+using VisualPinball.Unity.Physics.Collision;
+using VisualPinball.Unity.VPT.Ball;
+
+namespace VisualPinball.Unity.VPT.Trigger
+{
+	public static class TriggerCollider
+	{
+		public static void Collide(ref BallData ball, ref CollisionEventData collEvent,
+			ref DynamicBuffer<BallInsideOfBufferElement> insideOfs, ref TriggerAnimationData animationData,
+			in Collider coll)
+		{
+			// todo?
+			// if (!ball.isRealBall()) {
+			// 	return;
+			// }
+
+			var insideOf = BallData.IsInsideOf(in insideOfs, coll.Entity);
+			if (collEvent.HitFlag == insideOf) {                                            // Hit == NotAlreadyHit
+				ball.Position += PhysicsConstants.StaticTime * ball.Velocity; // move ball slightly forward
+
+				if (!insideOf) {
+					insideOfs.Add(new BallInsideOfBufferElement { Value = coll.Entity });
+					animationData.HitEvent = true;
+
+					// todo event
+					//this.obj!.fireGroupEvent(Event.HitEventsHit);
+
+				} else {
+					BallData.SetOutsideOf(ref insideOfs, coll.Entity);
+					animationData.UnHitEvent = true;
+
+					// todo event
+					//this.obj!.fireGroupEvent(Event.HitEventsUnhit);
+				}
+			}
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerCollider.cs
@@ -1,6 +1,6 @@
 using Unity.Entities;
-using UnityEngine;
 using VisualPinball.Engine.Common;
+using VisualPinball.Unity.Physics.Collider;
 using VisualPinball.Unity.Physics.Collision;
 using VisualPinball.Unity.VPT.Ball;
 
@@ -10,7 +10,7 @@ namespace VisualPinball.Unity.VPT.Trigger
 	{
 		public static void Collide(ref BallData ball, ref CollisionEventData collEvent,
 			ref DynamicBuffer<BallInsideOfBufferElement> insideOfs, ref TriggerAnimationData animationData,
-			in Physics.Collider.Collider coll)
+			in Collider coll)
 		{
 			// todo?
 			// if (!ball.isRealBall()) {

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerCollider.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerCollider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ef349f905235e94593852abbec058e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerExtensions.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Unity.Entities;
+using UnityEngine;
+using VisualPinball.Engine.Game;
+
+namespace VisualPinball.Unity.VPT.Trigger
+{
+	public static class TriggerExtensions
+	{
+		public static TriggerBehavior SetupGameObject(this Engine.VPT.Trigger.Trigger trigger, GameObject obj, RenderObjectGroup rog)
+		{
+			var ic = obj.AddComponent<TriggerBehavior>().SetData(trigger.Data);
+			obj.AddComponent<ConvertToEntity>();
+			return ic as TriggerBehavior;
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerMovementData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerMovementData.cs
@@ -1,0 +1,9 @@
+using Unity.Entities;
+
+namespace VisualPinball.Unity.VPT.Trigger
+{
+	public struct TriggerMovementData : IComponentData
+	{
+		public float HeightOffset;
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerMovementData.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerMovementData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c9219834360e6f643b78ba52d8046f91
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerMovementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerMovementSystem.cs
@@ -1,0 +1,44 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Profiling;
+using Unity.Transforms;
+using UnityEngine;
+using VisualPinball.Unity.Physics.SystemGroup;
+using VisualPinball.Unity.VPT.Table;
+
+namespace VisualPinball.Unity.VPT.Trigger
+{
+	[UpdateInGroup(typeof(TransformMeshesSystemGroup))]
+	public class TriggerMovementSystem : SystemBase
+	{
+		private float4x4 _baseTransform;
+		private static readonly ProfilerMarker PerfMarker = new ProfilerMarker("TriggerMovementSystem");
+
+		protected override void OnStartRunning()
+		{
+			var root = Object.FindObjectOfType<TableBehavior>();
+			var ltw = root.gameObject.transform.localToWorldMatrix;
+			_baseTransform = new float4x4(
+				ltw.m00, ltw.m01, ltw.m02, ltw.m03,
+				ltw.m10, ltw.m11, ltw.m12, ltw.m13,
+				ltw.m20, ltw.m21, ltw.m22, ltw.m23,
+				ltw.m30, ltw.m31, ltw.m32, ltw.m33
+			);
+		}
+
+		protected override void OnUpdate()
+		{
+			var ltw = _baseTransform;
+			var marker = PerfMarker;
+			Entities.WithName("TriggerMovementJob").ForEach((ref Translation translation, in TriggerMovementData data) => {
+
+				marker.Begin();
+
+				translation.Value = math.transform(ltw, new float3(0f, 0f, data.HeightOffset));
+
+				marker.End();
+
+			}).Run();
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerMovementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerMovementSystem.cs
@@ -34,7 +34,8 @@ namespace VisualPinball.Unity.VPT.Trigger
 
 				marker.Begin();
 
-				translation.Value = math.transform(ltw, new float3(0f, 0f, data.HeightOffset));
+				var t = math.transform(math.inverse(ltw), translation.Value);
+				translation.Value = math.transform(ltw, new float3(t.x, t.y, data.HeightOffset));
 
 				marker.End();
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerMovementSystem.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerMovementSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74ac7befec6231b4d9d48cd9098980f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerStaticData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerStaticData.cs
@@ -1,0 +1,14 @@
+using Unity.Entities;
+
+namespace VisualPinball.Unity.VPT.Trigger
+{
+	public struct TriggerStaticData : IComponentData
+	{
+		public int Shape;
+		public float Radius;
+		public float AnimSpeed;
+
+		// table data
+		public float TableScaleZ;
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerStaticData.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerStaticData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0ce1359544d2d54992757260f48f625
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR implements trigger collision and movement. Closes #30.

Visual Pinball uses two special colliders, `TriggerHitCircle` and `TriggerLineSeg`, that have their own collision resolution (pretty much identical), and hit test differently (non-lateral and non-rigid). During hit object conversion, we use `CircleCollider` and `LineCollider` directly, but set the type to `ColliderType.TriggerCircle` and `ColliderType.TriggerLine` respectively.

During broadphase we then just hit test like VP:

```cs
case ColliderType.TriggerCircle:
	return ((CircleCollider*)collider)->HitTestBasicRadius(ref collEvent, ref insideOf, in ball, dTime, false, false, false);
case ColliderType.TriggerLine:
	return ((LineCollider*) collider)->HitTestBasic(ref collEvent, ref insideOf, in ball, dTime, false, false, false);
```

Collision has its own resolver that is applied the same for both types (`TriggerCollider`):

```cs
case ColliderType.TriggerCircle:
case ColliderType.TriggerLine:
	var triggerAnimationData = GetComponent<TriggerAnimationData>(coll.Entity);
	TriggerCollider.Collide(
		ref ballData, ref collEvent, ref insideOfs, ref triggerAnimationData, in coll
	);
	SetComponent(coll.Entity, triggerAnimationData);
	break;
```

The animation is ported 1:1 and plugs into the animation system we've initially created for the bumpers (see #74).