### PR TITLE
Make colliders toggelable

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/ColliderData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/ColliderData.cs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+using Unity.Collections;
 using Unity.Entities;
 
 namespace VisualPinball.Unity

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/QuadTree.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/QuadTree.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 
@@ -190,14 +191,14 @@ namespace VisualPinball.Unity
 			};
 		}
 
-		public void GetAabbOverlaps(in BallData ball, ref DynamicBuffer<OverlappingStaticColliderBufferElement> matchedColliderIds)
+		public void GetAabbOverlaps(in BallData ball, in NativeHashMap<Entity, bool> itemsColliding, ref DynamicBuffer<OverlappingStaticColliderBufferElement> matchedColliderIds)
 		{
 			var ballAabb = ball.Aabb;
 			var collisionRadiusSqr = ball.CollisionRadiusSqr;
 
 			for (var i = 0; i < _bounds.Length; i++) {
 				ref var bounds = ref _bounds[i].Value;
-				if (bounds.Aabb.IntersectRect(ballAabb) && bounds.Aabb.IntersectSphere(ball.Position, collisionRadiusSqr)) {
+				if (itemsColliding[bounds.ColliderEntity] && bounds.Aabb.IntersectRect(ballAabb) && bounds.Aabb.IntersectSphere(ball.Position, collisionRadiusSqr)) {
 					matchedColliderIds.Add(new OverlappingStaticColliderBufferElement { Value = bounds.ColliderId });
 				}
 			}
@@ -209,22 +210,22 @@ namespace VisualPinball.Unity
 				if (ballAabb.Top <= _center.y) {
 					// Top
 					if (isLeft) {
-						_children[0].Value.GetAabbOverlaps(in ball, ref matchedColliderIds);
+						_children[0].Value.GetAabbOverlaps(in ball, in itemsColliding, ref matchedColliderIds);
 					}
 
 					if (isRight) {
-						_children[1].Value.GetAabbOverlaps(in ball, ref matchedColliderIds);
+						_children[1].Value.GetAabbOverlaps(in ball, in itemsColliding, ref matchedColliderIds);
 					}
 				}
 
 				if (ballAabb.Bottom >= _center.y) {
 					// Bottom
 					if (isLeft) {
-						_children[2].Value.GetAabbOverlaps(in ball, ref matchedColliderIds);
+						_children[2].Value.GetAabbOverlaps(in ball, in itemsColliding, ref matchedColliderIds);
 					}
 
 					if (isRight) {
-						_children[3].Value.GetAabbOverlaps(in ball, ref matchedColliderIds);
+						_children[3].Value.GetAabbOverlaps(in ball, in itemsColliding, ref matchedColliderIds);
 					}
 				}
 			}

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/QuadTreeCreator.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/QuadTreeCreator.cs
@@ -36,7 +36,7 @@ namespace VisualPinball.Unity
 		private static readonly ProfilerMarker PerfMarkerCreateQuadTree = new ProfilerMarker("QuadTreeCreator (3 - create quad tree)");
 		private static readonly ProfilerMarker PerfMarkerSaveToEntity = new ProfilerMarker("QuadTreeCreator (4 - save to entity)");
 
-		public static void Create(EntityManager entityManager)
+		public static void Create(EntityManager entityManager, ref NativeHashMap<Entity, bool> itemsColliding)
 		{
 			PerfMarkerTotal.Begin();
 
@@ -47,8 +47,12 @@ namespace VisualPinball.Unity
 			PerfMarkerGenerateColliders.Begin();
 			var colliderList = new List<ICollider>();
 			var (playfieldCollider, glassCollider) = player.TableApi.CreateColliders(player.Table);
+			itemsColliding = new NativeHashMap<Entity, bool>(itemApis.Length, Allocator.Persistent);
 			foreach (var itemApi in itemApis) {
 				PerfMarkerCreateColliders.Begin();
+				if (itemApi.ColliderEntity != Entity.Null) {
+					itemsColliding.Add(itemApi.ColliderEntity, itemApi.IsColliderEnabled);
+				}
 				itemApi.CreateColliders(player.Table, colliderList);
 				PerfMarkerCreateColliders.End();
 			}

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticBroadPhaseSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticBroadPhaseSystem.cs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using NLog;
+using Unity.Collections;
 using Unity.Entities;
 using Unity.Profiling;
 using Logger = NLog.Logger;
@@ -26,6 +27,7 @@ namespace VisualPinball.Unity
 	{
 		private EntityQuery _quadTreeEntityQuery;
 		private static readonly ProfilerMarker PerfMarker = new ProfilerMarker("StaticBroadPhaseSystem");
+
 
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/SystemGroup/SimulateCycleSystemGroup.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/SystemGroup/SimulateCycleSystemGroup.cs
@@ -39,6 +39,8 @@ namespace VisualPinball.Unity
 		/// </summary>
 		public bool SwapBallCollisionHandling;
 
+		public NativeHashMap<Entity, bool> ItemsColliding;
+
 		public DefaultPhysicsEngine PhysicsEngine;
 
 		public override IReadOnlyList<ComponentSystemBase> Systems => _systemsToUpdate;
@@ -66,7 +68,7 @@ namespace VisualPinball.Unity
 		protected override void OnStartRunning()
 		{
 			base.OnStartRunning();
-			QuadTreeCreator.Create(EntityManager);
+			QuadTreeCreator.Create(EntityManager, ref ItemsColliding);
 		}
 
 		protected override void OnCreate()

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperApi.cs
@@ -59,12 +59,12 @@ namespace VisualPinball.Unity
 
 		void IApiWireDest.OnChange(bool enabled) => (this as IApiCoil).OnCoil(enabled, false);
 
-
 		#region Collider Generation
 
-		protected override bool IsColliderEnabled => Data.IsCollidable;
+		public override bool IsColliderEnabled => Data.IsCollidable;
 		protected override bool FireHitEvents => Data.HitEvent;
 		protected override float HitThreshold => Data.Threshold;
+		Entity IApiColliderGenerator.ColliderEntity => Entity;
 
 		void IApiColliderGenerator.CreateColliders(Table table, List<ICollider> colliders)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperApi.cs
@@ -173,6 +173,8 @@ namespace VisualPinball.Unity
 
 		#region Collider Generation
 
+		Entity IApiColliderGenerator.ColliderEntity => Entity;
+
 		void IApiColliderGenerator.CreateColliders(Table table, List<ICollider> colliders)
 		{
 			var height = table.GetSurfaceHeight(Data.Surface, Data.Center.X, Data.Center.Y);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateApi.cs
@@ -83,6 +83,8 @@ namespace VisualPinball.Unity
 
 		#region Collider Generation
 
+		Entity IApiColliderGenerator.ColliderEntity => Entity;
+
 		void IApiColliderGenerator.CreateColliders(Table table, List<ICollider> colliders)
 		{
 			var colliderGenerator = new GateColliderGenerator(this);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetApi.cs
@@ -94,6 +94,7 @@ namespace VisualPinball.Unity
 
 		protected override bool FireHitEvents => Data.UseHitEvent;
 		protected override float HitThreshold => Data.Threshold;
+		Entity IApiColliderGenerator.ColliderEntity => Entity;
 
 		void IApiColliderGenerator.CreateColliders(Table table, List<ICollider> colliders)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/IApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/IApi.cs
@@ -37,6 +37,8 @@ namespace VisualPinball.Unity
 	{
 		void CreateColliders(Table table, List<ICollider> colliders);
 		ColliderInfo GetColliderInfo(Table table);
+		Entity ColliderEntity { get; }
+		bool IsColliderEnabled { get; }
 	}
 
 	public interface IApiHittable

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemApi.cs
@@ -80,7 +80,7 @@ namespace VisualPinball.Unity
 
 		#region Collider
 
-		protected virtual bool IsColliderEnabled  => !(Data is IPhysicalData physicalData) || physicalData.GetIsCollidable();
+		public virtual bool IsColliderEnabled  => !(Data is IPhysicalData physicalData) || physicalData.GetIsCollidable();
 		protected virtual bool FireHitEvents { get; } = false;
 		protected virtual float HitThreshold { get; } = 0;
 		protected virtual PhysicsMaterialData GetPhysicsMaterial(Table table)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerApi.cs
@@ -189,7 +189,8 @@ namespace VisualPinball.Unity
 
 		#region Collider Generation
 
-		protected override bool IsColliderEnabled => Data.IsEnabled;
+		public override bool IsColliderEnabled => Data.IsEnabled;
+		Entity IApiColliderGenerator.ColliderEntity => Entity;
 
 		void IApiColliderGenerator.CreateColliders(Table table, List<ICollider> colliders)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerApi.cs
@@ -142,8 +142,9 @@ namespace VisualPinball.Unity
 
 		IApiWireDest IApiWireDeviceDest.Wire(string coilId) => (this as IApiCoilDevice).Coil(coilId);
 
-
 		#region Collider Generation
+
+		Entity IApiColliderGenerator.ColliderEntity => Entity;
 
 		void IApiColliderGenerator.CreateColliders(Table table, List<ICollider> colliders)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveApi.cs
@@ -43,6 +43,7 @@ namespace VisualPinball.Unity
 
 		protected override bool FireHitEvents => Data.HitEvent;
 		protected override float HitThreshold => Data.Threshold;
+		Entity IApiColliderGenerator.ColliderEntity => Entity;
 
 		void IApiColliderGenerator.CreateColliders(Table table, List<ICollider> colliders)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampApi.cs
@@ -46,6 +46,7 @@ namespace VisualPinball.Unity
 
 		protected override bool FireHitEvents => Data.HitEvent;
 		protected override float HitThreshold => Data.Threshold;
+		Entity IApiColliderGenerator.ColliderEntity => Entity;
 
 		void IApiColliderGenerator.CreateColliders(Table table, List<ICollider> colliders)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberApi.cs
@@ -42,6 +42,7 @@ namespace VisualPinball.Unity
 
 		protected override bool FireHitEvents => Data.HitEvent;
 		protected override float HitThreshold { get; } = 2.0f; // hard coded threshold for now
+		Entity IApiColliderGenerator.ColliderEntity => Entity;
 
 		void IApiColliderGenerator.CreateColliders(Table table, List<ICollider> colliders)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerApi.cs
@@ -79,6 +79,7 @@ namespace VisualPinball.Unity
 		#region Collider Generation
 
 		protected override bool FireHitEvents { get; } = true;
+		Entity IApiColliderGenerator.ColliderEntity => Entity;
 
 		void IApiColliderGenerator.CreateColliders(Table table, List<ICollider> colliders)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceApi.cs
@@ -47,6 +47,7 @@ namespace VisualPinball.Unity
 
 		protected override bool FireHitEvents { get; } = true;
 		protected override float HitThreshold => Data.Threshold;
+		Entity IApiColliderGenerator.ColliderEntity => Entity;
 
 		void IApiColliderGenerator.CreateColliders(Table table, List<ICollider> colliders)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableApi.cs
@@ -166,6 +166,9 @@ namespace VisualPinball.Unity
 
 		#endregion
 
+		Entity IApiColliderGenerator.ColliderEntity { get; } = Entity.Null;
+		bool IApiColliderGenerator.IsColliderEnabled { get; } = true;
+
 		internal (PlaneCollider, PlaneCollider) CreateColliders(Table table)
 		{
 			var info = new ColliderInfo {

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableApi.cs
@@ -166,7 +166,7 @@ namespace VisualPinball.Unity
 
 		#endregion
 
-		Entity IApiColliderGenerator.ColliderEntity { get; } = Entity.Null;
+		Entity IApiColliderGenerator.ColliderEntity { get; } = Player.TableEntity;
 		bool IApiColliderGenerator.IsColliderEnabled { get; } = true;
 
 		internal (PlaneCollider, PlaneCollider) CreateColliders(Table table)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerApi.cs
@@ -56,6 +56,7 @@ namespace VisualPinball.Unity
 		#region Collider Generation
 
 		protected override bool FireHitEvents { get; } = true;
+		Entity IApiColliderGenerator.ColliderEntity => Entity;
 
 		void IApiColliderGenerator.CreateColliders(Table table, List<ICollider> colliders)
 		{


### PR DESCRIPTION
Until now, all colliders were enabled during gameplay. This PR stores the states in a `NativeHashMap` which are checked during runtime.