### PR TITLE
biffdata : fixed unserialized StoragePrefix 

### DIFF
--- a/VisualPinball.Engine/IO/BiffData.cs
+++ b/VisualPinball.Engine/IO/BiffData.cs
@@ -46,7 +46,7 @@ namespace VisualPinball.Engine.IO
 
 		public string StorageName => _storageName ?? $"{StoragePrefix}{StorageIndex}";
 
-		public readonly StoragePrefix StoragePrefix;
+		public StoragePrefix StoragePrefix;
 		public int StorageIndex;
 		public readonly List<UnknownBiffRecord> UnknownRecords = new List<UnknownBiffRecord>();
 		private readonly string _storageName;


### PR DESCRIPTION
- leading to StorageName duplication for GameItems/Sounds/Collections/Images at scene reload