### PR TITLE
Depth Prepass example for HDRP

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Common/PatcherUtil.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Common/PatcherUtil.cs
@@ -104,6 +104,34 @@ namespace VisualPinball.Unity.Patcher
 			}
 		}
 
+		public static void SetTransparentDepthPrepassEnabled(GameObject gameObject)
+		{
+			var material = gameObject.GetComponent<Renderer>().sharedMaterial;
+
+			switch (RenderPipeline.Current)
+			{
+				case RenderPipelineType.BuiltIn:
+				case RenderPipelineType.Urp:
+					Logger.Info("Not implemented for {0}: {1} for {2}", gameObject.name, "SetTransparentDepthPrepassEnabled", RenderPipeline.Current);
+					break;
+
+				case RenderPipelineType.Hdrp:
+					material.EnableKeyword("_DISABLE_SSR_TRANSPARENT");
+
+					material.SetInt("_TransparentDepthPrepassEnable", 1);
+					material.SetInt("_AlphaDstBlend", 10);
+					material.SetInt("_ZTestModeDistortion", 4);
+
+					material.SetShaderPassEnabled("TransparentDepthPrepass", true);
+					material.SetShaderPassEnabled("RayTracingPrepass", true);
+
+					break;
+
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+		}
+
 		/// <summary>
 		/// Set the AlphaCutOff value for the material of the gameobject.
 		/// </summary>

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/JurassicPark.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/JurassicPark.cs
@@ -58,6 +58,22 @@ namespace VisualPinball.Unity.Patcher
 			PatcherUtil.SetOpaque(gameObject);
 		}
 
+		[NameMatch("leftrail")]
+		[NameMatch("rightrail")]
+		[NameMatch("TrexMain")]
+		[NameMatch("sidewalls")]
+		public void SetDoubleSided(GameObject gameObject)
+		{
+			PatcherUtil.SetDoubleSided(gameObject);
+		}
+
+		[NameMatch("Primitive_SideWallReflect")]
+		[NameMatch("Primitive_SideWallReflect1")]
+		public void Hide(GameObject gameObject)
+		{
+			PatcherUtil.Hide(gameObject);
+		}
+
 		/// <summary>
 		/// Custom properties for the ramp:
 		/// * change opaque to transparent

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/JurassicPark.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/JurassicPark.cs
@@ -57,5 +57,49 @@ namespace VisualPinball.Unity.Patcher
 		{
 			PatcherUtil.SetOpaque(gameObject);
 		}
+
+		/// <summary>
+		/// Custom properties for the ramp:
+		/// * change opaque to transparent
+		/// * disable alpha clipping
+		/// * enable depth prepass
+		/// </summary>
+		/// <param name="gameObject"></param>
+		[NameMatch("Primitive_PlasticsRamp")]
+		public void ApplyRampSettings(GameObject gameObject)
+		{
+			var material = gameObject.GetComponent<Renderer>().sharedMaterial;
+
+			material.EnableKeyword("_BLENDMODE_PRESERVE_SPECULAR_LIGHTING");
+			material.EnableKeyword("_BLENDMODE_PRE_MULTIPLY");
+			material.EnableKeyword("_ENABLE_FOG_ON_TRANSPARENT");
+			material.EnableKeyword("_SURFACE_TYPE_TRANSPARENT");
+			material.EnableKeyword("_DISABLE_SSR_TRANSPARENT");
+			material.DisableKeyword("_ALPHATEST_ON");
+
+			material.SetInt("_DistortionSrcBlend", 1);
+			material.SetInt("_DistortionDstBlend", 1);
+			material.SetInt("_DistortionBlurSrcBlend", 1);
+			material.SetInt("_DistortionBlurDstBlend", 1);
+			material.SetInt("_StencilWriteMask", 6);
+			material.SetInt("_StencilWriteMaskGBuffer", 14);
+			material.SetInt("_StencilWriteMaskMV", 40);
+
+			material.SetInt("_AlphaCutoffEnable", 0);
+			material.SetInt("_TransparentDepthPrepassEnable", 1);
+			material.SetInt("_SurfaceType", 1);
+			material.SetInt("_BlendMode", 4);
+			material.SetInt("_DstBlend", 10);
+			material.SetInt("_AlphaDstBlend", 10);
+			material.SetInt("_ZWrite", 0);
+			material.SetInt("_ZTestDepthEqualForOpaque", 4);
+			material.SetInt("_ZTestGBuffer", 4);
+
+			material.SetShaderPassEnabled("TransparentDepthPrepass", true);
+			material.SetShaderPassEnabled("RayTracingPrepass", false);
+
+			material.renderQueue = 3000;
+
+		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/JurassicPark.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/JurassicPark.cs
@@ -69,6 +69,7 @@ namespace VisualPinball.Unity.Patcher
 
 		[NameMatch("Primitive_SideWallReflect")]
 		[NameMatch("Primitive_SideWallReflect1")]
+		[NameMatch("Primitive_PlasticWhitePart")] // bug in the table, sticks out from the ramp; doesn't contribute anyway to the table
 		public void Hide(GameObject gameObject)
 		{
 			PatcherUtil.Hide(gameObject);

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/JurassicPark.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/JurassicPark.cs
@@ -98,7 +98,7 @@ namespace VisualPinball.Unity.Patcher
 			material.SetShaderPassEnabled("TransparentDepthPrepass", true);
 			material.SetShaderPassEnabled("RayTracingPrepass", false);
 
-			material.renderQueue = 3000;
+			material.renderQueue = (int) UnityEngine.Rendering.RenderQueue.Transparent;
 
 		}
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/Mississippi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/Mississippi.cs
@@ -1,0 +1,57 @@
+﻿// Visual Pinball Engine
+// Copyright (C) 2020 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// ReSharper disable StringLiteralTypo
+
+using UnityEngine;
+using VisualPinball.Unity.Patcher.Matcher.Table;
+
+namespace VisualPinball.Unity.Patcher
+{
+	[MetaMatch(TableName = "Mississipi", AuthorName = "jpsalas, akiles50000, Loserman")]
+	public class Mississippi
+	{
+		[NameMatch("lrail1", Ref = "Ramps/lrail1/LeftWall")] // left outside wall to the left
+		[NameMatch("rrail1", Ref = "Ramps/rrail1/LeftWall")] // left inside wall to the right
+		public void SetDoubleSided(GameObject gameObject, ref GameObject child)
+		{
+			if (gameObject == child)
+				PatcherUtil.SetDoubleSided(gameObject);
+		}
+
+		/// <summary>
+		/// Activate depth prepass or else the image visibility changes depending on distance
+		/// </summary>
+		/// <param name="gameObject"></param>
+		/// <param name="child"></param>
+		[NameMatch("wall13", Ref = "Surfaces/wall13/Top")]
+		[NameMatch("wall14", Ref = "Surfaces/wall14/Top")]
+		[NameMatch("wall15", Ref = "Surfaces/wall15/Top")]
+		[NameMatch("wall18", Ref = "Surfaces/wall18/Top")]
+		[NameMatch("wall19", Ref = "Surfaces/wall19/Top")]
+		[NameMatch("wall22", Ref = "Surfaces/wall22/Top")]
+		[NameMatch("wall23", Ref = "Surfaces/wall23/Top")]
+		[NameMatch("wall359", Ref = "Surfaces/wall359/Top")]
+		[NameMatch("apron", Ref = "Surfaces/apron/Top")]
+		public void SetTransparentDepthPrepassEnabled(GameObject gameObject, ref GameObject child)
+		{
+			if (gameObject == child)
+			{
+				PatcherUtil.SetTransparentDepthPrepassEnabled(gameObject);
+			}
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/Mississippi.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/Mississippi.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe1e47b630735fc4c8fc80dbe2e65b3a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* patcher for Mississippi table. required depth prepass enabled or else the images wouldn't be shown from a distance