### PR TITLE
Enter playmode faster

### DIFF
--- a/VisualPinball.Engine/Game/IHittable.cs
+++ b/VisualPinball.Engine/Game/IHittable.cs
@@ -23,5 +23,6 @@ namespace VisualPinball.Engine.Game
 		int Index { get; }
 		int Version { get; }
 		HitObject[] GetHitShapes();
+		bool IsCollidable { get; }
 	}
 }

--- a/VisualPinball.Engine/VPT/Bumper/Bumper.cs
+++ b/VisualPinball.Engine/VPT/Bumper/Bumper.cs
@@ -55,5 +55,6 @@ namespace VisualPinball.Engine.VPT.Bumper
 		}
 
 		public HitObject[] GetHitShapes() => _hits;
+		public bool IsCollidable => Data.IsCollidable;
 	}
 }

--- a/VisualPinball.Engine/VPT/Flipper/Flipper.cs
+++ b/VisualPinball.Engine/VPT/Flipper/Flipper.cs
@@ -53,5 +53,6 @@ namespace VisualPinball.Engine.VPT.Flipper
 		}
 
 		public HitObject[] GetHitShapes() => new HitObject[] { _hit };
+		public bool IsCollidable => true;
 	}
 }

--- a/VisualPinball.Engine/VPT/Gate/Gate.cs
+++ b/VisualPinball.Engine/VPT/Gate/Gate.cs
@@ -71,5 +71,6 @@ namespace VisualPinball.Engine.VPT.Gate
 				.Concat(_hitCircles ?? new HitObject[0])
 				.ToArray();
 		}
+		public bool IsCollidable => Data.IsCollidable;
 	}
 }

--- a/VisualPinball.Engine/VPT/HitTarget/HitTarget.cs
+++ b/VisualPinball.Engine/VPT/HitTarget/HitTarget.cs
@@ -55,5 +55,7 @@ namespace VisualPinball.Engine.VPT.HitTarget
 		{
 			return _meshGenerator.GetRenderObjects(table, origin, asRightHanded);
 		}
+
+		public bool IsCollidable => Data.IsCollidable;
 	}
 }

--- a/VisualPinball.Engine/VPT/Kicker/Kicker.cs
+++ b/VisualPinball.Engine/VPT/Kicker/Kicker.cs
@@ -61,10 +61,9 @@ namespace VisualPinball.Engine.VPT.Kicker
 			return _meshGenerator.GetRenderObjects(table, origin, asRightHanded);
 		}
 
-		public HitObject[] GetHitShapes()
-		{
-			return new HitObject[] {_hit};
-		}
+		public HitObject[] GetHitShapes() => new HitObject[] {_hit};
+
+		public bool IsCollidable => Data.IsEnabled;
 
 		public Vertex3D GetBallCreationPosition(Table.Table table)
 		{

--- a/VisualPinball.Engine/VPT/Plunger/Plunger.cs
+++ b/VisualPinball.Engine/VPT/Plunger/Plunger.cs
@@ -62,5 +62,6 @@ namespace VisualPinball.Engine.VPT.Plunger
 		}
 
 		public HitObject[] GetHitShapes() => _hitObjects;
+		public bool IsCollidable => true;
 	}
 }

--- a/VisualPinball.Engine/VPT/Primitive/Primitive.cs
+++ b/VisualPinball.Engine/VPT/Primitive/Primitive.cs
@@ -64,6 +64,7 @@ namespace VisualPinball.Engine.VPT.Primitive
 			_meshGenerator.GetRenderObjects(table, origin, asRightHanded);
 
 		public HitObject[] GetHitShapes() => _hits;
+		public bool IsCollidable => !Data.IsToy && Data.IsCollidable;
 
 		public Mesh GetMesh() => _meshGenerator.GetMesh();
 

--- a/VisualPinball.Engine/VPT/Ramp/Ramp.cs
+++ b/VisualPinball.Engine/VPT/Ramp/Ramp.cs
@@ -65,6 +65,8 @@ namespace VisualPinball.Engine.VPT.Ramp
 			return _meshGenerator.GetRenderObjects(table, asRightHanded);
 		}
 
+		public bool IsCollidable => Data.IsCollidable;
+
 		public float GetSurfaceHeight(float x, float y, Table.Table table)
 		{
 			var vVertex = _meshGenerator.GetCentralCurve(table);

--- a/VisualPinball.Engine/VPT/Rubber/Rubber.cs
+++ b/VisualPinball.Engine/VPT/Rubber/Rubber.cs
@@ -65,6 +65,8 @@ namespace VisualPinball.Engine.VPT.Rubber
 			return _meshGenerator.GetRenderObjects(table, origin, asRightHanded);
 		}
 
+		public bool IsCollidable => Data.IsCollidable;
+
 		public void Init(Table.Table table)
 		{
 			_hits = _hitGenerator.GenerateHitObjects(table, this);

--- a/VisualPinball.Engine/VPT/Spinner/Spinner.cs
+++ b/VisualPinball.Engine/VPT/Spinner/Spinner.cs
@@ -68,5 +68,6 @@ namespace VisualPinball.Engine.VPT.Spinner
 				.Concat(_hitCircles)
 				.ToArray();
 		}
+		public bool IsCollidable => true;
 	}
 }

--- a/VisualPinball.Engine/VPT/Surface/Surface.cs
+++ b/VisualPinball.Engine/VPT/Surface/Surface.cs
@@ -26,6 +26,7 @@ namespace VisualPinball.Engine.VPT.Surface
 		public override string ItemType => "Wall";
 
 		public HitObject[] GetHitShapes() => _hits;
+		public bool IsCollidable => Data.IsCollidable;
 
 		private readonly SurfaceMeshGenerator _meshGenerator;
 		private readonly SurfaceHitGenerator _hitGenerator;

--- a/VisualPinball.Engine/VPT/Table/Table.cs
+++ b/VisualPinball.Engine/VPT/Table/Table.cs
@@ -456,6 +456,7 @@ namespace VisualPinball.Engine.VPT.Table
 		}
 
 		public HitObject[] GetHitShapes() => _hitGenerator.GenerateHitObjects(this).ToArray();
+		public bool IsCollidable => true;
 
 		public HitPlane GeneratePlayfieldHit() => _hitGenerator.GeneratePlayfieldHit(this);
 		public HitPlane GenerateGlassHit() => _hitGenerator.GenerateGlassHit(this);

--- a/VisualPinball.Engine/VPT/Trigger/Trigger.cs
+++ b/VisualPinball.Engine/VPT/Trigger/Trigger.cs
@@ -26,6 +26,7 @@ namespace VisualPinball.Engine.VPT.Trigger
 		public override string ItemType => "Trigger";
 
 		public HitObject[] GetHitShapes() => _hits;
+		public bool IsCollidable => Data.IsEnabled;
 
 		private readonly TriggerMeshGenerator _meshGenerator;
 		private readonly TriggerHitGenerator _hitGenerator;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/PlayerInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/PlayerInspector.cs
@@ -14,8 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+using System.Linq;
 using UnityEditor;
-using UnityEngine;
+using VisualPinball.Engine.Common;
 
 namespace VisualPinball.Unity.Editor
 {
@@ -23,14 +24,52 @@ namespace VisualPinball.Unity.Editor
 	[CanEditMultipleObjects]
 	public class PlayerInspector : UnityEditor.Editor
 	{
+		private IPhysicsEngine[] _physicsEngines;
+		private string[] _physicsEngineNames;
+		private int _physicsEngineIndex;
+
+		private IDebugUI[] _debugUIs;
+		private string[] _debugUINames;
+		private int _debugUIIndex;
+
 		public override void OnInspectorGUI()
 		{
-			// if (EditorApplication.isPlaying) {
-			// 	if (GUILayout.Button("Spawn Ball")) {
-			// 		var player = (Player) target;
-			// 		player.CreateBall(new DebugBallCreator(), Entity.Null);
-			// 	}
-			// }
+			var player = (Player) target;
+			if (player == null) {
+				return;
+			}
+			DrawEngineSelector("Physics Engine", ref player.physicsEngineId, ref _physicsEngines, ref _physicsEngineNames, ref _physicsEngineIndex);
+			DrawEngineSelector("Debug UI", ref player.debugUiId, ref _debugUIs, ref _debugUINames, ref _debugUIIndex);
+		}
+
+		private void DrawEngineSelector<T>(string engineName, ref string engineId, ref T[] instances, ref string[] names, ref int index) where T : IEngine
+		{
+			if (instances == null) {
+				// get all instances
+				instances = EngineProvider<T>.GetAll().ToArray();
+				names = instances.Select(x => x.Name).ToArray();
+
+				// set the current index based on the table's ID
+				index = -1;
+				for (var i = 0; i < instances.Length; i++) {
+					if (EngineProvider<T>.GetId(instances[i]) == engineId) {
+						index = i;
+						break;
+					}
+				}
+				if (instances.Length > 0 && index < 0) {
+					index = 0;
+					engineId = EngineProvider<T>.GetId(instances[index]);
+				}
+			}
+			if (names.Length == 0) {
+				return;
+			}
+			var newIndex = EditorGUILayout.Popup(engineName, index, names);
+			if (index != newIndex) {
+				index = newIndex;
+				engineId = EngineProvider<T>.GetId(instances[newIndex]);
+			}
 		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/TableInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/TableInspector.cs
@@ -29,22 +29,11 @@ namespace VisualPinball.Unity.Editor
 	[CanEditMultipleObjects]
 	public class TableInspector : ItemInspector
 	{
-		private IPhysicsEngine[] _physicsEngines;
-		private string[] _physicsEngineNames;
-		private int _physicsEngineIndex;
-
-		private IDebugUI[] _debugUIs;
-		private string[] _debugUINames;
-		private int _debugUIIndex;
-
 		public override void OnInspectorGUI()
 		{
 			OnPreInspectorGUI();
 
 			var tableComponent = (TableAuthoring) target;
-			DrawEngineSelector("Physics Engine", ref tableComponent.physicsEngineId, ref _physicsEngines, ref _physicsEngineNames, ref _physicsEngineIndex);
-			DrawEngineSelector("Debug UI", ref tableComponent.debugUiId, ref _debugUIs, ref _debugUINames, ref _debugUIIndex);
-
 			if (!EditorApplication.isPlaying) {
 				DrawDefaultInspector();
 				if (GUILayout.Button("Export VPX")) {
@@ -62,36 +51,6 @@ namespace VisualPinball.Unity.Editor
 			}
 
 			base.OnInspectorGUI();
-		}
-
-		private void DrawEngineSelector<T>(string engineName, ref string engineId, ref T[] instances, ref string[] names, ref int index) where T : IEngine
-		{
-			if (instances == null) {
-				// get all instances
-				instances = EngineProvider<T>.GetAll().ToArray();
-				names = instances.Select(x => x.Name).ToArray();
-
-				// set the current index based on the table's ID
-				index = -1;
-				for (var i = 0; i < instances.Length; i++) {
-					if (EngineProvider<T>.GetId(instances[i]) == engineId) {
-						index = i;
-						break;
-					}
-				}
-				if (instances.Length > 0 && index < 0) {
-					index = 0;
-					engineId = EngineProvider<T>.GetId(instances[index]);
-				}
-			}
-			if (names.Length == 0) {
-				return;
-			}
-			var newIndex = EditorGUILayout.Popup(engineName, index, names);
-			if (index != newIndex) {
-				index = newIndex;
-				engineId = EngineProvider<T>.GetId(instances[newIndex]);
-			}
 		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Common/Defaults.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Common/Defaults.cs
@@ -41,5 +41,13 @@ namespace VisualPinball.Unity.Patcher
 		{
 			gameObject.GetComponent<MeshRenderer>().enabled = false;
 		}
+
+		[NameMatch("Ruler_mm")]
+		[NameMatch("Ruler_inches")]
+		[NameMatch("Ruler_inches_and_mm")]
+		public void RemoveColliders(GameObject gameObject)
+		{
+			gameObject.SetActive(false);
+		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/VisualPinballSimulationSystemGroup.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/VisualPinballSimulationSystemGroup.cs
@@ -82,7 +82,6 @@ namespace VisualPinball.Unity
 		{
 			_currentPhysicsTime = GetTargetTime();
 			_nextPhysicsFrameTime = _currentPhysicsTime + PhysicsConstants.PhysicsStepTime;
-			BallManager.Init();
 		}
 
 		protected override void OnUpdate()

--- a/VisualPinball.Unity/VisualPinball.Unity/Input/InputManager.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Input/InputManager.cs
@@ -109,8 +109,13 @@ namespace VisualPinball.Unity
 		public void Enable(Action<object, InputActionChange> action)
 		{
 			_asset.Enable();
-
 			InputSystem.onActionChange += action;
+		}
+
+		public void Disable(Action<object, InputActionChange> action)
+		{
+			InputSystem.onActionChange -= action;
+			_asset.Disable();
 		}
 
 		public List<string> GetActionMapNames()

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/QuadTreeCreationSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/QuadTreeCreationSystem.cs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System.Collections.Generic;
+using System.Linq;
 using NLog;
 using Unity.Entities;
 using UnityEngine;

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/QuadTreeCreationSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/QuadTreeCreationSystem.cs
@@ -36,9 +36,10 @@ namespace VisualPinball.Unity
 			}
 
 			// index hittables
+			var hittables = table.Hittables.Where(hittable => hittable.IsCollidable).ToArray();
 			var hitObjects = new List<HitObject>();
 			var id = 0;
-			foreach (var item in table.Hittables) {
+			foreach (var item in hittables) {
 				foreach (var hitObject in item.GetHitShapes()) {
 					hitObject.SetIndex(item.Index, item.Version);
 					hitObject.Id = id++;

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Engine/IPhysicsEngine.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Engine/IPhysicsEngine.cs
@@ -34,7 +34,8 @@ namespace VisualPinball.Unity
 		/// themselves when this method is called.
 		/// </remarks>
 		/// <param name="tableAuthoring"></param>
-		void Init(TableAuthoring tableAuthoring);
+		/// <param name="ballManager"></param>
+		void Init(TableAuthoring tableAuthoring, BallManager ballManager);
 
 		/// <summary>
 		/// Create a new ball and returns its entity.

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/SystemGroup/SimulateCycleSystemGroup.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/SystemGroup/SimulateCycleSystemGroup.cs
@@ -60,12 +60,14 @@ namespace VisualPinball.Unity
 		private EntityQuery _collisionEventDataQuery;
 
 		private readonly Stopwatch _simulationTime = new Stopwatch();
+		private VisualPinballSimulationSystemGroup _simulationSystemGroup;
 
 		protected override void OnCreate()
 		{
 			_flipperDataQuery = EntityManager.CreateEntityQuery(ComponentType.ReadOnly<FlipperMovementData>(), ComponentType.ReadOnly<FlipperStaticData>());
 			_collisionEventDataQuery = EntityManager.CreateEntityQuery(ComponentType.ReadOnly<CollisionEventData>());
 
+			_simulationSystemGroup = World.GetExistingSystem<VisualPinballSimulationSystemGroup>();
 			_staticBroadPhaseSystem = World.GetOrCreateSystem<StaticBroadPhaseSystem>();
 			_dynamicBroadPhaseSystem = World.GetOrCreateSystem<DynamicBroadPhaseSystem>();
 			_staticNarrowPhaseSystem = World.GetOrCreateSystem<StaticNarrowPhaseSystem>();
@@ -102,10 +104,8 @@ namespace VisualPinball.Unity
 		{
 			_simulationTime.Restart();
 
-			var sim = World.GetExistingSystem<VisualPinballSimulationSystemGroup>();
-
 			_staticCounts = PhysicsConstants.StaticCnts;
-			var dTime = sim.PhysicsDiffTime;
+			var dTime = _simulationSystemGroup.PhysicsDiffTime;
 			var numSteps = 0;
 			while (dTime > 0) {
 
@@ -140,7 +140,7 @@ namespace VisualPinball.Unity
 			if (EngineProvider<IDebugUI>.Exists) {
 				PhysicsEngine.UpdateDebugFlipperStates();
 				PhysicsEngine.PushPendingCreateBallNotifications();
-				EngineProvider<IDebugUI>.Get().OnPhysicsUpdate(sim.CurrentPhysicsTime, numSteps, (float)_simulationTime.Elapsed.TotalMilliseconds);
+				EngineProvider<IDebugUI>.Get().OnPhysicsUpdate(_simulationSystemGroup.CurrentPhysicsTime, numSteps, (float)_simulationTime.Elapsed.TotalMilliseconds);
 			}
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/SystemGroup/SimulateCycleSystemGroup.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/SystemGroup/SimulateCycleSystemGroup.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Unity.Collections;
 using Unity.Entities;
-using Unity.Jobs;
 using VisualPinball.Engine.Common;
 
 namespace VisualPinball.Unity
@@ -43,7 +42,6 @@ namespace VisualPinball.Unity
 
 		public override IEnumerable<ComponentSystemBase> Systems => _systemsToUpdate;
 		public NativeList<ContactBufferElement> Contacts;
-		public JobHandle ContactsDependencies;
 
 		private readonly List<ComponentSystemBase> _systemsToUpdate = new List<ComponentSystemBase>();
 
@@ -61,7 +59,7 @@ namespace VisualPinball.Unity
 		private EntityQuery _flipperDataQuery;
 		private EntityQuery _collisionEventDataQuery;
 
-		private Stopwatch _simulationTime = new Stopwatch();
+		private readonly Stopwatch _simulationTime = new Stopwatch();
 
 		protected override void OnCreate()
 		{
@@ -148,11 +146,7 @@ namespace VisualPinball.Unity
 
 		private void ClearContacts()
 		{
-			// if (contacts.Length > 0) {
-			// 	Debug.Break();
-			// }
-
-			Contacts.Clear();;
+			Contacts.Clear();
 		}
 
 		private void ApplyFlipperTime()

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallManager.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallManager.cs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+using System;
 using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Rendering;
@@ -23,37 +24,30 @@ using UnityEngine.Rendering;
 using VisualPinball.Engine.Common;
 using VisualPinball.Engine.Game;
 using VisualPinball.Engine.VPT.Table;
+using Object = UnityEngine.Object;
 
 namespace VisualPinball.Unity
 {
 	/// <summary>
 	/// A singleton class that handles ball creation and destruction.
 	/// </summary>
+	[Serializable]
 	public class BallManager
 	{
-		public static int NumBallsCreated { get; private set; }
-		public static int NumBalls { get; private set; }
+		public int NumBallsCreated { get; private set; }
+		public int NumBalls { get; private set; }
 
 		private readonly Table _table;
 		private readonly Matrix4x4 _ltw;
 
 		private static EntityManager EntityManager => World.DefaultGameObjectInjectionWorld.EntityManager;
 
-		private static BallManager _instance;
 		private static Mesh _unitySphereMesh; // used to cache ball mesh from GameObject
-
-		public static BallManager Instance(Table table, Matrix4x4 ltw) => _instance ?? (_instance = new BallManager(table, ltw));
 
 		public BallManager(Table table, Matrix4x4 ltw)
 		{
 			_table = table;
 			_ltw = ltw;
-		}
-
-		public static void Init()
-		{
-			NumBallsCreated = 0;
-			NumBalls = 0;
 		}
 
 		public void CreateBall(IBallCreationPosition ballCreator, float radius = 25f, float mass = 1f)
@@ -83,7 +77,7 @@ namespace VisualPinball.Unity
 				.BallCreate(mesh, material, worldPos, localPos, localVel, scale, mass, radius, in kickerRef);
 		}
 
-		public static void CreateEntity(Mesh mesh, Material material, in float3 worldPos, in float3 localPos,
+		public void CreateEntity(Mesh mesh, Material material, in float3 worldPos, in float3 localPos,
 			in float3 localVel, in float scale, in float mass, in float radius, in Entity kickerEntity)
 		{
 			var world = World.DefaultGameObjectInjectionWorld;
@@ -166,7 +160,7 @@ namespace VisualPinball.Unity
 			NumBalls++;
 		}
 
-		public static void DestroyEntity(Entity ballEntity)
+		public void DestroyEntity(Entity ballEntity)
 		{
 			World.DefaultGameObjectInjectionWorld
 				.GetOrCreateSystem<CreateBallEntityCommandBufferSystem>()

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperApi.cs
@@ -41,7 +41,7 @@ namespace VisualPinball.Unity
 
 		#region Events
 
-		void IApiInitializable.OnInit()
+		void IApiInitializable.OnInit(BallManager ballManager)
 		{
 			Init?.Invoke(this, EventArgs.Empty);
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperApi.cs
@@ -85,7 +85,7 @@ namespace VisualPinball.Unity
 
 		#region Events
 
-		void IApiInitializable.OnInit()
+		void IApiInitializable.OnInit(BallManager ballManager)
 		{
 			Init?.Invoke(this, EventArgs.Empty);
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateApi.cs
@@ -73,7 +73,7 @@ namespace VisualPinball.Unity
 
 		#region Events
 
-		void IApiInitializable.OnInit()
+		void IApiInitializable.OnInit(BallManager ballManager)
 		{
 			Init?.Invoke(this, EventArgs.Empty);
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetApi.cs
@@ -81,7 +81,7 @@ namespace VisualPinball.Unity
 
 		#region Events
 
-		void IApiInitializable.OnInit()
+		void IApiInitializable.OnInit(BallManager ballManager)
 		{
 			Init?.Invoke(this, EventArgs.Empty);
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/IApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/IApi.cs
@@ -18,7 +18,7 @@ namespace VisualPinball.Unity
 {
 	internal interface IApiInitializable
 	{
-		void OnInit();
+		void OnInit(BallManager ballManager);
 	}
 
 	internal interface IApiHittable

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemApi.cs
@@ -24,21 +24,22 @@ namespace VisualPinball.Unity
 	public abstract class ItemApi<T, TData> where T : Item<TData> where TData : ItemData
 	{
 		protected readonly T Item;
-		protected readonly Player Player;
 		internal readonly Entity Entity;
 
 		protected TData Data => Item.Data;
-		protected Table Table => Player.Table;
+		protected Table Table => _player.Table;
 
 		protected readonly EntityManager EntityManager = World.DefaultGameObjectInjectionWorld.EntityManager;
 
 		internal VisualPinballSimulationSystemGroup SimulationSystemGroup => World.DefaultGameObjectInjectionWorld.GetOrCreateSystem<VisualPinballSimulationSystemGroup>();
 
+		private readonly Player _player;
+
 		protected ItemApi(T item, Entity entity, Player player)
 		{
 			Item = item;
 			Entity = entity;
-			Player = player;
+			_player = player;
 			_gamelogicEngineWithSwitches = player.GameEngine;
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerApi.cs
@@ -79,7 +79,7 @@ namespace VisualPinball.Unity
 			var kickerCollisionData = entityManager.GetComponentData<KickerCollisionData>(Entity);
 			var ballEntity = kickerCollisionData.BallEntity;
 			if (ballEntity != Entity.Null) {
-				BallManager.DestroyEntity(ballEntity);
+				_ballManager.DestroyEntity(ballEntity);
 				SimulationSystemGroup.QueueAfterBallCreation(() => DestroyBall(Entity));
 			}
 		}
@@ -162,9 +162,9 @@ namespace VisualPinball.Unity
 
 		#region Events
 
-		void IApiInitializable.OnInit()
+		void IApiInitializable.OnInit(BallManager ballManager)
 		{
-			_ballManager = BallManager.Instance(Player.Table, Player.TableToWorld);
+			_ballManager = ballManager;
 			Init?.Invoke(this, EventArgs.Empty);
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerApi.cs
@@ -93,7 +93,7 @@ namespace VisualPinball.Unity
 
 		#region Events
 
-		void IApiInitializable.OnInit()
+		void IApiInitializable.OnInit(BallManager ballManager)
 		{
 			Init?.Invoke(this, EventArgs.Empty);
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveApi.cs
@@ -38,7 +38,7 @@ namespace VisualPinball.Unity
 
 		#region Events
 
-		void IApiInitializable.OnInit()
+		void IApiInitializable.OnInit(BallManager ballManager)
 		{
 			Init?.Invoke(this, EventArgs.Empty);
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampApi.cs
@@ -32,7 +32,7 @@ namespace VisualPinball.Unity
 
 		#region Events
 
-		void IApiInitializable.OnInit()
+		void IApiInitializable.OnInit(BallManager ballManager)
 		{
 			Init?.Invoke(this, EventArgs.Empty);
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberApi.cs
@@ -37,7 +37,7 @@ namespace VisualPinball.Unity
 
 		#region Events
 
-		void IApiInitializable.OnInit()
+		void IApiInitializable.OnInit(BallManager ballManager)
 		{
 			Init?.Invoke(this, EventArgs.Empty);
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerApi.cs
@@ -68,7 +68,7 @@ namespace VisualPinball.Unity
 
 		#region Events
 
-		void IApiInitializable.OnInit()
+		void IApiInitializable.OnInit(BallManager ballManager)
 		{
 			Init?.Invoke(this, EventArgs.Empty);
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceApi.cs
@@ -43,7 +43,7 @@ namespace VisualPinball.Unity
 
 		#region Events
 
-		void IApiInitializable.OnInit()
+		void IApiInitializable.OnInit(BallManager ballManager)
 		{
 			Init?.Invoke(this, EventArgs.Empty);
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableApi.cs
@@ -118,7 +118,7 @@ namespace VisualPinball.Unity
 
 		#region Events
 
-		void IApiInitializable.OnInit()
+		void IApiInitializable.OnInit(BallManager ballManager)
 		{
 			Init?.Invoke(this, EventArgs.Empty);
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableAuthoring.cs
@@ -64,8 +64,6 @@ namespace VisualPinball.Unity
 
 		protected override string[] Children => null;
 
-		[HideInInspector] [SerializeField] public string physicsEngineId;
-		[HideInInspector] [SerializeField] public string debugUiId;
 		[HideInInspector] [SerializeField] private TableSidecar _sidecar;
 		private readonly Dictionary<string, Texture2D> _unityTextures = new Dictionary<string, Texture2D>();
 		// note: this cache needs to be keyed on the engine material itself so that when its recreated due to property changes the unity material
@@ -78,15 +76,6 @@ namespace VisualPinball.Unity
 		[HideInInspector] [SerializeField] private Dictionary<Type, List<string>> _dirtySerializables = new Dictionary<Type, List<string>>();
 
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
-
-		protected void Awake()
-		{
-			EngineProvider<IPhysicsEngine>.Set(physicsEngineId);
-			EngineProvider<IPhysicsEngine>.Get().Init(this);
-			if (!string.IsNullOrEmpty(debugUiId)) {
-				EngineProvider<IDebugUI>.Set(debugUiId);
-			}
-		}
 
 		protected virtual void Start()
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerApi.cs
@@ -45,7 +45,7 @@ namespace VisualPinball.Unity
 
 		#region Events
 
-		void IApiInitializable.OnInit()
+		void IApiInitializable.OnInit(BallManager ballManager)
 		{
 			Init?.Invoke(this, EventArgs.Empty);
 		}


### PR DESCRIPTION
This comes with three fixes:

1. Don't just take all objects from the playfield when creating colliders, but check `IsCollidable`.
2. Don't use BallManager as singleton
3. Unsubscribe from input events after player is destroyed so events only get emitted once for multiple launches.

A few things about playmode performance:

1. Most of the enter playmode time seems to spent on allocating colliders.
2. The tables I've checked that are still slow have primitives marked as collidable that actually shouldn't be. It gets slow from 10k colliders upwards.
3. The default table comes with unnecessary collidable primitives, like the rulers. You might want to remove those for significantly faster start-up time
4. I'll spend some more time to see if we can get this faster. VP doesn't seem to have a problem with it.