### PR TITLE
Fix color alpha issues.

### DIFF
--- a/VisualPinball.Engine/Math/Color.cs
+++ b/VisualPinball.Engine/Math/Color.cs
@@ -64,6 +64,11 @@ namespace VisualPinball.Engine.Math
 			return new Color(Red, Green, Blue, Alpha);
 		}
 
+		public Color WithAlpha(int alpha)
+		{
+			return new Color(Red, Green, Blue, alpha);
+		}
+
 		public bool IsGray()
 		{
 			return Red == Green && Green == Blue;

--- a/VisualPinball.Engine/VPT/Light/LightMeshGenerator.cs
+++ b/VisualPinball.Engine/VPT/Light/LightMeshGenerator.cs
@@ -107,18 +107,18 @@ namespace VisualPinball.Engine.VPT.Light
 		private static Material GetBulbMaterial()
 		{
 			return new Material(Light.BulbMaterialName) {
-				BaseColor = new Color(0x000000, ColorFormat.Bgr),
+				BaseColor = new Color(0x000000ff, ColorFormat.Bgr),
 				WrapLighting = 0.5f,
 				IsOpacityActive = true,
 				Opacity = 0.2f,
-				Glossiness = new Color(0xFFFFFF, ColorFormat.Bgr),
+				Glossiness = new Color(0xFFFFFFFF, ColorFormat.Bgr),
 				IsMetal = false,
 				Edge = 1.0f,
 				EdgeAlpha = 1.0f,
 				Roughness = 0.9f,
 				GlossyImageLerp = 1.0f,
 				Thickness = 0.05f,
-				ClearCoat = new Color(0xFFFFFF, ColorFormat.Bgr),
+				ClearCoat = new Color(0xFFFFFFFF, ColorFormat.Bgr),
 			};
 		}
 

--- a/VisualPinball.Engine/VPT/PbrMaterial.cs
+++ b/VisualPinball.Engine/VPT/PbrMaterial.cs
@@ -35,7 +35,7 @@ namespace VisualPinball.Engine.VPT
 
 		public readonly bool VertexLerpWithUvEnabled;
 
-		public Color Color => _material?.BaseColor ?? new Color(0xffffff, ColorFormat.Bgr);
+		public Color Color => _material?.BaseColor.WithAlpha(255) ?? new Color(0xffffffff, ColorFormat.Bgr);
 		public bool IsMetal => _material?.IsMetal ?? false;
 		public bool IsOpacityActive => _material?.IsOpacityActive ?? false;
 		public float Opacity => MathF.Min(1, MathF.Max(0, _material?.Opacity ?? 1f));

--- a/VisualPinball.Engine/VPT/Spinner/SpinnerMeshGenerator.cs
+++ b/VisualPinball.Engine/VPT/Spinner/SpinnerMeshGenerator.cs
@@ -82,18 +82,18 @@ namespace VisualPinball.Engine.VPT.Spinner
 		private static Material GetBracketMaterial()
 		{
 			return new Material(Spinner.BracketMaterialName) {
-				BaseColor = new Color(0x20202020, ColorFormat.Bgr),
+				BaseColor = new Color(0x202020ff, ColorFormat.Bgr),
 				WrapLighting = 0.9f,
 				IsOpacityActive = false,
 				Opacity = 1.0f,
-				Glossiness = new Color(0x60606060, ColorFormat.Bgr),
+				Glossiness = new Color(0x606060ff, ColorFormat.Bgr),
 				IsMetal = false,
 				Edge = 1.0f,
 				EdgeAlpha = 1.0f,
 				Roughness = 0.4f,
 				GlossyImageLerp = 1.0f,
 				Thickness = 0.05f,
-				ClearCoat = new Color(0x20202020, ColorFormat.Bgr),
+				ClearCoat = new Color(0x202020ff, ColorFormat.Bgr),
 			};
 		}
 


### PR DESCRIPTION
We've recently added alpha support to color, resulting in parsing all colors including the alpha channel. However some colors were hard-coded without alpha, resulting in no color at all. 

This PR adds opacity back to those colors, and sets alpha to 1 when the material's color is retrieved.