### PR TITLE
ci: add release workflow and support for publishing to nuget

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.x'
-      - uses: nuget/setup-nuget@v1
       - name: Build
         run: dotnet build -c Release -r win-x64
       - name: Build Contents
@@ -33,7 +32,6 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.x'
-      - uses: nuget/setup-nuget@v1
       - name: Build
         run: dotnet build -c Release -r win-x86
       - name: Build Contents
@@ -50,7 +48,6 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.x'
-      - uses: nuget/setup-nuget@v1
       - name: Force 3.1.x
         run: |
           echo "{ \"sdk\": { \"version\": \"3.1.0\", \"rollForward\": \"latestFeature\" } }" > global.json
@@ -68,7 +65,6 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.x'
-      - uses: nuget/setup-nuget@v1
       - name: Build
         run: dotnet build -c Release -r linux-x64
       - name: Build Contents

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,17 @@
 name: Publish
 on:
   workflow_run:
-    workflows: [ "Build" ]
+    workflows: [ "Release" ]
     branches: [ master ]
     types:
       - completed
 
 jobs:
-  publish:
+  registry:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'workflow_run' }}
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          lfs: true
       - name: Add Meta Files
         run: |
           echo -e "fileFormatVersion: 2\nguid: 766a31c3b9f34ab0885c9eb91f7b1fe4" > package.json.meta
@@ -24,37 +21,6 @@ jobs:
           echo -e "fileFormatVersion: 2\nguid: a2a4b6cb3229489f99c06f0771c522ce" > CONTRIBUTING.md.meta
           echo -e "fileFormatVersion: 2\nguid: 931f3c49f79d4032bceefe14682a7d5a" > VisualPinball.Unity.meta
           echo -e "fileFormatVersion: 2\nguid: ea4f7f8d4c2c418e9fc0fbed8ab1f5a9" > VisualPinball.Engine.meta
-      - name: Fetch next version
-        id: nextVersion
-        uses: VisualPinball/next-version-action@v0.1.6
-        with:
-          tagPrefix: 'v'
-      - name: Bump
-        if: ${{ steps.nextVersion.outputs.isBump == 'true' }}
-        run: |
-          npm version ${{ steps.nextVersion.outputs.nextVersion }} --no-git-tag-version
-      - name: Commit
-        id: commit
-        if: ${{ steps.nextVersion.outputs.isBump == 'true' }}
-        run: |
-          git config user.name "github-actions"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json
-          git commit -m "release: ${{ steps.nextVersion.outputs.nextTag }}."
-          git push
-          commitish=$(git rev-parse HEAD)
-          echo ::set-output name=commitish::${commitish}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create Release
-        uses: actions/create-release@v1
-        with:
-          tag_name: ${{ steps.nextVersion.outputs.nextTag }}
-          release_name: ${{ steps.nextVersion.outputs.nextTag }}
-          prerelease: ${{ steps.nextVersion.outputs.isPrerelease }}
-          commitish: ${{ steps.commit.outputs.commitish }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish
         run: |
           echo "//registry.visualpinball.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
@@ -62,3 +28,19 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  nuget:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'workflow_run' }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+      - name: Pack
+        run: |
+          VERSION="$(npx -c 'echo "$npm_package_version"')"
+          dotnet pack VisualPinball.Resources/VisualPinball.Resources.csproj -c Release /p:PackageVersion=$VERSION -o nupkg
+          dotnet pack VisualPinball.Engine/VisualPinball.Engine.csproj -c Release /p:PackageVersion=$VERSION -o nupkg
+      - name: Publish
+        run: |
+          dotnet nuget push nupkg/*.nupkg -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - completed
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+on:
+  workflow_run:
+    workflows: [ "Build" ]
+    branches: [ master ]
+    types:
+      - completed
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch next version
+        id: nextVersion
+        uses: VisualPinball/next-version-action@v0.1.6
+        with:
+          tagPrefix: 'v'
+      - name: Bump
+        if: ${{ steps.nextVersion.outputs.isBump == 'true' }}
+        run: |
+          npm version ${{ steps.nextVersion.outputs.nextVersion }} --no-git-tag-version
+      - name: Commit
+        id: commit
+        if: ${{ steps.nextVersion.outputs.isBump == 'true' }}
+        run: |
+          git config user.name "github-actions"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "release: ${{ steps.nextVersion.outputs.nextTag }}."
+          git push
+          commitish=$(git rev-parse HEAD)
+          echo ::set-output name=commitish::${commitish}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ steps.nextVersion.outputs.nextTag }}
+          release_name: ${{ steps.nextVersion.outputs.nextTag }}
+          prerelease: ${{ steps.nextVersion.outputs.isPrerelease }}
+          commitish: ${{ steps.commit.outputs.commitish }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds support for publishing to NuGet. 

We reworked the `Publish` workflow into `Release`, and then made a new `Publish` workflow the publishes to the Visual Pinball Registry and NuGet.

The github workflows will work as follows:

```
documentation
build -> release -> publish (registry / nuget) -> dependents
```

If desired, we can adjust to:

```
documentation
build -> release -> publish (registry / nuget)
                 -> dependents
```

Unfortunately, we can not actually test the NuGet publish process until this is merged into master. 