### PR TITLE
sounds : SoundManager upgrades

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/SoundManager.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/SoundManager.cs
@@ -20,6 +20,7 @@ using UnityEngine;
 using UnityEditor;
 using VisualPinball.Engine.VPT.Sound;
 using VisualPinball.Engine.VPT;
+using VisualPinball.Unity.Editor.Utils;
 
 namespace VisualPinball.Unity.Editor
 {
@@ -29,7 +30,28 @@ namespace VisualPinball.Unity.Editor
 
 		private static readonly NLog.Logger Logger = LogManager.GetCurrentClassLogger();
 
+		/// <summary>
+		/// Sound positions display
+		/// </summary>
 		private bool _displaySoundPosition = true;
+		private bool _displayAllSounds = false;
+
+		/// <summary>
+		/// Auto framing, going to Top view and frame on whole table when focused to ease sound position visualization
+		/// </summary>
+		private bool _autoFrame = true;
+		private bool _needFraming = false;
+
+		/// <summary>
+		/// Table & selected sound position & size used for display
+		/// </summary>
+		private Vector3 _tableCenter = Vector3.zero;
+		private Vector2 _tableSize = Vector2.zero;
+		private Vector3 _selectedSoundPos = Vector3.zero;
+		private float  _selectedSoundSize = 0.0f;
+
+		private readonly Color _selectedColor = Color.yellow;
+		private readonly Color _unselectedColor = new Color(0.25f, 0.25f, 0.25f, 0.75f);
 
 		[MenuItem("Visual Pinball/Sound Manager", false, 104)]
 		public static void ShowWindow()
@@ -40,10 +62,20 @@ namespace VisualPinball.Unity.Editor
 		protected override void OnButtonBarGUI()
 		{
 			EditorGUI.BeginChangeCheck();
-			_displaySoundPosition = GUILayout.Toggle(_displaySoundPosition, "Display Sound Position");
+			_autoFrame = GUILayout.Toggle(_autoFrame, "Auto Framing", GUILayout.ExpandWidth(false));
+			if (EditorGUI.EndChangeCheck() && _autoFrame) {
+				_needFraming = true;
+			}
+
+			EditorGUI.BeginChangeCheck();
+			_displaySoundPosition = GUILayout.Toggle(_displaySoundPosition, "Display Sound Position", GUILayout.ExpandWidth(false));
+			if (_displaySoundPosition) {
+				_displayAllSounds = GUILayout.Toggle(_displayAllSounds, "Display All Sounds", GUILayout.ExpandWidth(false));
+			}
 			if (EditorGUI.EndChangeCheck()) {
 				SceneView.RepaintAll();
 			}
+
 		}
 
 		public static string[] _soundOutTypeStrings = {
@@ -75,23 +107,100 @@ namespace VisualPinball.Unity.Editor
 			SceneView.duringSceneGui -= OnSceneGUI;
 		}
 
-		private bool _shouldDisplaySoundPosition => (_table != null && _displaySoundPosition && _selectedItem != null && _selectedItem.SoundData.OutputTarget == SoundOutTypes.Table);
-
-		void OnSceneGUI(SceneView sceneView)
+		protected override void OnFocus()
 		{
-			//Draw the sound position based on Balance/Fade data
-			if (_shouldDisplaySoundPosition) {
-				var bb = _table.Item.BoundingBox;
-				var sndData = _selectedItem.SoundData;
-				Vector3 center = new Vector3((bb.Right - bb.Left) * 0.5f, (bb.Bottom - bb.Top) * 0.5f, (bb.ZHigh - bb.ZLow) * 0.5f);
-				center = _table.gameObject.transform.TransformPoint(center);
-				Vector3 size = new Vector3(bb.Width, bb.Height, bb.Depth);
-				size = _table.gameObject.transform.TransformVector(size);
-				center.x += size.x * 0.5f * sndData.Balance.PercentageToRatio();
-				center.z += size.z * 0.5f * sndData.Fade.PercentageToRatio();
+			base.OnFocus();
+
+			if (_table == null || _table.gameObject == null) return;
+
+			Selection.activeObject = _table.gameObject;
+
+			if (_autoFrame) {
+				_needFraming = true;
+			}
+
+			SceneView.RepaintAll();
+		}
+
+		private void OnLostFocus()
+		{
+			SceneView.RepaintAll();
+		}
+
+		private bool _shouldDisplaySoundPosition => (	_table != null && 
+														Event.current.type == EventType.Repaint &&
+														(EditorWindow.focusedWindow == this || (EditorWindow.focusedWindow == SceneView.lastActiveSceneView && Selection.activeObject == _table.gameObject)) && 
+														_displaySoundPosition && 
+														_selectedItem != null && 
+														_selectedItem.SoundData.OutputTarget == SoundOutTypes.Table);
+
+
+		//Draw the sound position based on Balance/Fade data
+		private void RenderSound(SoundData data, bool selected)
+		{
+			var sndPos = _tableCenter;
+			sndPos.x += _tableSize.x * 0.5f * data.Balance.PercentageToRatio();
+			sndPos.z += _tableSize.y * 0.5f * data.Fade.PercentageToRatio();
+
+			//Sphere size based on sound volume
+			var minSphereSize = 0.1f;
+			var maxSphereSize = 0.5f;
+			//Volume goes from -100 to 100 -> ratio
+			var sphereSizeRatio = (data.Volume + 100) * 0.005f;
+			var sphereSize = HandleUtility.GetHandleSize(_tableCenter) * (minSphereSize + (sphereSizeRatio * (maxSphereSize - minSphereSize)));
+			
+			//Soundwave
+			if (selected) {
 				Handles.color = Color.grey;
-				Handles.SphereHandleCap(-1, center, Quaternion.identity, HandleUtility.GetHandleSize(center) * 0.2f, EventType.Repaint);
-				Handles.DrawWireDisc(center, Vector3.up, Mathf.Repeat(Time.realtimeSinceStartup * 0.5f, size.magnitude * 0.25f));
+				Handles.DrawWireDisc(sndPos, Vector3.up, sphereSize + Mathf.Repeat(Time.realtimeSinceStartup * 0.5f, _tableSize.magnitude * 0.25f));
+			}
+
+			//SoundPos
+			Handles.color = selected ? _selectedColor : _unselectedColor;
+			Handles.SphereHandleCap(-1, sndPos, Quaternion.identity, sphereSize, EventType.Repaint);
+			if (selected) {
+				_selectedSoundPos = sndPos;
+				_selectedSoundSize = sphereSize;
+			}
+		}
+
+		private void OnSceneGUI(SceneView sceneView)
+		{
+			if (_table == null) return;
+
+			var bb = _table.Item.BoundingBox;
+			var sndData = _selectedItem.SoundData;
+			_tableCenter = new Vector3((bb.Right - bb.Left) * 0.5f, (bb.Bottom - bb.Top) * 0.5f, (bb.ZHigh - bb.ZLow) * 0.5f);
+			_tableCenter = _table.gameObject.transform.TransformPoint(_tableCenter);
+			Vector3 size = new Vector3(bb.Width, bb.Height, bb.Depth);
+			size = _table.gameObject.transform.TransformVector(size);
+			_tableSize.x = size.x;
+			_tableSize.y = size.z;
+
+			if (_shouldDisplaySoundPosition) {
+				if (_displayAllSounds) {
+					foreach (var snd in _table.Sounds) {
+						if (snd.Data != sndData) {
+							RenderSound(snd.Data, false);
+						}
+					}
+				}
+
+				RenderSound(sndData, true);
+
+				HandleUtility.Repaint();
+			}
+
+			//Ask for framing after _tableCenter calculation
+			if (_needFraming) {
+				//Frame to Top View 
+				SceneViewFramer.FrameObjects(Selection.objects);
+				var view = SceneView.lastActiveSceneView;
+				var quat = Quaternion.identity;
+				quat.SetLookRotation(Vector3.down);
+				view.LookAt(_tableCenter, quat, Mathf.Max(_tableSize.x, _tableSize.y) * 1.1f);
+
+				_needFraming = false;
 			}
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Utils/SceneViewFramer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Utils/SceneViewFramer.cs
@@ -26,6 +26,10 @@ namespace VisualPinball.Unity.Editor.Utils
 	{
 		public static void FrameObjects(Object[] objects, bool includeChildren = true, bool instant = false)
 		{
+			if (SceneView.lastActiveSceneView == null) {
+				return;
+			}
+
 			Bounds bounds = new Bounds();
 			foreach (var obj in objects) {
 				if (obj is UnityEngine.GameObject gameObj) {


### PR DESCRIPTION
- fixed sound position display in SceneView when manager unfocus, close https://github.com/freezy/VisualPinball.Engine/issues/187

- add a display all sounds toggle, selected sound still highlighted
- add an auto framing feature, automatically switch to top view & frame on table when focusing the soundmanager
- change sound position sphere radius regarding SoundData.Volume

![image](https://user-images.githubusercontent.com/13945459/94357971-a8652b00-009d-11eb-9260-3bfd36606f56.png)

![image](https://user-images.githubusercontent.com/13945459/94357973-ae5b0c00-009d-11eb-8c2d-ef6c456541bc.png)

Should close https://github.com/freezy/VisualPinball.Engine/issues/163
