### PR TITLE
editor: ItemData/GameObject name synchronization

### DIFF
--- a/VisualPinball.Engine/IO/BiffData.cs
+++ b/VisualPinball.Engine/IO/BiffData.cs
@@ -158,7 +158,7 @@ namespace VisualPinball.Engine.IO
 				}
 			} catch (Exception e) {
 				if (obj is ItemData itemData) {
-					throw new Exception("Error parsing tag \"" + tag + "\" at \"" + itemData.GetName() + "\" (" + itemData.StorageName + ").", e);
+					throw new Exception("Error parsing tag \"" + tag + "\" at \"" + itemData.Name + "\" (" + itemData.StorageName + ").", e);
 				}
 				throw new Exception("Error parsing tag \"" + tag + "\".", e);
 			}

--- a/VisualPinball.Engine/VPT/Ball/Ball.cs
+++ b/VisualPinball.Engine/VPT/Ball/Ball.cs
@@ -7,7 +7,7 @@ namespace VisualPinball.Engine.VPT.Ball
 	public class Ball
 	{
 		public uint Id => Data.Id;
-		public string Name => Data.GetName();
+		public string Name => Data.Name;
 
 		public readonly BallData Data;
 		public readonly BallState State;

--- a/VisualPinball.Engine/VPT/Ball/BallData.cs
+++ b/VisualPinball.Engine/VPT/Ball/BallData.cs
@@ -32,9 +32,6 @@ namespace VisualPinball.Engine.VPT.Ball
 			// balls aren't persisted
 		}
 
-		public override string GetName()
-		{
-			return $"Ball{Id}";
-		}
+		public override string Name { get { return $"Ball{Id}"; } set { } }
 	}
 }

--- a/VisualPinball.Engine/VPT/BinaryData.cs
+++ b/VisualPinball.Engine/VPT/BinaryData.cs
@@ -16,13 +16,11 @@ namespace VisualPinball.Engine.VPT
 	[Serializable]
 	public class BinaryData : ItemData, IImageData
 	{
-		public override string GetName() => Name;
-
 		public byte[] Bytes => Data;
 		public byte[] FileContent => Data;
 
 		[BiffString("NAME", HasExplicitLength = true, Pos = 1)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffString("INME", Pos = 2)]
 		public string InternalName;

--- a/VisualPinball.Engine/VPT/Bumper/BumperData.cs
+++ b/VisualPinball.Engine/VPT/Bumper/BumperData.cs
@@ -17,10 +17,8 @@ namespace VisualPinball.Engine.VPT.Bumper
 	[Serializable]
 	public class BumperData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 17)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffVertex("VCEN", Pos = 1)]
 		public Vertex2D Center;

--- a/VisualPinball.Engine/VPT/Collection/CollectionData.cs
+++ b/VisualPinball.Engine/VPT/Collection/CollectionData.cs
@@ -16,10 +16,8 @@ namespace VisualPinball.Engine.VPT.Collection
 	[Serializable]
 	public class CollectionData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 1)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffString("ITEM", IsWideString = true, TagAll = true, Pos = 2)]
 		public string[] ItemNames;

--- a/VisualPinball.Engine/VPT/Decal/DecalData.cs
+++ b/VisualPinball.Engine/VPT/Decal/DecalData.cs
@@ -17,10 +17,8 @@ namespace VisualPinball.Engine.VPT.Decal
 	[Serializable]
 	public class DecalData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 7)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffVertex("VCEN", Pos = 1)]
 		public Vertex2D Center;

--- a/VisualPinball.Engine/VPT/DispReel/DispReelData.cs
+++ b/VisualPinball.Engine/VPT/DispReel/DispReelData.cs
@@ -17,10 +17,8 @@ namespace VisualPinball.Engine.VPT.DispReel
 	[Serializable]
 	public class DispReelData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 9)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffVertex("VER1", Pos = 1)]
 		public Vertex2D V1;

--- a/VisualPinball.Engine/VPT/Flasher/FlasherData.cs
+++ b/VisualPinball.Engine/VPT/Flasher/FlasherData.cs
@@ -18,10 +18,8 @@ namespace VisualPinball.Engine.VPT.Flasher
 	[Serializable]
 	public class FlasherData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 10)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffFloat("FHEI", Pos = 1)]
 		public float Height = 50.0f;

--- a/VisualPinball.Engine/VPT/Flipper/FlipperData.cs
+++ b/VisualPinball.Engine/VPT/Flipper/FlipperData.cs
@@ -21,10 +21,8 @@ namespace VisualPinball.Engine.VPT.Flipper
 	[BiffIgnore("RTHK")]
 	public class FlipperData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 14)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffFloat("BASR", Pos = 2)]
 		public float BaseRadius = 21.5f;

--- a/VisualPinball.Engine/VPT/Flipper/FlipperMover.cs
+++ b/VisualPinball.Engine/VPT/Flipper/FlipperMover.cs
@@ -148,11 +148,11 @@ namespace VisualPinball.Engine.VPT.Flipper
 				AngleSpeed = _angularMomentum / Inertia;
 
 				if (EnableRotateEvent > 0) {
-					Logger.Info("[{0}] Flipper is up", _data.GetName());
+					Logger.Info("[{0}] Flipper is up", _data.Name);
 					_events.FireVoidEventParam(EventId.LimitEventsEos, angleSpeed); // send EOS event
 
 				} else if (EnableRotateEvent < 0) {
-					Logger.Info("[{0}] Flipper is down", _data.GetName());
+					Logger.Info("[{0}] Flipper is down", _data.Name);
 					_events.FireVoidEventParam(EventId.LimitEventsBos, angleSpeed); // send Beginning of Stroke/Park event
 				}
 

--- a/VisualPinball.Engine/VPT/Gate/GateData.cs
+++ b/VisualPinball.Engine/VPT/Gate/GateData.cs
@@ -17,10 +17,8 @@ namespace VisualPinball.Engine.VPT.Gate
 	[Serializable]
 	public class GateData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 18)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffFloat("GAMA", Pos = 12)]
 		public float AngleMax = MathF.PI / 2.0f;

--- a/VisualPinball.Engine/VPT/HitTarget/HitTargetData.cs
+++ b/VisualPinball.Engine/VPT/HitTarget/HitTargetData.cs
@@ -17,10 +17,8 @@ namespace VisualPinball.Engine.VPT.HitTarget
 	[Serializable]
 	public class HitTargetData : ItemData, IPhysicalData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 6)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffFloat("PIDB", Pos = 20)]
 		public float DepthBias;

--- a/VisualPinball.Engine/VPT/Item.cs
+++ b/VisualPinball.Engine/VPT/Item.cs
@@ -8,7 +8,7 @@ namespace VisualPinball.Engine.VPT
 	{
 		public readonly TData Data;
 
-		public string Name => Data.GetName();
+		public string Name { get { return Data.Name; } set { Data.Name = value; } }
 		public int Index { get; set; }
 		public int Version { get; set; }
 

--- a/VisualPinball.Engine/VPT/ItemData.cs
+++ b/VisualPinball.Engine/VPT/ItemData.cs
@@ -26,7 +26,7 @@ namespace VisualPinball.Engine.VPT
 		[BiffBool("LVIS", Pos = 1003)]
 		public bool EditorLayerVisibility = true;
 
-		public abstract string GetName();
+		public abstract string Name { get; set; }
 
 		protected ItemData(string storageName) : base(storageName) { }
 	}

--- a/VisualPinball.Engine/VPT/Kicker/KickerData.cs
+++ b/VisualPinball.Engine/VPT/Kicker/KickerData.cs
@@ -18,10 +18,8 @@ namespace VisualPinball.Engine.VPT.Kicker
 	[Serializable]
 	public class KickerData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 8)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffInt("TYPE", Pos = 9)]
 		public int KickerType = VisualPinball.Engine.VPT.KickerType.KickerHole;

--- a/VisualPinball.Engine/VPT/Light/LightData.cs
+++ b/VisualPinball.Engine/VPT/Light/LightData.cs
@@ -18,10 +18,8 @@ namespace VisualPinball.Engine.VPT.Light
 	[BiffIgnore("PNTS")]
 	public class LightData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 15)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffVertex("VCEN", Pos = 1)]
 		public Vertex2D Center;

--- a/VisualPinball.Engine/VPT/LightSeq/LightSeqData.cs
+++ b/VisualPinball.Engine/VPT/LightSeq/LightSeqData.cs
@@ -16,10 +16,8 @@ namespace VisualPinball.Engine.VPT.LightSeq
 	[Serializable]
 	public class LightSeqData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 8)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffString("COLC", IsWideString = true, Pos = 2)]
 		public string Collection;

--- a/VisualPinball.Engine/VPT/Plunger/PlungerData.cs
+++ b/VisualPinball.Engine/VPT/Plunger/PlungerData.cs
@@ -16,10 +16,8 @@ namespace VisualPinball.Engine.VPT.Plunger
 	[Serializable]
 	public class PlungerData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 23)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffInt("TYPE", Pos = 8)]
 		public int Type = PlungerType.PlungerTypeModern;

--- a/VisualPinball.Engine/VPT/Primitive/PrimitiveData.cs
+++ b/VisualPinball.Engine/VPT/Primitive/PrimitiveData.cs
@@ -17,10 +17,8 @@ namespace VisualPinball.Engine.VPT.Primitive
 	[Serializable]
 	public class PrimitiveData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 15)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffVertex("VPOS", IsPadded = true, Pos = 1)]
 		public Vertex3D Position;

--- a/VisualPinball.Engine/VPT/Ramp/RampData.cs
+++ b/VisualPinball.Engine/VPT/Ramp/RampData.cs
@@ -17,10 +17,8 @@ namespace VisualPinball.Engine.VPT.Ramp
 	[Serializable]
 	public class RampData : ItemData, IPhysicalData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 9)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffFloat("RADB", Pos = 24)]
 		public float DepthBias = 0f;

--- a/VisualPinball.Engine/VPT/Rubber/RubberData.cs
+++ b/VisualPinball.Engine/VPT/Rubber/RubberData.cs
@@ -17,10 +17,8 @@ namespace VisualPinball.Engine.VPT.Rubber
 	[Serializable]
 	public class RubberData : ItemData, IPhysicalData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 8)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffFloat("HTTP", Pos = 1)]
 		public float Height = 25f;

--- a/VisualPinball.Engine/VPT/Sound/SoundData.cs
+++ b/VisualPinball.Engine/VPT/Sound/SoundData.cs
@@ -9,9 +9,7 @@ namespace VisualPinball.Engine.VPT.Sound
 	[Serializable]
 	public class SoundData : ItemData
 	{
-		public override string GetName() => Name;
-
-		public string Name;
+		public override string Name { get; set; }
 		public string Path;
 		public string InternalName;
 		public WaveFormat Wfx;

--- a/VisualPinball.Engine/VPT/Spinner/SpinnerData.cs
+++ b/VisualPinball.Engine/VPT/Spinner/SpinnerData.cs
@@ -17,10 +17,8 @@ namespace VisualPinball.Engine.VPT.Spinner
 	[Serializable]
 	public class SpinnerData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 16)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffVertex("VCEN", Pos = 1)]
 		public Vertex2D Center;

--- a/VisualPinball.Engine/VPT/Surface/SurfaceData.cs
+++ b/VisualPinball.Engine/VPT/Surface/SurfaceData.cs
@@ -17,10 +17,8 @@ namespace VisualPinball.Engine.VPT.Surface
 	[Serializable]
 	public class SurfaceData : ItemData, IPhysicalData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 16)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffBool("HTEV", Pos = 1)]
 		public bool HitEvent = false;

--- a/VisualPinball.Engine/VPT/Table/TableData.cs
+++ b/VisualPinball.Engine/VPT/Table/TableData.cs
@@ -16,10 +16,8 @@ namespace VisualPinball.Engine.VPT.Table
 	[Serializable]
 	public class TableData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 112)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffFloat("LEFT", Pos = 1)]
 		public float Left;

--- a/VisualPinball.Engine/VPT/TextBox/TextBoxData.cs
+++ b/VisualPinball.Engine/VPT/TextBox/TextBoxData.cs
@@ -17,10 +17,8 @@ namespace VisualPinball.Engine.VPT.TextBox
 	[Serializable]
 	public class TextBoxData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 9)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffVertex("VER1", Pos = 1)]
 		public Vertex2D V1;

--- a/VisualPinball.Engine/VPT/TextureData.cs
+++ b/VisualPinball.Engine/VPT/TextureData.cs
@@ -16,11 +16,10 @@ namespace VisualPinball.Engine.VPT
 	[Serializable]
 	public class TextureData : ItemData
 	{
-		public override string GetName() => Name;
 		public bool HasBitmap => Bitmap != null && Bitmap.Data != null && Bitmap.Data.Length > 0;
 
 		[BiffString("NAME", HasExplicitLength = true, Pos = 1)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffString("INME", Pos = 2)]
 		public string InternalName;

--- a/VisualPinball.Engine/VPT/Timer/TimerData.cs
+++ b/VisualPinball.Engine/VPT/Timer/TimerData.cs
@@ -16,10 +16,8 @@ namespace VisualPinball.Engine.VPT.Timer
 	[Serializable]
 	public class TimerData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 4)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffVertex("VCEN", Pos = 1)]
 		public Vertex2D Center;

--- a/VisualPinball.Engine/VPT/Trigger/TriggerData.cs
+++ b/VisualPinball.Engine/VPT/Trigger/TriggerData.cs
@@ -17,10 +17,8 @@ namespace VisualPinball.Engine.VPT.Trigger
 	[Serializable]
 	public class TriggerData : ItemData
 	{
-		public override string GetName() => Name;
-
 		[BiffString("NAME", IsWideString = true, Pos = 14)]
-		public string Name;
+		public override string Name { get; set; }
 
 		[BiffDragPoint("DPNT", TagAll = true, Pos = 2000)]
 		public DragPointData[] DragPoints;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/ItemInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/ItemInspector.cs
@@ -23,6 +23,11 @@ namespace VisualPinball.Unity.Editor.Inspectors
 		{
 			_table = (target as MonoBehaviour)?.gameObject.GetComponentInParent<TableBehavior>();
 			PopulateDropDownOptions();
+			EditorApplication.hierarchyChanged += OnHierarchyChange;
+		}
+		protected virtual void OnDisable()
+		{
+			EditorApplication.hierarchyChanged -= OnHierarchyChange;
 		}
 
 		protected void PopulateDropDownOptions()
@@ -44,6 +49,15 @@ namespace VisualPinball.Unity.Editor.Inspectors
 					_allTextures[i + 1] = _table.Textures[i].Name;
 				}
 				Array.Sort(_allTextures, 1, _allTextures.Length - 1);
+			}
+		}
+
+		protected virtual void OnHierarchyChange()
+		{
+			if (target is MonoBehaviour bh && target is IIdentifiableItemBehavior item) {
+				if (item.Name != bh.gameObject.name) {
+					item.Name = bh.gameObject.name;
+				}
 			}
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/IIdentifiableItemBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/IIdentifiableItemBehavior.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace VisualPinball.Unity.VPT
+{
+	public interface IIdentifiableItemBehavior
+	{
+		string Name { get; set; }
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemBehavior.cs
@@ -13,7 +13,7 @@ using Logger = NLog.Logger;
 
 namespace VisualPinball.Unity.VPT
 {
-	public abstract class ItemBehavior<TItem, TData> : MonoBehaviour, IEditableItemBehavior
+	public abstract class ItemBehavior<TItem, TData> : MonoBehaviour, IEditableItemBehavior, IIdentifiableItemBehavior
 		where TData : ItemData where TItem : Item<TData>, IRenderable
 	{
 		[SerializeField]
@@ -42,7 +42,7 @@ namespace VisualPinball.Unity.VPT
 
 		public ItemBehavior<TItem, TData> SetData(TData d, string gameObjectName = null)
 		{
-			name = gameObjectName ?? d.GetName();
+			name = gameObjectName ?? d.Name;
 			data = d;
 			ItemDataChanged();
 			return this;
@@ -56,7 +56,7 @@ namespace VisualPinball.Unity.VPT
 			}
 			var table = transform.GetComponentInParent<TableBehavior>();
 			if (table == null) {
-				_logger.Warn("Cannot retrieve table component from {0}, not updating meshes.", data.GetName());
+				_logger.Warn("Cannot retrieve table component from {0}, not updating meshes.", data.Name);
 				return;
 			}
 
@@ -183,5 +183,7 @@ namespace VisualPinball.Unity.VPT
 		protected abstract string[] Children { get; }
 
 		protected abstract TItem GetItem();
+
+		public string Name { get { return Item.Name; } set { Item.Name = value; } }
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableBehavior.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableBehavior.cs
@@ -225,7 +225,7 @@ namespace VisualPinball.Unity.VPT.Table
 		private static void Restore<TItem, TData>(IEnumerable<TData> src, IDictionary<string, TItem> dest, Func<TData, TItem> create) where TData : ItemData where TItem : Item<TData>
 		{
 			foreach (var d in src) {
-				dest[d.GetName()] = create(d);
+				dest[d.Name] = create(d);
 			}
 		}
 	}


### PR DESCRIPTION
- tested import/rename/export/reimport to/from VPX7 and items are renamed.
- Active ItemInspector is regisistered to EditorApplication.hierarchyChanged
- ItemData are renamed while changing the attached gameObject name
- Changed ItemData/Item/ItemBehavior name exposition (was readonly)
- no name-collision check yet (as Unity gameobject are identified by instanceID they don't care about name collision afaik)