### PR TITLE
Various Fixes

### DIFF
--- a/VisualPinball.Engine.Test/Test/BaseTests.cs
+++ b/VisualPinball.Engine.Test/Test/BaseTests.cs
@@ -1,4 +1,6 @@
 ﻿using NLog;
+using NLog.Targets;
+using NUnit.Framework;
 using VisualPinball.Engine.Game;
 using VisualPinball.Engine.Math;
 using VisualPinball.Engine.VPT.Ball;
@@ -12,6 +14,10 @@ namespace VisualPinball.Engine.Test.Test
 
 		protected BaseTests()
 		{
+			var config = new NLog.Config.LoggingConfiguration();
+			var logConsole = new TestTarget();
+			config.AddRule(LogLevel.Trace, LogLevel.Fatal, logConsole);
+			LogManager.Configuration = config;
 			Logger = LogManager.GetCurrentClassLogger();
 		}
 
@@ -20,6 +26,17 @@ namespace VisualPinball.Engine.Test.Test
 			return player.CreateBall(new TestBallCreator(x, y, z, vx, vy, vz));
 		}
 	}
+
+	[Target("Test")]
+	public class TestTarget : TargetWithLayout
+	{
+		protected override void Write(LogEventInfo logEvent)
+		{
+			var msg = Layout.Render(logEvent);
+			TestContext.Out.WriteLine(msg);
+		}
+	}
+
 
 	public class TestBallCreator : IBallCreationPosition
 	{

--- a/VisualPinball.Engine/IO/BiffData.cs
+++ b/VisualPinball.Engine/IO/BiffData.cs
@@ -165,7 +165,7 @@ namespace VisualPinball.Engine.IO
 			return obj;
 		}
 
-		protected void Write(BinaryWriter writer, Dictionary<string, List<BiffAttribute>> attributes, HashWriter hashWriter)
+		protected void WriteRecord(BinaryWriter writer, Dictionary<string, List<BiffAttribute>> attributes, HashWriter hashWriter)
 		{
 			// filter known records, join them with unknown records, and sort.
 			var records = attributes.Values

--- a/VisualPinball.Engine/Math/DragPointData.cs
+++ b/VisualPinball.Engine/Math/DragPointData.cs
@@ -75,7 +75,7 @@ namespace VisualPinball.Engine.Math
 
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/BinaryData.cs
+++ b/VisualPinball.Engine/VPT/BinaryData.cs
@@ -66,7 +66,7 @@ namespace VisualPinball.Engine.VPT
 
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Bumper/BumperData.cs
+++ b/VisualPinball.Engine/VPT/Bumper/BumperData.cs
@@ -116,7 +116,7 @@ namespace VisualPinball.Engine.VPT.Bumper
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.Bumper);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Collection/CollectionData.cs
+++ b/VisualPinball.Engine/VPT/Collection/CollectionData.cs
@@ -59,7 +59,7 @@ namespace VisualPinball.Engine.VPT.Collection
 
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Decal/DecalData.cs
+++ b/VisualPinball.Engine/VPT/Decal/DecalData.cs
@@ -79,7 +79,7 @@ namespace VisualPinball.Engine.VPT.Decal
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.Decal);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/DispReel/DispReelData.cs
+++ b/VisualPinball.Engine/VPT/DispReel/DispReelData.cs
@@ -98,7 +98,7 @@ namespace VisualPinball.Engine.VPT.DispReel
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.DispReel);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Flasher/FlasherData.cs
+++ b/VisualPinball.Engine/VPT/Flasher/FlasherData.cs
@@ -102,7 +102,7 @@ namespace VisualPinball.Engine.VPT.Flasher
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.Flasher);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Flipper/FlipperData.cs
+++ b/VisualPinball.Engine/VPT/Flipper/FlipperData.cs
@@ -219,7 +219,7 @@ namespace VisualPinball.Engine.VPT.Flipper
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.Flipper);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Gate/GateData.cs
+++ b/VisualPinball.Engine/VPT/Gate/GateData.cs
@@ -97,7 +97,7 @@ namespace VisualPinball.Engine.VPT.Gate
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.Gate);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/HitTarget/HitTargetData.cs
+++ b/VisualPinball.Engine/VPT/HitTarget/HitTargetData.cs
@@ -120,7 +120,7 @@ namespace VisualPinball.Engine.VPT.HitTarget
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.HitTarget);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Kicker/KickerData.cs
+++ b/VisualPinball.Engine/VPT/Kicker/KickerData.cs
@@ -80,7 +80,7 @@ namespace VisualPinball.Engine.VPT.Kicker
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.Kicker);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Light/LightData.cs
+++ b/VisualPinball.Engine/VPT/Light/LightData.cs
@@ -122,7 +122,7 @@ namespace VisualPinball.Engine.VPT.Light
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.Light);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/LightSeq/LightSeqData.cs
+++ b/VisualPinball.Engine/VPT/LightSeq/LightSeqData.cs
@@ -71,7 +71,7 @@ namespace VisualPinball.Engine.VPT.LightSeq
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.LightSeq);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Material.cs
+++ b/VisualPinball.Engine/VPT/Material.cs
@@ -100,6 +100,8 @@ namespace VisualPinball.Engine.VPT
 		public Material(BinaryReader reader)
 		{
 			MaterialData = new MaterialData(reader);
+			PhysicsMaterialData = new PhysicsMaterialData();
+
 			Name = MaterialData.Name;
 			BaseColor = new Color(MaterialData.BaseColor, ColorFormat.Bgr);
 			Glossiness = new Color(MaterialData.Glossiness, ColorFormat.Bgr);

--- a/VisualPinball.Engine/VPT/Plunger/PlungerData.cs
+++ b/VisualPinball.Engine/VPT/Plunger/PlungerData.cs
@@ -131,7 +131,7 @@ namespace VisualPinball.Engine.VPT.Plunger
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.Plunger);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Plunger/PlungerDesc.cs
+++ b/VisualPinball.Engine/VPT/Plunger/PlungerDesc.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using VisualPinball.Engine.Math;
 
 namespace VisualPinball.Engine.VPT.Plunger
@@ -77,8 +78,18 @@ namespace VisualPinball.Engine.VPT.Plunger
 				var ts = tipShape.Trim().Split(' ');
 				ref var c = ref desc.c[i];
 
-				c.y = int.Parse(ts[0], CultureInfo.InvariantCulture);
-				c.r = float.Parse(ts[1], CultureInfo.InvariantCulture) * 0.5f;
+				try {
+					c.y = int.Parse(ts[0], CultureInfo.InvariantCulture);
+				} catch (FormatException) {
+					c.y = 0;
+				}
+
+				try {
+					var v = ts.Length > 1 ? ts[1] : "0.0";
+					c.r = float.Parse(v.StartsWith(".") ? "0" + v : v, CultureInfo.InvariantCulture) * 0.5f;
+				} catch (FormatException) {
+					c.r = 0;
+				}
 
 				// each entry has to have a higher y value than the last
 				if (c.y < tipLen) {

--- a/VisualPinball.Engine/VPT/Primitive/PrimitiveData.cs
+++ b/VisualPinball.Engine/VPT/Primitive/PrimitiveData.cs
@@ -174,7 +174,7 @@ namespace VisualPinball.Engine.VPT.Primitive
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.Primitive);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Ramp/RampData.cs
+++ b/VisualPinball.Engine/VPT/Ramp/RampData.cs
@@ -130,7 +130,7 @@ namespace VisualPinball.Engine.VPT.Ramp
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.Ramp);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Rubber/RubberData.cs
+++ b/VisualPinball.Engine/VPT/Rubber/RubberData.cs
@@ -118,7 +118,7 @@ namespace VisualPinball.Engine.VPT.Rubber
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.Rubber);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Spinner/SpinnerData.cs
+++ b/VisualPinball.Engine/VPT/Spinner/SpinnerData.cs
@@ -82,7 +82,7 @@ namespace VisualPinball.Engine.VPT.Spinner
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.Spinner);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Surface/SurfaceData.cs
+++ b/VisualPinball.Engine/VPT/Surface/SurfaceData.cs
@@ -145,7 +145,7 @@ namespace VisualPinball.Engine.VPT.Surface
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.Surface);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Table/CustomInfoTags.cs
+++ b/VisualPinball.Engine/VPT/Table/CustomInfoTags.cs
@@ -33,7 +33,7 @@ namespace VisualPinball.Engine.VPT.Table
 
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Table/TableData.cs
+++ b/VisualPinball.Engine/VPT/Table/TableData.cs
@@ -361,7 +361,7 @@ namespace VisualPinball.Engine.VPT.Table
 
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/TextBox/TextBoxData.cs
+++ b/VisualPinball.Engine/VPT/TextBox/TextBoxData.cs
@@ -73,7 +73,7 @@ namespace VisualPinball.Engine.VPT.TextBox
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.TextBox);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/TextureData.cs
+++ b/VisualPinball.Engine/VPT/TextureData.cs
@@ -75,7 +75,7 @@ namespace VisualPinball.Engine.VPT
 
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Timer/TimerData.cs
+++ b/VisualPinball.Engine/VPT/Timer/TimerData.cs
@@ -48,7 +48,7 @@ namespace VisualPinball.Engine.VPT.Timer
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.Timer);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 

--- a/VisualPinball.Engine/VPT/Trigger/TriggerData.cs
+++ b/VisualPinball.Engine/VPT/Trigger/TriggerData.cs
@@ -88,7 +88,7 @@ namespace VisualPinball.Engine.VPT.Trigger
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
 		{
 			writer.Write((int)ItemType.Trigger);
-			Write(writer, Attributes, hashWriter);
+			WriteRecord(writer, Attributes, hashWriter);
 			WriteEnd(writer, hashWriter);
 		}
 


### PR DESCRIPTION
Just small stuff I've noticed while debugging the corruption error:

- Add a test logger
- Rename `BiffData.Write()` to `BiffData.WriteRecord()` in order to make all the `Write()`s less confusing
- Don't crash if the plunger tip shape doesn't comply with the syntax it's supposed to
- Fix a crash where `PhysicsMaterialData` wasn't instantiated