### PR TITLE
Add more patcher features

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Toolbox/ToolboxEditor.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Toolbox/ToolboxEditor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.Game;
@@ -193,7 +194,8 @@ namespace VisualPinball.Unity.Editor
 		{
 			var tb = TableAuthoring;
 			var rog = renderable.GetRenderObjects(table, Origin.Original, false);
-			return VpxConverter.ConvertRenderObjects(renderable, rog, GetOrCreateParent(tb, rog), tb);
+			VpxConverter.ConvertRenderObjects(renderable, rog, GetOrCreateParent(tb, rog), tb, out var obj);
+			return obj;
 		}
 
 		private static GameObject GetOrCreateParent(Component tb, RenderObjectGroup rog)

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/Item/ItemMatchAttribute.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/Item/ItemMatchAttribute.cs
@@ -7,6 +7,11 @@ namespace VisualPinball.Unity.Patcher
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 	public abstract class ItemMatchAttribute : Attribute
 	{
+		/// <summary>
+		/// If set, pass the game object with this name as reference to the patcher.
+		/// </summary>
+		public string Ref;
+
 		public abstract bool Matches(Engine.VPT.Table.Table table, IRenderable item, RenderObject ro, GameObject obj);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/Item/RenderPipelineAttribute.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/Item/RenderPipelineAttribute.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using VisualPinball.Engine.Game;
+
+namespace VisualPinball.Unity.Patcher.Matcher.Item
+{
+	/// <summary>
+	/// Matches if the render pipeline is set to a given type.
+	/// </summary>
+	public class RenderPipelineAttribute : ItemMatchAttribute
+	{
+		private readonly RenderPipelineType _type;
+
+		public RenderPipelineAttribute(RenderPipelineType type)
+		{
+			_type = type;
+		}
+
+		public override bool Matches(Engine.VPT.Table.Table table, IRenderable item, RenderObject ro, GameObject obj)
+		{
+			return RenderPipeline.Current == _type;
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/Item/RenderPipelineAttribute.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/Item/RenderPipelineAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 60df9b98a21aebc4dbafe2ecb517bd7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/RenderPipeline.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/RenderPipeline.cs
@@ -1,0 +1,27 @@
+namespace VisualPinball.Unity.Patcher.Matcher
+{
+	public enum RenderPipelineType
+	{
+		BuiltIn,
+		Hdrp,
+		Urp
+	}
+
+	public static class RenderPipeline
+	{
+		public static RenderPipelineType Current
+		{
+			get { if (UnityEngine.Rendering.GraphicsSettings.renderPipelineAsset != null) {
+
+					if (UnityEngine.Rendering.GraphicsSettings.renderPipelineAsset.GetType().Name.Contains("UniversalRenderPipelineAsset")) {
+						return RenderPipelineType.Urp;
+					}
+
+					if (UnityEngine.Rendering.GraphicsSettings.renderPipelineAsset.GetType().Name.Contains("HDRenderPipelineAsset")) {
+						return RenderPipelineType.Hdrp;
+					}
+				}
+				return RenderPipelineType.BuiltIn; }
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/RenderPipeline.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/RenderPipeline.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3c9cce3a51fb264590e2801ea69b977
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/Table/RenderPipelineAttribute.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/Table/RenderPipelineAttribute.cs
@@ -1,0 +1,20 @@
+namespace VisualPinball.Unity.Patcher.Matcher.Table
+{
+	/// <summary>
+	/// Matches if the render pipeline is set to a given type.
+	/// </summary>
+	public class RenderPipelineAttribute : TableMatchAttribute
+	{
+		private readonly RenderPipelineType _type;
+
+		public RenderPipelineAttribute(RenderPipelineType type)
+		{
+			_type = type;
+		}
+
+		public override bool Matches(Engine.VPT.Table.Table table, string fileName)
+		{
+			return RenderPipeline.Current == _type;
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/Table/RenderPipelineAttribute.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/Table/RenderPipelineAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d843e35ea7645aa48b9b28957381b49c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/Table/TableNameMatchAttribute.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/Table/TableNameMatchAttribute.cs
@@ -1,0 +1,20 @@
+namespace VisualPinball.Unity.Patcher.Matcher.Table
+{
+	/// <summary>
+	/// Matches by table name (how the table is called in the script). <p/>
+	/// </summary>
+	public class TableNameMatchAttribute : TableMatchAttribute
+	{
+		private readonly string _name;
+
+		public TableNameMatchAttribute(string name)
+		{
+			_name = name;
+		}
+
+		public override bool Matches(Engine.VPT.Table.Table table, string fileName)
+		{
+			return _name == null || table.Data.Name == _name;
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/Table/TableNameMatchAttribute.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Matcher/Table/TableNameMatchAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 460d940b13b909742912dca08c9b7a2c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Common/Defaults.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Common/Defaults.cs
@@ -1,4 +1,6 @@
 using UnityEngine;
+using VisualPinball.Engine.Game;
+using VisualPinball.Engine.VPT.Table;
 
 namespace VisualPinball.Unity.Patcher
 {
@@ -22,6 +24,14 @@ namespace VisualPinball.Unity.Patcher
 		public void RemoveFlipperShadow(GameObject gameObject)
 		{
 			gameObject.GetComponent<MeshRenderer>().enabled = false;
+		}
+
+		[NameMatch("Wall1")]
+		public void ObjectTest(Table table, IRenderable item, GameObject gameObject)
+		{
+			Debug.Log("table = " + table);
+			Debug.Log("item = " + item);
+			Debug.Log("gameObject = " + gameObject);
 		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Common/Defaults.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Common/Defaults.cs
@@ -25,13 +25,5 @@ namespace VisualPinball.Unity.Patcher
 		{
 			gameObject.GetComponent<MeshRenderer>().enabled = false;
 		}
-
-		[NameMatch("Wall1")]
-		public void ObjectTest(Table table, IRenderable item, GameObject gameObject)
-		{
-			Debug.Log("table = " + table);
-			Debug.Log("item = " + item);
-			Debug.Log("gameObject = " + gameObject);
-		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/JurassicPark.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/JurassicPark.cs
@@ -8,8 +8,8 @@ namespace VisualPinball.Unity.Patcher
 	public class JurassicPark
 	{
 		/// <summary>
-		/// Removing the normal map. 
-		/// The normal map of the TRex Head is bad and contains invalid data. 
+		/// Removing the normal map.
+		/// The normal map of the TRex Head is bad and contains invalid data.
 		/// This causes the entire unity editor window to become black and the play mode flicker if normal map scale is higher than 0.
 		/// </summary>
 		/// <param name="gameObject"></param>
@@ -19,6 +19,22 @@ namespace VisualPinball.Unity.Patcher
 			var unityMat = gameObject.GetComponent<Renderer>().sharedMaterial;
 			unityMat.SetTexture("_NormalMap", null);
 			unityMat.DisableKeyword("_NORMALMAP");
+		}
+
+
+		[NameMatch("LFLogo", Ref="Flippers/LeftFlipper")]
+		[NameMatch("RFLogo", Ref="Flippers/RightFlipper")]
+		[NameMatch("RFLogo1", Ref="Flippers/UpperRightFlipper")]
+		public void ReparentFlippers(GameObject gameObject, ref GameObject parent)
+		{
+			var rot = gameObject.transform.rotation;
+			var pos = gameObject.transform.position;
+
+			// re-parent the child
+			gameObject.transform.SetParent(parent.transform, false);
+
+			gameObject.transform.rotation = rot;
+			gameObject.transform.position = pos;
 		}
 
 		[NameMatch("PLeftFlipper")]

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/TomAndJerry.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/TomAndJerry.cs
@@ -1,6 +1,7 @@
 ﻿// ReSharper disable StringLiteralTypo
 
 using UnityEngine;
+using VisualPinball.Engine.VPT.Primitive;
 using VisualPinball.Unity.Patcher.Matcher.Table;
 
 namespace VisualPinball.Unity.Patcher

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/TomAndJerry.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/TomAndJerry.cs
@@ -1,11 +1,11 @@
 ﻿// ReSharper disable StringLiteralTypo
 
 using UnityEngine;
+using VisualPinball.Unity.Patcher.Matcher.Table;
 
 namespace VisualPinball.Unity.Patcher
 {
-	// TODO Problem: the table has wrong meta info, we should adapt the metamatch
-	[MetaMatch(TableName = "Beach Bums (HH Mod - Gottlieb 1986)", AuthorName = "Retro Bash")]
+	[TableNameMatch("TomandJerry")]
 	public class TomAndJerry : Defaults
 	{
 		[NameMatch("ShadowsRamp")]

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/TomAndJerry.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/TomAndJerry.cs
@@ -6,7 +6,7 @@ using VisualPinball.Unity.Patcher.Matcher.Table;
 namespace VisualPinball.Unity.Patcher
 {
 	[TableNameMatch("TomandJerry")]
-	public class TomAndJerry : Defaults
+	public class TomAndJerry
 	{
 		[NameMatch("ShadowsRamp")]
 		[NameMatch("JerryHAMMERshadow")]

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/README.md
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/README.md
@@ -126,8 +126,8 @@ Let's look at how to apply this in the next section.
 ## Patcher
 
 Now we know how to match an item, let's create a patch. It's as easy as
-writing a `void` method in your patch class that takes in Unity's `GameObject`
-and decorate it with an item matcher.
+writing a `void` method in your patch class that takes in the objects you're
+interested in (see below), and decorate it with an item matcher.
 
 Let's take the name matcher from the example above and use it to hide the
 flipper shadows:
@@ -143,8 +143,38 @@ public void RemoveFlipperShadow(GameObject gameObject)
 
 Putting several attributes on a method means that it is matched if *at least 
 one* of the matchers matches (the same applies to the table matchers, by the 
-way). 
+way).
 
+You can pass different types in any order to the method. Supported types are:
+
+- `UnityEngine.GameObject` - Unity game object that was created for that game item.
+- `VisualPinball.Engine.VPT.Table.Table` - The table object for which the game 
+  item was created for
+- Any game item type, e.g. `VisualPinball.Engine.VPT.Flipper.Flipper` that 
+  extends `IItem`. If your matched game item is not of the type you've provided
+  in the method signature, the patch is skipped and a warning is printed.
+- `VisualPinball.Engine.Game.IRenderable` if you don't care about the item type
+  but still want to access something from the item.
+  
+## Built-in Matchers
+
+### Table Matchers
+
+- `[AnyMatch]` - Matches all tables
+- `[MetaMatch(string TableName, string AuthorName)]` - Matches a table  where 
+  `TableName` is the table name and `AuthorName` the (exact) string of the
+  authors field of the table's metadata.
+ - `[TableNameMatch(string name)]` - Matches a table by the table's game item
+  item name (also the table name in the table script).
+- `[RenderPipeline(RenderPipelineType rp)]` - Matches if the current render
+  pipeline is set to the given value.  
+
+### Item Matchers
+
+- `[NameMatch(string name)]` - Matches an item by its name.
+- `[RenderPipeline(RenderPipelineType rp)]` - Matches if the current render
+  pipeline is set to the given value.  
+  
 ## Summary
 
 For a new table:

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/README.md
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/README.md
@@ -155,6 +155,8 @@ You can pass different types in any order to the method. Supported types are:
   in the method signature, the patch is skipped and a warning is printed.
 - `VisualPinball.Engine.Game.IRenderable` if you don't care about the item type
   but still want to access something from the item.
+- `ref UnityEngine.GameObject` - Another game object, specified by the `Ref` 
+  field of the matcher (see *Advanced Features* below).  
   
 ## Built-in Matchers
 
@@ -173,8 +175,34 @@ You can pass different types in any order to the method. Supported types are:
 
 - `[NameMatch(string name)]` - Matches an item by its name.
 - `[RenderPipeline(RenderPipelineType rp)]` - Matches if the current render
-  pipeline is set to the given value.  
+  pipeline is set to the given value. 
   
+## Advanced Features
+
+You might need to find another game object during patching, and repeat this 
+over several patch methods. For that, you can use the matcher's `Ref` field,
+which is a search path for the game object you'd like to find. In the patch
+method, you can retrieve this using a `ref GameObject` parameter.
+
+For example, many tables use a primitive for the flipper, that we'd like to 
+re-parent to the actual flipper object. So we would do the following:
+
+```cs
+[NameMatch("RightFlipperPrimitive", Ref="Flippers/RightFlipper")]
+[NameMatch("LeftFlipperPrimitive", Ref="Flippers/LeftFlipper")]
+public void ReparentFlippers(GameObject gameObject, ref GameObject parent)
+{
+	var rot = gameObject.transform.rotation;
+	var pos = gameObject.transform.position;
+
+	// re-parent the child
+	gameObject.transform.SetParent(parent.transform, false);
+
+	gameObject.transform.rotation = rot;
+	gameObject.transform.position = pos;
+}  
+```
+
 ## Summary
 
 For a new table:

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/VisualPinball.Unity.Patcher.csproj
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/VisualPinball.Unity.Patcher.csproj
@@ -17,6 +17,9 @@
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>..\Plugins\.unity\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
+    <Reference Include="VisualPinball.Unity, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\vpe-2020.1\Library\ScriptAssemblies\VisualPinball.Unity.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\VisualPinball.Engine\VisualPinball.Engine.csproj" />

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/VisualPinball.Unity.Patcher.csproj
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/VisualPinball.Unity.Patcher.csproj
@@ -17,9 +17,6 @@
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>..\Plugins\.unity\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
-    <Reference Include="VisualPinball.Unity, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\..\vpe-2020.1\Library\ScriptAssemblies\VisualPinball.Unity.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\VisualPinball.Engine\VisualPinball.Engine.csproj" />

--- a/VisualPinball.Unity/VisualPinball.Unity/Extensions/MaterialExtensions.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Extensions/MaterialExtensions.cs
@@ -1,9 +1,12 @@
 ﻿// ReSharper disable StringLiteralTypo
 
+using System;
 using System.Text;
 using NLog;
 using VisualPinball.Engine.VPT;
+using VisualPinball.Unity.Patcher.Matcher;
 using Logger = NLog.Logger;
+using Material = UnityEngine.Material;
 
 namespace VisualPinball.Unity
 {
@@ -23,22 +26,20 @@ namespace VisualPinball.Unity
 		/// <returns></returns>
 		private static IMaterialConverter CreateMaterialConverter()
 		{
-			if (UnityEngine.Rendering.GraphicsSettings.renderPipelineAsset != null)
+			switch (RenderPipeline.Current)
 			{
-				if (UnityEngine.Rendering.GraphicsSettings.renderPipelineAsset.GetType().Name.Contains("UniversalRenderPipelineAsset"))
-				{
-					return new UrpMaterialConverter();
-				}
-				else if (UnityEngine.Rendering.GraphicsSettings.renderPipelineAsset.GetType().Name.Contains("HDRenderPipelineAsset"))
-				{
+				case RenderPipelineType.BuiltIn:
+					return new StandardMaterialConverter();
+				case RenderPipelineType.Hdrp:
 					return new HdrpMaterialConverter();
-				}
+				case RenderPipelineType.Urp:
+					return new UrpMaterialConverter();
+				default:
+					throw new ArgumentOutOfRangeException();
 			}
-
-			return new StandardMaterialConverter();
 		}
 
-		public static UnityEngine.Material ToUnityMaterial(this PbrMaterial vpxMaterial, TableAuthoring table, StringBuilder debug = null)
+		public static Material ToUnityMaterial(this PbrMaterial vpxMaterial, TableAuthoring table, StringBuilder debug = null)
 		{
 			if (table != null)
 			{

--- a/VisualPinball.Unity/VisualPinball.Unity/Import/VpxConverter.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Import/VpxConverter.cs
@@ -85,7 +85,7 @@ namespace VisualPinball.Unity
 			}
 
 			// import
-			ConvertGameItems();
+			ConvertGameItems(go);
 
 			// set root transformation
 			go.transform.localRotation = GlobalRotation;
@@ -118,13 +118,13 @@ namespace VisualPinball.Unity
 			return obj;
 		}
 
-		private void ConvertGameItems()
+		private void ConvertGameItems(GameObject tableGameObject)
 		{
 			// convert game objects
-			ConvertRenderables();
+			ConvertRenderables(tableGameObject);
 		}
 
-		private void ConvertRenderables()
+		private void ConvertRenderables(GameObject tableGameObject)
 		{
 			var createdObjs = new Dictionary<IRenderable, IEnumerable<Tuple<GameObject, RenderObject>>>();
 			foreach (var renderable in _renderObjects.Keys) {
@@ -140,7 +140,7 @@ namespace VisualPinball.Unity
 			// now we have all renderables imported, patch them.
 			foreach (var renderable in createdObjs.Keys) {
 				foreach (var (obj, ro) in createdObjs[renderable]) {
-					_tableAuthoring.Patcher.ApplyPatches(renderable, ro, obj);
+					_tableAuthoring.Patcher.ApplyPatches(renderable, ro, obj, tableGameObject);
 				}
 			}
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemAuthoring.cs
@@ -85,7 +85,6 @@ namespace VisualPinball.Unity
 								var subObj = new GameObject(ro.Name);
 								subObj.transform.SetParent(transform, false);
 								subObj.layer = VpxConverter.ChildObjectsLayer;
-								VpxConverter.ConvertRenderObject(Item, ro, subObj, table);
 							}
 						}
 					}


### PR DESCRIPTION
The patcher is now more flexible. Basically you can pull in more data when applying the patch, and there is a new matcher that matches by the script table name (`TableNameMatch`) and one by render pipeline (`RenderPipeline`). The [patcher's README](https://github.com/freezy/VisualPinball.Engine/tree/patcher/enhancements/VisualPinball.Unity/VisualPinball.Unity.Patcher#unity-patching-system) is updated, so you can check for details there, but the most relevant part is:

> You can pass different types in any order to the method. Supported types are:
> 
> - `UnityEngine.GameObject` - Unity game object that was created for that game item.
> - `VisualPinball.Engine.VPT.Table.Table` - The table object for which the game 
>   item was created for
> - Any game item type, e.g. `VisualPinball.Engine.VPT.Flipper.Flipper` that 
>   extends `IItem`. If your matched game item is not of the type you've provided
>   in the method signature, the patch is skipped and a warning is printed.
> - `VisualPinball.Engine.Game.IRenderable` if you don't care about the item type
>   but still want to access something from the item.

Additionally, patches are now all applied *after* all game items are created, which was necessary if a game item needs re-parenting (i.e. moved below another game item, which needs to exist).

This PR closes #145.