### PR TITLE
Port last collider: Hit3DPoly

### DIFF
--- a/VisualPinball.Engine/Game/PlayerPhysics.cs
+++ b/VisualPinball.Engine/Game/PlayerPhysics.cs
@@ -136,7 +136,6 @@ namespace VisualPinball.Engine.Game
 			//         this.HitTimers.Push(...Scriptable.GetApi()._getTimers());
 			// }
 
-			_hitObjects.AddRange(_table.GetHitShapes()); // these are the table's outer borders
 			_hitPlayfield = _table.GeneratePlayfieldHit();
 			_hitTopGlass = _table.GenerateGlassHit();
 

--- a/VisualPinball.Engine/Physics/HitTriangle.cs
+++ b/VisualPinball.Engine/Physics/HitTriangle.cs
@@ -42,7 +42,7 @@ namespace VisualPinball.Engine.Physics
 		public override float HitTest(Ball ball, float dTime, CollisionEvent coll, PlayerPhysics physics)
 		{
 			// not needed in unity ECS
-			throw new System.NotImplementedException();
+			return -1;
 		}
 
 		public override void Collide(CollisionEvent coll, PlayerPhysics physics)

--- a/VisualPinball.Engine/VPT/Primitive/PrimitiveHitGenerator.cs
+++ b/VisualPinball.Engine/VPT/Primitive/PrimitiveHitGenerator.cs
@@ -24,7 +24,7 @@ namespace VisualPinball.Engine.VPT.Primitive
 
 		public HitObject[] GenerateHitObjects(Table.Table table, PrimitiveMeshGenerator meshGenerator)
 		{
-			var hitObjects = new List<HitObject>();
+
 
 			if (_data.Name == "playfield_mesh") {
 				_data.IsVisible = false;
@@ -33,7 +33,7 @@ namespace VisualPinball.Engine.VPT.Primitive
 
 			// playfield can't be a toy
 			if (_data.IsToy && !_primitive.UseAsPlayfield) {
-				return hitObjects.ToArray();
+				return new HitObject[0];
 			}
 
 			var mesh = meshGenerator.GetTransformedMesh(table, Origin.Global, false);
@@ -48,6 +48,12 @@ namespace VisualPinball.Engine.VPT.Primitive
 				mesh = ComputeReducedMesh(mesh, reducedVertices);
 			}
 
+			return MeshToHitObjects(mesh, ItemType.Primitive).Select(ho => SetupHitObject(ho, table)).ToArray();
+		}
+
+		public static IEnumerable<HitObject> MeshToHitObjects(Mesh mesh, ItemType itemType)
+		{
+			var hitObjects = new List<HitObject>();
 			var addedEdges = new EdgeSet();
 
 			// add collision triangles and edges
@@ -64,19 +70,19 @@ namespace VisualPinball.Engine.VPT.Primitive
 					mesh.Vertices[i1].GetVertex(),
 				};
 
-				hitObjects.Add(new HitTriangle(rgv3D, ItemType.Primitive));
+				hitObjects.Add(new HitTriangle(rgv3D, itemType));
 
-				hitObjects.AddRange(addedEdges.AddHitEdge(i0, i1, rgv3D[0], rgv3D[2], ItemType.Primitive));
-				hitObjects.AddRange(addedEdges.AddHitEdge(i1, i2, rgv3D[2], rgv3D[1], ItemType.Primitive));
-				hitObjects.AddRange(addedEdges.AddHitEdge(i2, i0, rgv3D[1], rgv3D[0], ItemType.Primitive));
+				hitObjects.AddRange(addedEdges.AddHitEdge(i0, i1, rgv3D[0], rgv3D[2], itemType));
+				hitObjects.AddRange(addedEdges.AddHitEdge(i1, i2, rgv3D[2], rgv3D[1], itemType));
+				hitObjects.AddRange(addedEdges.AddHitEdge(i2, i0, rgv3D[1], rgv3D[0], itemType));
 			}
 
 			// add collision vertices
 			foreach (var vertex in mesh.Vertices) {
-				hitObjects.Add(new HitPoint(vertex.GetVertex(), ItemType.Primitive));
+				hitObjects.Add(new HitPoint(vertex.GetVertex(), itemType));
 			}
 
-			return hitObjects.Select(ho => SetupHitObject(ho, table)).ToArray();
+			return hitObjects;
 		}
 
 		private static Mesh ComputeReducedMesh(Mesh mesh, uint reducedVertices)

--- a/VisualPinball.Engine/VPT/Surface/SurfaceHitGenerator.cs
+++ b/VisualPinball.Engine/VPT/Surface/SurfaceHitGenerator.cs
@@ -51,10 +51,10 @@ namespace VisualPinball.Engine.VPT.Surface
 				hitObjects.AddRange(GenerateLinePolys(pv2, pv3, events, table));
 			}
 
-			hitObjects.Add(new Hit3DPoly(rgv3Dt, ItemType.Surface));
+			hitObjects.AddRange(new Hit3DPoly(rgv3Dt, ItemType.Surface).ConvertToTriangles());
 
 			if (rgv3Db != null) {
-				hitObjects.Add(new Hit3DPoly(rgv3Db, ItemType.Surface));
+				hitObjects.AddRange(new Hit3DPoly(rgv3Db, ItemType.Surface).ConvertToTriangles());
 			}
 
 			return hitObjects.ToArray();

--- a/VisualPinball.Engine/VPT/Table/Table.cs
+++ b/VisualPinball.Engine/VPT/Table/Table.cs
@@ -16,7 +16,7 @@ namespace VisualPinball.Engine.VPT.Table
 	/// A table contains all the playfield elements, as well as a set of
 	/// global data.
 	/// </summary>
-	public class Table : Item<TableData>, IRenderable
+	public class Table : Item<TableData>, IRenderable, IHittable
 	{
 		public CustomInfoTags CustomInfoTags { get; set; }
 		public int FileVersion { get; set; }
@@ -31,6 +31,9 @@ namespace VisualPinball.Engine.VPT.Table
 		public Rect3D BoundingBox => new Rect3D(Data.Left, Data.Right, Data.Top, Data.Bottom, TableHeight, GlassHeight);
 
 		public bool HasMeshAsPlayfield => _meshGenerator.HasMeshAsPlayfield;
+
+		public bool IsCollidable => true;
+		public EventProxy EventProxy { get; }
 
 		public readonly Dictionary<string, string> TableInfo = new Dictionary<string, string>();
 		public ITableResourceContainer<Texture> Textures = new DefaultTableResourceContainer<Texture>();
@@ -141,7 +144,7 @@ namespace VisualPinball.Engine.VPT.Table
 			.Concat(_gates.Values)
 			.Concat(_spinners.Values);
 
-		public IEnumerable<IHittable> Hittables => new IHittable[0]
+		public IEnumerable<IHittable> Hittables => new IHittable[] { this }
 			.Concat(_bumpers.Values)
 			.Concat(_flippers.Values)
 			.Concat(_gates.Values)
@@ -271,6 +274,10 @@ namespace VisualPinball.Engine.VPT.Table
 		}
 
 		#endregion
+
+		public void Init(Table table)
+		{
+		}
 
 		/// <summary>
 		/// Adds a game item to the table.
@@ -436,7 +443,8 @@ namespace VisualPinball.Engine.VPT.Table
 			return _meshGenerator.GetRenderObjects(table, origin, asRightHanded);
 		}
 
-		public IEnumerable<HitObject> GetHitShapes() => _hitGenerator.GenerateHitObjects();
+		public HitObject[] GetHitShapes() => _hitGenerator.GenerateHitObjects().ToArray();
+
 		public HitPlane GeneratePlayfieldHit() => _hitGenerator.GeneratePlayfieldHit();
 		public HitPlane GenerateGlassHit() => _hitGenerator.GenerateGlassHit();
 

--- a/VisualPinball.Engine/VPT/Table/TableHitGenerator.cs
+++ b/VisualPinball.Engine/VPT/Table/TableHitGenerator.cs
@@ -59,9 +59,14 @@ namespace VisualPinball.Engine.VPT.Table
 			};
 			var hit3DPoly = new Hit3DPoly(rgv3D, ItemType.Table);
 			hit3DPoly.CalcHitBBox();
-			hitObjects.Add(hit3DPoly);
+			hitObjects.AddRange(hit3DPoly.ConvertToTriangles());
 
-			return hitObjects.ToArray();
+			foreach (var hitObject in hitObjects) {
+				hitObject.ItemIndex = _table.Index;
+				hitObject.ItemVersion = _table.Version;
+			}
+
+			return hitObjects;
 		}
 
 		public HitPlane GeneratePlayfieldHit() {

--- a/VisualPinball.Engine/VPT/Trigger/TriggerHitGenerator.cs
+++ b/VisualPinball.Engine/VPT/Trigger/TriggerHitGenerator.cs
@@ -55,9 +55,7 @@ namespace VisualPinball.Engine.VPT.Trigger
 				hitObjects.Add(GetLineSeg(pv2, pv3, events, height));
 			}
 
-			hitObjects.Add( new Hit3DPoly(rgv3D, ItemType.Trigger) {
-				Obj = events
-			});
+			hitObjects.AddRange( new Hit3DPoly(rgv3D, ItemType.Trigger).ConvertToTriangles());
 
 			return hitObjects.ToArray();
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
@@ -11,6 +11,7 @@ using VisualPinball.Engine.VPT.Gate;
 using VisualPinball.Engine.VPT.HitTarget;
 using VisualPinball.Engine.VPT.Kicker;
 using VisualPinball.Engine.VPT.Plunger;
+using VisualPinball.Engine.VPT.Primitive;
 using VisualPinball.Engine.VPT.Ramp;
 using VisualPinball.Engine.VPT.Rubber;
 using VisualPinball.Engine.VPT.Spinner;
@@ -137,6 +138,14 @@ namespace VisualPinball.Unity
 			_tableApi.Triggers[trigger.Name] = triggerApi;
 			_initializables.Add(triggerApi);
 			_hittables[entity] = triggerApi;
+		}
+
+		public void RegisterPrimitive(Primitive primitive, Entity entity, GameObject go)
+		{
+			var primitiveApi = new PrimitiveApi(primitive, entity, this);
+			_tableApi.Primitives[primitive.Name] = primitiveApi;
+			_initializables.Add(primitiveApi);
+			_hittables[entity] = primitiveApi;
 		}
 
 		#endregion

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
@@ -82,9 +82,6 @@ namespace VisualPinball.Unity
 				case HitPoint hitPoint:
 					PointCollider.Create(builder, hitPoint, ref dest);
 					break;
-				case Hit3DPoly hit3DPoly:
-					Poly3DCollider.Create(builder, hit3DPoly, ref dest);
-					break;
 				case HitPlane hitPlane:
 					PlaneCollider.Create(builder, hitPlane, ref dest);
 					break;
@@ -98,7 +95,7 @@ namespace VisualPinball.Unity
 					TriangleCollider.Create(builder, hitTriangle, ref dest);
 					break;
 				default:
-					Logger.Warn("Unknown collider {0}, skipping.", src.GetType().Name);
+					Logger.Warn("Unsupported collider {0}, skipping.", src.GetType().Name);
 					break;
 			}
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveApi.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Unity.Entities;
+
+namespace VisualPinball.Unity
+{
+	public class PrimitiveApi : ItemApi<Engine.VPT.Primitive.Primitive, Engine.VPT.Primitive.PrimitiveData>,
+		IApiInitializable, IApiHittable
+	{
+		/// <summary>
+		/// Event emitted when the table is started.
+		/// </summary>
+		public event EventHandler Init;
+
+		/// <summary>
+		/// Event emitted when the ball glides on the primitive.
+		/// </summary>
+		public event EventHandler Hit;
+
+		internal PrimitiveApi(Engine.VPT.Primitive.Primitive item, Entity entity, Player player) : base(item, entity, player)
+		{
+		}
+
+		#region Events
+
+		void IApiInitializable.OnInit()
+		{
+			Init?.Invoke(this, EventArgs.Empty);
+		}
+
+		void IApiHittable.OnHit(bool _)
+		{
+			Hit?.Invoke(this, EventArgs.Empty);
+		}
+
+		#endregion
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveApi.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveApi.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 904a6384bbf86884ba39b465bc27cd41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveAuthoring.cs
@@ -19,6 +19,10 @@ namespace VisualPinball.Unity
 		public void Convert(Entity entity, EntityManager dstManager, GameObjectConversionSystem conversionSystem)
 		{
 			Convert(entity, dstManager);
+
+			// register
+			var primitive = GetComponent<PrimitiveAuthoring>().Item;
+			transform.GetComponentInParent<Player>().RegisterPrimitive(primitive, entity, gameObject);
 		}
 
 		protected override Primitive GetItem() => new Primitive(data);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableApi.cs
@@ -16,6 +16,7 @@ namespace VisualPinball.Unity
 		internal readonly Dictionary<string, SpinnerApi> Spinners = new Dictionary<string, SpinnerApi>();
 		internal readonly Dictionary<string, SurfaceApi> Surfaces = new Dictionary<string, SurfaceApi>();
 		internal readonly Dictionary<string, TriggerApi> Triggers = new Dictionary<string, TriggerApi>();
+		internal readonly Dictionary<string, PrimitiveApi> Primitives = new Dictionary<string, PrimitiveApi>();
 
 		/// <summary>
 		/// Event emitted before the game starts.


### PR DESCRIPTION
This implements the `Hit3DPoly` collider. It closes #123. Just to be clear what `Hit3DPoly` does: It's a 2D-polygon in the XY-plane and it collides with its surface, i.e. against the Z axis. It's only used in three cases:

- Surface: the ceiling and optionally the ground (depending on `IsBottomSolid`) of the surface
- Trigger: the surface under the trigger that kicks off the events.
- Playfield: the glass surface of the playfield

They way this is solved now is that instead of one dynamically sized polygon, we triangulate it and split it into triangles, edges and points. Like that we can keep the collider size static. 

The only problem is now the event check for the trigger, since one collider now doesn't know whether the ball has entered into the *combination* of all triangles. We could solve this by marking the triangle line segments as inner and outer. Then, only when an *outer* line is crossed, we update the `BallInsideOfBufferElement`s.

For the triangulation we're using Nick Gravelyn's [Triangulator](https://github.com/nickgravelyn/Triangulator). For generating the colliders out of the triangulated mesh, we're re-using the primitive's hit generator.

## TODO
- [ ] Fix trigger event
- [x] Clean up obsolete `Poly3DCollider` code