### PR TITLE
Replaced manual material changes with material default templates

### DIFF
--- a/VisualPinball.Unity/Assets/Resources/Materials.meta
+++ b/VisualPinball.Unity/Assets/Resources/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5a051ba9fc610994f9d2f3ee65896581
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/Assets/Resources/Materials/TableCutout.mat
+++ b/VisualPinball.Unity/Assets/Resources/Materials/TableCutout.mat
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: TableCutout
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: _ALPHATEST_ON
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 2450
+  stringTagMap:
+    RenderType: TransparentCutout
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 1
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/VisualPinball.Unity/Assets/Resources/Materials/TableCutout.mat.meta
+++ b/VisualPinball.Unity/Assets/Resources/Materials/TableCutout.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8aca463636d4d5e418080f9bed6b41b0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/Assets/Resources/Materials/TableOpaque.mat
+++ b/VisualPinball.Unity/Assets/Resources/Materials/TableOpaque.mat
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: TableOpaque
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/VisualPinball.Unity/Assets/Resources/Materials/TableOpaque.mat.meta
+++ b/VisualPinball.Unity/Assets/Resources/Materials/TableOpaque.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2ee48425ea4f368418fbc4f0d7d1cd32
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/Assets/Resources/Materials/TableTranslucent.mat
+++ b/VisualPinball.Unity/Assets/Resources/Materials/TableTranslucent.mat
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: TableTranslucent
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: _ALPHAPREMULTIPLY_ON
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 10
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 3
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/VisualPinball.Unity/Assets/Resources/Materials/TableTranslucent.mat.meta
+++ b/VisualPinball.Unity/Assets/Resources/Materials/TableTranslucent.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: abaf623203f801e4b9234d2e200a5ce6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/Rendering/Standard/StandardMaterialConverter.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Rendering/Standard/StandardMaterialConverter.cs
@@ -25,11 +25,11 @@ namespace VisualPinball.Unity
 	{
 		#region Shader Properties
 
-		private static readonly int Color = Shader.PropertyToID("_Color");
-		private static readonly int MainTex = Shader.PropertyToID("_MainTex");
-		private static readonly int BumpMap = Shader.PropertyToID("_BumpMap");
+		private static readonly int BaseColor = Shader.PropertyToID("_Color");
+		private static readonly int BaseColorMap = Shader.PropertyToID("_MainTex");
+		private static readonly int NormalMap = Shader.PropertyToID("_BumpMap");
 		private static readonly int Metallic = Shader.PropertyToID("_Metallic");
-		private static readonly int Glossiness = Shader.PropertyToID("_Glossiness");
+		private static readonly int Smoothness = Shader.PropertyToID("_Glossiness");
 		private static readonly int Mode = Shader.PropertyToID("_Mode");
 		private static readonly int SrcBlend = Shader.PropertyToID("_SrcBlend");
 		private static readonly int DstBlend = Shader.PropertyToID("_DstBlend");
@@ -42,12 +42,29 @@ namespace VisualPinball.Unity
 			return Shader.Find("Standard");
 		}
 
+		public static UnityEngine.Material GetDefaultMaterial(BlendMode blendMode)
+		{
+			switch (blendMode)
+			{
+				case Engine.VPT.BlendMode.Opaque:
+					return UnityEngine.Resources.Load<UnityEngine.Material>("Materials/TableOpaque");
+				case Engine.VPT.BlendMode.Cutout:
+					return UnityEngine.Resources.Load<UnityEngine.Material>("Materials/TableCutout");
+				case Engine.VPT.BlendMode.Translucent:
+					return UnityEngine.Resources.Load<UnityEngine.Material>("Materials/TableTranslucent");
+				default:
+					throw new ArgumentOutOfRangeException("Undefined blend mode " + blendMode);
+			}
+
+		}
+
 		public UnityEngine.Material CreateMaterial(PbrMaterial vpxMaterial, TableAuthoring table, Type objectType, StringBuilder debug = null)
 		{
-			var unityMaterial = new UnityEngine.Material(GetShader())
-			{
-				name = vpxMaterial.Id
-			};
+			UnityEngine.Material defaultMaterial = GetDefaultMaterial(vpxMaterial.MapBlendMode);
+
+			var unityMaterial = new UnityEngine.Material(GetShader());
+			unityMaterial.CopyPropertiesFromMaterial(defaultMaterial);
+			unityMaterial.name = vpxMaterial.Id;
 
 			// apply some basic manipulations to the color. this just makes very
 			// very white colors be clipped to 0.8204 aka 204/255 is 0.8
@@ -59,120 +76,46 @@ namespace VisualPinball.Unity
 				debug?.AppendLine("Color manipulation performed, brightness reduced.");
 				col.r = col.g = col.b = 0.8f;
 			}
-			unityMaterial.SetColor(Color, col);
+
+
+			if (vpxMaterial.MapBlendMode == Engine.VPT.BlendMode.Translucent)
+			{
+				col.a = Mathf.Min(1, Mathf.Max(0, vpxMaterial.Opacity));
+			}
+			unityMaterial.SetColor(BaseColor, col);
 
 			// validate IsMetal. if true, set the metallic value.
 			// found VPX authors setting metallic as well as translucent at the
 			// same time, which does not render correctly in unity so we have
 			// to check if this value is true and also if opacity <= 1.
+			float metallicValue = 0f;
 			if (vpxMaterial.IsMetal && (!vpxMaterial.IsOpacityActive || vpxMaterial.Opacity >= 1))
 			{
-				unityMaterial.SetFloat(Metallic, 1f);
+				metallicValue = 1f;
 				debug?.AppendLine("Metallic set to 1.");
 			}
 
-			// roughness / glossiness
-			unityMaterial.SetFloat(Glossiness, vpxMaterial.Roughness);
+			unityMaterial.SetFloat(Metallic, metallicValue);
 
-			// blend mode
-			ApplyBlendMode(unityMaterial, vpxMaterial.MapBlendMode);
-			if (vpxMaterial.MapBlendMode == BlendMode.Translucent)
-			{
-				col.a = Mathf.Min(1, Mathf.Max(0, vpxMaterial.Opacity));
-				unityMaterial.SetColor(Color, col);
-			}
+			// roughness / glossiness
+			unityMaterial.SetFloat(Smoothness, vpxMaterial.Roughness);
 
 			// map
 			if (table != null && vpxMaterial.HasMap)
 			{
-				unityMaterial.SetTexture(
-					MainTex,
-					table.GetTexture(vpxMaterial.Map.Name)
-				);
+				unityMaterial.SetTexture(BaseColorMap, table.GetTexture(vpxMaterial.Map.Name));
 			}
 
 			// normal map
 			if (table != null && vpxMaterial.HasNormalMap)
 			{
 				unityMaterial.EnableKeyword("_NORMALMAP");
-				unityMaterial.SetTexture(
-					BumpMap,
-					table.GetTexture(vpxMaterial.NormalMap.Name)
-				);
+				unityMaterial.EnableKeyword("_NORMALMAP_TANGENT_SPACE");
+
+				unityMaterial.SetTexture(NormalMap, table.GetTexture(vpxMaterial.NormalMap.Name));
 			}
 
 			return unityMaterial;
-		}
-
-		private static void ApplyBlendMode(UnityEngine.Material unityMaterial, BlendMode blendMode)
-		{
-			switch (blendMode)
-			{
-				case BlendMode.Opaque:
-
-					// keywords
-					unityMaterial.DisableKeyword("_ALPHATEST_ON");
-					unityMaterial.DisableKeyword("_ALPHABLEND_ON");
-					unityMaterial.DisableKeyword("_ALPHAPREMULTIPLY_ON");
-
-					// required for the blend mode
-					unityMaterial.SetInt(SrcBlend, (int)UnityEngine.Rendering.BlendMode.One);
-					unityMaterial.SetInt(DstBlend, (int)UnityEngine.Rendering.BlendMode.Zero);
-					unityMaterial.SetInt(ZWrite, 1);
-
-					// properties
-					unityMaterial.SetFloat(Mode, 0);
-
-					// render queue
-					unityMaterial.renderQueue = -1;
-
-					break;
-
-				case BlendMode.Cutout:
-
-					// keywords
-					unityMaterial.EnableKeyword("_ALPHATEST_ON");
-					unityMaterial.DisableKeyword("_ALPHABLEND_ON");
-					unityMaterial.DisableKeyword("_ALPHAPREMULTIPLY_ON");
-
-					// required for the blend mode
-					unityMaterial.SetInt(SrcBlend, (int)UnityEngine.Rendering.BlendMode.One);
-					unityMaterial.SetInt(DstBlend, (int)UnityEngine.Rendering.BlendMode.Zero);
-					unityMaterial.SetInt(ZWrite, 1);
-
-					// properties
-					unityMaterial.SetFloat(Mode, 1);
-
-					// render queue
-					unityMaterial.renderQueue = 2450;
-
-					break;
-
-				case BlendMode.Translucent:
-
-					// keywords
-					unityMaterial.DisableKeyword("_ALPHATEST_ON");
-					unityMaterial.DisableKeyword("_ALPHABLEND_ON");
-					unityMaterial.EnableKeyword("_ALPHAPREMULTIPLY_ON");
-
-					// required for the blend mode
-					unityMaterial.SetInt(SrcBlend, (int)UnityEngine.Rendering.BlendMode.One);
-					unityMaterial.SetInt(DstBlend, (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
-					//!!!!!!! this is normally switched off but somehow enabling it seems to resolve so many issues.. keep an eye out for weirld opacity issues
-					//unityMaterial.SetInt("_ZWrite", 0);
-					unityMaterial.SetInt(ZWrite, 1);
-
-					// properties
-					unityMaterial.SetFloat(Mode, 3);
-
-					// render queue
-					unityMaterial.renderQueue = 3000;
-
-					break;
-
-				default:
-					throw new ArgumentOutOfRangeException();
-			}
 		}
 	}
 }


### PR DESCRIPTION
Created material templates of which the properties are copied to the new created material. This is more future proof and supports automatic upgrade via Unity's own mechanism in case the shader changes.