### PR TITLE
Convert plunger to coil device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Built with [Unity 2020.2](https://github.com/freezy/VisualPinball.Engine/pull/25
 - Native trough component ([#229](https://github.com/freezy/VisualPinball.Engine/pull/229), [#248](https://github.com/freezy/VisualPinball.Engine/pull/248), [#256](https://github.com/freezy/VisualPinball.Engine/pull/256), [Documentation](https://docs.visualpinball.org/creators-guide/manual/mechanisms/troughs.html))
 
 ### Changed
+- Plunger is now a coil device, meaning it can both be pulled back and fired through different inputs.
 - Move render pipelines into separate repos ([#259](https://github.com/freezy/VisualPinball.Engine/pull/259))
 - Put game-, mesh-, collision- animation data into separate components ([#227](https://github.com/freezy/VisualPinball.Engine/pull/227), [Documentation](https://docs.visualpinball.org/creators-guide/editor/unity-components.html)) 
 

--- a/VisualPinball.Engine.Test/Common/EngineTests.cs
+++ b/VisualPinball.Engine.Test/Common/EngineTests.cs
@@ -1,0 +1,67 @@
+// Visual Pinball Engine
+// Copyright (C) 2021 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using FluentAssertions;
+using NUnit.Framework;
+using VisualPinball.Engine.Common;
+
+namespace VisualPinball.Engine.Test.Common
+{
+	public class EngineTests
+	{
+		[Test]
+		public void ShouldFailIfNoneSet()
+		{
+			Action act = () => EngineProvider<ITestEngine>.Get();
+			act.Should().Throw<InvalidOperationException >()
+				.WithMessage("Must select VisualPinball.Engine.Test.Common.ITestEngine engine before retrieving!");
+		}
+
+		[Test]
+		public void ShouldProvideIfSet()
+		{
+			EngineProvider<ITestEngine>.Set("VisualPinball.Engine.Test.Common.TestEngine1");
+			var engine = EngineProvider<ITestEngine>.Get();
+
+			engine.Should().NotBeNull();
+			engine.Name.Should().Be("Engine 1");
+
+			EngineProvider<ITestEngine>.Set("VisualPinball.Engine.Test.Common.TestEngine2");
+			engine = EngineProvider<ITestEngine>.Get();
+
+			engine.Should().NotBeNull();
+			engine.Name.Should().Be("Engine 2");
+		}
+	}
+
+	internal interface ITestEngine : IEngine
+	{
+
+	}
+
+	internal class TestEngine1 : ITestEngine
+	{
+
+		public string Name { get; } = "Engine 1";
+	}
+
+	internal class TestEngine2 : ITestEngine
+	{
+
+		public string Name { get; } = "Engine 2";
+	}
+}

--- a/VisualPinball.Engine/Common/Constants.cs
+++ b/VisualPinball.Engine/Common/Constants.cs
@@ -136,6 +136,7 @@ namespace VisualPinball.Engine.Common
 		public const string ActionFrontBuyIn = "Front (buy-in)";
 		public const string ActionStartGame = "Start Game";
 		public const string ActionPlunger = "Plunger";
+		public const string ActionPlungerAnalog = "Plunger (analog)";
 		public const string ActionInsertCoin1 = "Insert Coin Slot 1";
 		public const string ActionInsertCoin2 = "Insert Coin Slot 2";
 		public const string ActionInsertCoin3 = "Insert Coin Slot 3";

--- a/VisualPinball.Engine/VPT/Plunger/Plunger.cs
+++ b/VisualPinball.Engine/VPT/Plunger/Plunger.cs
@@ -14,17 +14,27 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+using System.Collections.Generic;
 using System.IO;
 using VisualPinball.Engine.Game;
+using VisualPinball.Engine.Game.Engines;
 using VisualPinball.Engine.Math;
 using VisualPinball.Engine.Physics;
 
 namespace VisualPinball.Engine.VPT.Plunger
 {
-	public class Plunger : Item<PlungerData>, IRenderable, IHittable, ICoilable
+	public class Plunger : Item<PlungerData>, IRenderable, IHittable, ICoilableDevice
 	{
 		public override string ItemName { get; } = "Plunger";
 		public override string ItemGroupName { get; } = "Plungers";
+
+		public const string PullCoil = "c_pull";
+		public const string FireCoil = "c_autofire";
+
+		public IEnumerable<GamelogicEngineCoil> AvailableCoils { get; } = new[] {
+			new GamelogicEngineCoil(PullCoil) {Description = "Pull back"},
+			new GamelogicEngineCoil(FireCoil) {Description = "Auto-fire"},
+		};
 
 		public Vertex3D Position { get => new Vertex3D(Data.Center.X, Data.Center.Y, 0); set => Data.Center = new Vertex2D(value.X, value.Y); }
 		public float RotationY { get => 0; set { } }

--- a/VisualPinball.Engine/VPT/Table/Table.cs
+++ b/VisualPinball.Engine/VPT/Table/Table.cs
@@ -122,7 +122,7 @@ namespace VisualPinball.Engine.VPT.Table
 		public Kicker.Kicker Kicker(string name) => _kickers[name];
 		public Light.Light Light(string name) => _lights[name];
 		public LightSeq.LightSeq LightSeq(string name) => _lightSeqs[name];
-		public Plunger.Plunger Plunger(string name) => _plungers[name];
+		public Plunger.Plunger Plunger(string name = null) => name == null ? _plungers.Values.First() : _plungers[name];
 		public Flasher.Flasher Flasher(string name) => _flashers[name];
 		public Primitive.Primitive Primitive(string name) => _primitives[name];
 		public Ramp.Ramp Ramp(string name) => _ramps[name];
@@ -243,11 +243,11 @@ namespace VisualPinball.Engine.VPT.Table
 		public IEnumerable<ICoilable> Coilables => new ICoilable[0]
 			.Concat(_bumpers.Values)
 			.Concat(_flippers.Values)
-			.Concat(_kickers.Values)
-			.Concat(_plungers.Values);
+			.Concat(_kickers.Values);
 
 		public IEnumerable<ICoilableDevice> CoilableDevices => new ICoilableDevice[0]
-			.Concat(_troughs.Values);
+			.Concat(_troughs.Values)
+			.Concat(_plungers.Values);
 
 		public IEnumerable<ILightable> Lightables => new ILightable[0]
 			.Concat(_lights.Values)

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Plunger/PlungerColliderInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Plunger/PlungerColliderInspector.cs
@@ -34,7 +34,6 @@ namespace VisualPinball.Unity.Editor
 			ItemDataField("Release Speed", ref Data.SpeedFire, false);
 			ItemDataField("Stroke Length", ref Data.Stroke, false);
 			ItemDataField("Scatter Velocity", ref Data.ScatterVelocity, false);
-			ItemDataField("Enable Mechanical Plunger", ref Data.IsMechPlunger, false);
 			ItemDataField("Auto Plunger", ref Data.AutoPlunger, false);
 			ItemDataField("Visible", ref Data.IsVisible);
 			ItemDataField("Mech Strength", ref Data.MechStrength, false);

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Plunger/PlungerInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Plunger/PlungerInspector.cs
@@ -17,6 +17,7 @@
 // ReSharper disable AssignmentInConditionalExpression
 
 using UnityEditor;
+using UnityEngine.InputSystem;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Plunger;
 
@@ -42,6 +43,8 @@ namespace VisualPinball.Unity.Editor
 			SurfaceField("Surface", ref Data.Surface);
 
 			OnPreInspectorGUI();
+
+			ItemAuthoring.analogPlungerAction = (InputActionReference)EditorGUILayout.ObjectField("Analog Key", ItemAuthoring.analogPlungerAction, typeof(InputActionReference), false);
 
 			if (_foldoutColorsAndFormatting = EditorGUILayout.BeginFoldoutHeaderGroup(_foldoutColorsAndFormatting, "Colors & Formatting")) {
 				DropDownField("Type", ref Data.Type, PlungerTypeLabels, PlungerTypeValues, onChanged: ItemAuthoring.OnTypeChanged);

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Plunger/PlungerInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Plunger/PlungerInspector.cs
@@ -44,7 +44,10 @@ namespace VisualPinball.Unity.Editor
 
 			OnPreInspectorGUI();
 
+			ItemDataField("Mechanical Plunger", ref Data.IsMechPlunger, false);
+			EditorGUI.BeginDisabledGroup(!Data.IsMechPlunger);
 			ItemAuthoring.analogPlungerAction = (InputActionReference)EditorGUILayout.ObjectField("Analog Key", ItemAuthoring.analogPlungerAction, typeof(InputActionReference), false);
+			EditorGUI.EndDisabledGroup();
 
 			if (_foldoutColorsAndFormatting = EditorGUILayout.BeginFoldoutHeaderGroup(_foldoutColorsAndFormatting, "Colors & Formatting")) {
 				DropDownField("Type", ref Data.Type, PlungerTypeLabels, PlungerTypeValues, onChanged: ItemAuthoring.OnTypeChanged);

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/DefaultGamelogicEngine.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/DefaultGamelogicEngine.cs
@@ -53,7 +53,6 @@ namespace VisualPinball.Unity
 		private const string SwTrough2 = "s_trough2";
 		private const string SwTrough3 = "s_trough3";
 		private const string SwTrough4 = "s_trough4";
-		private const string SwPlunger = "s_plunger";
 		private const string SwCreateBall = "s_create_ball";
 		private const string SwRedBumper = "s_red_bumper";
 
@@ -62,7 +61,6 @@ namespace VisualPinball.Unity
 			new GamelogicEngineSwitch(SwRightFlipper) { Description = "Right Flipper (button)", InputActionHint = InputConstants.ActionRightFlipper },
 			new GamelogicEngineSwitch(SwLeftFlipperEos) { Description = "Left Flipper (EOS)", PlayfieldItemHint = "^(LeftFlipper|LFlipper|FlipperLeft|FlipperL)$"},
 			new GamelogicEngineSwitch(SwRightFlipperEos) { Description = "Right Flipper (EOS)", PlayfieldItemHint = "^(RightFlipper|RFlipper|FlipperRight|FlipperR)$"},
-			new GamelogicEngineSwitch(SwPlunger) { Description = "Plunger", InputActionHint = InputConstants.ActionPlunger },
 			new GamelogicEngineSwitch(SwTroughDrain) { Description = "Trough Drain", DeviceHint = "^Trough\\s*\\d?", DeviceItemHint = Trough.EntrySwitchId },
 			new GamelogicEngineSwitch(SwTrough1) { Description = "Trough 1 (eject)", DeviceHint = "^Trough\\s*\\d?", DeviceItemHint = "1"},
 			new GamelogicEngineSwitch(SwTrough2) { Description = "Trough 2", DeviceHint = "^Trough\\s*\\d?", DeviceItemHint = "2"},
@@ -77,7 +75,6 @@ namespace VisualPinball.Unity
 		private const string CoilLeftFlipperHold = "c_flipper_left_hold";
 		private const string CoilRightFlipperMain = "c_flipper_right_main";
 		private const string CoilRightFlipperHold = "c_flipper_right_hold";
-		private const string CoilAutoPlunger = "c_auto_plunger";
 		private const string CoilTroughEntry = "c_trough_entry";
 		private const string CoilTroughEject = "c_trough_eject";
 
@@ -86,7 +83,6 @@ namespace VisualPinball.Unity
 			new GamelogicEngineCoil(CoilLeftFlipperHold) { MainCoilIdOfHoldCoil = CoilLeftFlipperMain },
 			new GamelogicEngineCoil(CoilRightFlipperMain) { Description = "Right Flipper", PlayfieldItemHint = "^(RightFlipper|RFlipper|FlipperRight|FlipperR)$" },
 			new GamelogicEngineCoil(CoilRightFlipperHold) { MainCoilIdOfHoldCoil = CoilRightFlipperMain },
-			new GamelogicEngineCoil(CoilAutoPlunger) { Description = "Plunger", PlayfieldItemHint = "Plunger" },
 			new GamelogicEngineCoil(CoilTroughEject) { Description = "Trough Eject", DeviceHint = "^Trough\\s*\\d?", DeviceItemHint = Trough.EjectCoilId},
 			new GamelogicEngineCoil(CoilTroughEntry) { Description = "Trough Entry", DeviceHint = "^Trough\\s*\\d?", DeviceItemHint = Trough.EntryCoilId},
 		};
@@ -186,10 +182,6 @@ namespace VisualPinball.Unity
 				case SwRightFlipper:
 				case SwRightFlipperEos:
 					Flip(id, isClosed);
-					break;
-
-				case SwPlunger:
-					OnCoilChanged?.Invoke(this, new CoilEventArgs(CoilAutoPlunger, isClosed));
 					break;
 
 				case SwTrough4:

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
@@ -227,8 +227,8 @@ namespace VisualPinball.Unity
 			_apis.Add(plungerApi);
 			_initializables.Add(plungerApi);
 			_rotatables[entity] = plungerApi;
-			_coilPlayer.RegisterCoil(plunger, plungerApi);
-			_wirePlayer.RegisterWire(plunger, plungerApi);
+			_coilPlayer.RegisterCoilDevice(plunger, plungerApi);
+			_wirePlayer.RegisterWireDevice(plunger, plungerApi);
 		}
 
 		public void RegisterPrimitive(Primitive primitive, Entity entity, GameObject go)

--- a/VisualPinball.Unity/VisualPinball.Unity/Import/VpxConverter.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Import/VpxConverter.cs
@@ -23,6 +23,8 @@ using System.Collections.Generic;
 using System.Linq;
 using NLog;
 using UnityEngine;
+using UnityEngine.InputSystem;
+using VisualPinball.Engine.Common;
 using VisualPinball.Engine.Game;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Bumper;
@@ -34,6 +36,7 @@ using VisualPinball.Engine.VPT.Gate;
 using VisualPinball.Engine.VPT.HitTarget;
 using VisualPinball.Engine.VPT.Kicker;
 using VisualPinball.Engine.VPT.LightSeq;
+using VisualPinball.Engine.VPT.Mappings;
 using VisualPinball.Engine.VPT.Plunger;
 using VisualPinball.Engine.VPT.Primitive;
 using VisualPinball.Engine.VPT.Ramp;
@@ -112,6 +115,20 @@ namespace VisualPinball.Unity
 			if (_table.Mappings.IsEmpty()) {
 				_table.Mappings.PopulateSwitches(dga.AvailableSwitches, table.Switchables, table.SwitchableDevices);
 				_table.Mappings.PopulateCoils(dga.AvailableCoils, table.Coilables, table.CoilableDevices);
+
+				// wire up plunger
+				var plunger = _table.Plunger();
+				if (plunger != null) {
+					_table.Mappings.Data.AddWire(new MappingsWireData {
+						Description = "Plunger",
+						Source = SwitchSource.InputSystem,
+						SourceInputActionMap = InputConstants.MapCabinetSwitches,
+						SourceInputAction = InputConstants.ActionPlunger,
+						Destination = WireDestination.Device,
+						DestinationDevice = plunger.Name,
+						DestinationDeviceItem = Plunger.PullCoil
+					});
+				}
 			}
 
 			// don't need that anymore.

--- a/VisualPinball.Unity/VisualPinball.Unity/Input/InputManager.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Input/InputManager.cs
@@ -118,15 +118,6 @@ namespace VisualPinball.Unity
 			return list;
 		}
 
-		public InputActionReference GetActionReference(string mapName, string actionName)
-		{
-			var map = _asset.FindActionMap(mapName);
-			var action = map.FindAction(actionName);
-			var iar = InputActionReference.Create(action);
-			iar.Set(_asset, mapName, actionName);
-			return iar;
-		}
-
 		public static InputActionAsset GetDefaultInputActionAsset()
 		{
 			var asset = ScriptableObject.CreateInstance<InputActionAsset>();
@@ -134,7 +125,7 @@ namespace VisualPinball.Unity
 			map.AddAction(InputConstants.ActionUpperLeftFlipper, InputActionType.Button, "<Keyboard>/a");
 			map.AddAction(InputConstants.ActionUpperRightFlipper, InputActionType.Button, "<Keyboard>/quote");
 			map.AddAction(InputConstants.ActionLeftFlipper, InputActionType.Button, "<Keyboard>/leftShift").AddBinding("<Gamepad>/leftShoulder");
-			map.AddAction(InputConstants.ActionRightFlipper, InputActionType.Button, "<Keyboard>/rightShift").AddBinding("<Gamepad>/rightShoulder");;
+			map.AddAction(InputConstants.ActionRightFlipper, InputActionType.Button, "<Keyboard>/rightShift").AddBinding("<Gamepad>/rightShoulder");
 			map.AddAction(InputConstants.ActionRightMagnasave, InputActionType.Button, "<Keyboard>/rightCtrl");
 			map.AddAction(InputConstants.ActionLeftMagnasave, InputActionType.Button, "<Keyboard>/leftCtrl");
 			map.AddAction(InputConstants.ActionFire1, InputActionType.Button, "<Keyboard>/leftCtrl");

--- a/VisualPinball.Unity/VisualPinball.Unity/Input/InputManager.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Input/InputManager.cs
@@ -118,15 +118,23 @@ namespace VisualPinball.Unity
 			return list;
 		}
 
+		public InputActionReference GetActionReference(string mapName, string actionName)
+		{
+			var map = _asset.FindActionMap(mapName);
+			var action = map.FindAction(actionName);
+			var iar = InputActionReference.Create(action);
+			iar.Set(_asset, mapName, actionName);
+			return iar;
+		}
+
 		public static InputActionAsset GetDefaultInputActionAsset()
 		{
 			var asset = ScriptableObject.CreateInstance<InputActionAsset>();
-
 			var map = new InputActionMap(InputConstants.MapCabinetSwitches);
 			map.AddAction(InputConstants.ActionUpperLeftFlipper, InputActionType.Button, "<Keyboard>/a");
 			map.AddAction(InputConstants.ActionUpperRightFlipper, InputActionType.Button, "<Keyboard>/quote");
-			map.AddAction(InputConstants.ActionLeftFlipper, InputActionType.Button, "<Keyboard>/leftShift");
-			map.AddAction(InputConstants.ActionRightFlipper, InputActionType.Button, "<Keyboard>/rightShift");
+			map.AddAction(InputConstants.ActionLeftFlipper, InputActionType.Button, "<Keyboard>/leftShift").AddBinding("<Gamepad>/leftShoulder");
+			map.AddAction(InputConstants.ActionRightFlipper, InputActionType.Button, "<Keyboard>/rightShift").AddBinding("<Gamepad>/rightShoulder");;
 			map.AddAction(InputConstants.ActionRightMagnasave, InputActionType.Button, "<Keyboard>/rightCtrl");
 			map.AddAction(InputConstants.ActionLeftMagnasave, InputActionType.Button, "<Keyboard>/leftCtrl");
 			map.AddAction(InputConstants.ActionFire1, InputActionType.Button, "<Keyboard>/leftCtrl");
@@ -134,6 +142,7 @@ namespace VisualPinball.Unity
 			map.AddAction(InputConstants.ActionFrontBuyIn, InputActionType.Button, "<Keyboard>/2");
 			map.AddAction(InputConstants.ActionStartGame, InputActionType.Button, "<Keyboard>/1");
 			map.AddAction(InputConstants.ActionPlunger, InputActionType.Button, "<Keyboard>/enter");
+			map.AddAction(InputConstants.ActionPlungerAnalog, InputActionType.Button, "<Gamepad>/rightStick/down");
 			map.AddAction(InputConstants.ActionInsertCoin1, InputActionType.Button, "<Keyboard>/3");
 			map.AddAction(InputConstants.ActionInsertCoin2, InputActionType.Button, "<Keyboard>/4");
 			map.AddAction(InputConstants.ActionInsertCoin3, InputActionType.Button, "<Keyboard>/5");

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerApi.cs
@@ -16,6 +16,8 @@
 
 using System;
 using Unity.Entities;
+using UnityEngine;
+using UnityEngine.InputSystem;
 using VisualPinball.Engine.VPT.Plunger;
 
 namespace VisualPinball.Unity
@@ -59,6 +61,14 @@ namespace VisualPinball.Unity
 
 		internal PlungerApi(Plunger item, Entity entity, Player player) : base(item, entity, player)
 		{
+		}
+
+		internal void OnAnalogPlunge(InputAction.CallbackContext ctx)
+		{
+			var pos = ctx.ReadValue<float>(); // 0 = resting pos, 1 = pulled back
+			var movementData = EntityManager.GetComponentData<PlungerMovementData>(Entity);
+			movementData.AnalogPosition = pos;
+			EntityManager.SetComponentData(Entity, movementData);
 		}
 
 		void IApiInitializable.OnInit(BallManager ballManager)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerAuthoring.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;
 using UnityEngine;
+using VisualPinball.Engine.Game.Engines;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Plunger;
 
@@ -27,9 +28,11 @@ namespace VisualPinball.Unity
 	[ExecuteAlways]
 	[AddComponentMenu("Visual Pinball/Game Item/Plunger")]
 	public class PlungerAuthoring : ItemMainRenderableAuthoring<Plunger, PlungerData>,
-		ICoilAuthoring, IConvertGameObjectToEntity
+		ICoilDeviceAuthoring, IConvertGameObjectToEntity
 	{
 		protected override Plunger InstantiateItem(PlungerData data) => new Plunger(data);
+
+		public IEnumerable<GamelogicEngineCoil> AvailableCoils => Item.AvailableCoils;
 
 		protected override Type MeshAuthoringType { get; } = typeof(ItemMeshAuthoring<Plunger, PlungerData, PlungerAuthoring>);
 		protected override Type ColliderAuthoringType { get; } = typeof(ItemColliderAuthoring<Plunger, PlungerData, PlungerAuthoring>);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerAuthoring.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;
 using UnityEngine;
+using UnityEngine.InputSystem;
 using VisualPinball.Engine.Game.Engines;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Plunger;
@@ -34,6 +35,8 @@ namespace VisualPinball.Unity
 
 		public IEnumerable<GamelogicEngineCoil> AvailableCoils => Item.AvailableCoils;
 
+		public InputActionReference analogPlungerAction;
+
 		protected override Type MeshAuthoringType { get; } = typeof(ItemMeshAuthoring<Plunger, PlungerData, PlungerAuthoring>);
 		protected override Type ColliderAuthoringType { get; } = typeof(ItemColliderAuthoring<Plunger, PlungerData, PlungerAuthoring>);
 
@@ -47,7 +50,7 @@ namespace VisualPinball.Unity
 		{
 			Convert(entity, dstManager);
 			var table = gameObject.GetComponentInParent<TableAuthoring>().Item;
-			transform.GetComponentInParent<Player>().RegisterPlunger(Item, entity, gameObject);
+			transform.GetComponentInParent<Player>().RegisterPlunger(Item, entity, analogPlungerAction);
 
 			Item.Init(table);
 			var hit = Item.PlungerHit;
@@ -61,6 +64,7 @@ namespace VisualPinball.Unity
 				FrameLen = hit.FrameLen,
 				RestPosition = hit.RestPos,
 				IsAutoPlunger = Data.AutoPlunger,
+				IsMechPlunger = Data.IsMechPlunger,
 				SpeedFire = Data.SpeedFire,
 				NumFrames = Item.MeshGenerator.NumFrames
 			});

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerExtensions.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerExtensions.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using NLog;
 using Unity.Entities;
 using UnityEngine;
+using VisualPinball.Engine.Common;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Plunger;
 using Logger = NLog.Logger;
@@ -31,7 +32,10 @@ namespace VisualPinball.Unity
 
 		public static ConvertedItem SetupGameObject(this Plunger plunger, GameObject obj)
 		{
-			var mainAuthoring = obj.AddComponent<PlungerAuthoring>().SetItem(plunger);
+			var mainAuthoring = obj.AddComponent<PlungerAuthoring>();
+			var inputManager = new InputManager("Assets/Resources");
+			mainAuthoring.analogPlungerAction = inputManager.GetActionReference(InputConstants.MapCabinetSwitches, InputConstants.ActionPlungerAnalog);
+			mainAuthoring.SetItem(plunger);
 			var meshAuthoring = new List<IItemMeshAuthoring>();
 			PlungerColliderAuthoring colliderAuthoring = null;
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerExtensions.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerExtensions.cs
@@ -32,10 +32,7 @@ namespace VisualPinball.Unity
 
 		public static ConvertedItem SetupGameObject(this Plunger plunger, GameObject obj)
 		{
-			var mainAuthoring = obj.AddComponent<PlungerAuthoring>();
-			var inputManager = new InputManager("Assets/Resources");
-			mainAuthoring.analogPlungerAction = inputManager.GetActionReference(InputConstants.MapCabinetSwitches, InputConstants.ActionPlungerAnalog);
-			mainAuthoring.SetItem(plunger);
+			var mainAuthoring = obj.AddComponent<PlungerAuthoring>().SetItem(plunger);
 			var meshAuthoring = new List<IItemMeshAuthoring>();
 			PlungerColliderAuthoring colliderAuthoring = null;
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerMovementData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerMovementData.cs
@@ -152,5 +152,12 @@ namespace VisualPinball.Unity
 		/// if we stop at one of the ends for a while.
 		/// </summary>
 		public bool StrokeEventsArmed;
+
+		/// <summary>
+		/// The analog position read from the gamepad or plunger.
+		///
+		/// Between 0 (rest position) and 1f (fully retracted).
+		/// </summary>
+		public float AnalogPosition;
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerStaticData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerStaticData.cs
@@ -38,6 +38,7 @@ namespace VisualPinball.Unity
 		// velocity
 		public bool IsAutoPlunger;
 		public float SpeedFire;
+		public bool IsMechPlunger;
 
 		// mesh frame calc
 		public int NumFrames;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerVelocitySystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerVelocitySystem.cs
@@ -37,9 +37,7 @@ namespace VisualPinball.Unity
 				// maximum retracted position)
 				var pos = (movementData.Position - staticData.FrameEnd) / staticData.FrameLen;
 
-				// todo | If "mech plunger" is enabled, read the mechanical plunger
-				// todo | position; otherwise treat it as fixed at 0.
-				const float mech = 0f; //staticData.IsMechPlunger ? MechPlunger() : 0.0f;
+				var mech = staticData.IsMechPlunger ? movementData.AnalogPosition : 0.0f;
 
 				// calculate the delta from the last reading
 				var dMech = velocityData.Mech0 - mech;


### PR DESCRIPTION
This PR adds multiple inputs to the plunger so it can be configured to be pulled back as well as auto-fired. Closes #286.

Pinball machines often have both an analog plunger and an auto-plunger that can be controlled by the ROM. The behavior is different: The analog plunger starts moving to the start position when the key is pressed and fires when the key is released, while the auto-plunger fires directly.

This PR converts the plunger to a coil device with two coils: One that mimics an analog plunger, and one for the auto-plunger.

It also wires the plunger key to the analog plunger when importing the table:

![image](https://user-images.githubusercontent.com/70426/106658634-d1428300-659d-11eb-94b3-88acfda6b099.png)

Additionally, the plunger coil and switch were removed from the gamelogic engine, meaning the plunger bypasses the gamelogic engine by default.

Analog controller test:

https://user-images.githubusercontent.com/70426/106957947-f1f31000-6738-11eb-952f-25843a550eb6.mp4

## TODO

- [x] Handle analog input
