### PR TITLE
Add comma/period variation support and refactor shaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 Built with [Unity 2020.2](https://github.com/freezy/VisualPinball.Engine/pull/255).
 
 ### Added
+- DMD and segment display support ([Documentation](https://docs.visualpinball.org/creators-guide/manual/displays.html)).
 - Plugin: Mission Pinball Framework ([Documentation](https://docs.visualpinball.org/plugins/mpf/index.html))
 - Gamelogic Engine: Support for hardware rules ([#293](https://github.com/freezy/VisualPinball.Engine/pull/293)).
 - Support for Extended ASCII strings ([#291](https://github.com/freezy/VisualPinball.Engine/pull/291)).

--- a/VisualPinball.Unity/Assets/Resources/Materials/DotMatrixDisplay.mat
+++ b/VisualPinball.Unity/Assets/Resources/Materials/DotMatrixDisplay.mat
@@ -265,7 +265,7 @@ Material:
     - _ZTestGBuffer: 4
     - _ZTestTransparent: 4
     - _ZWrite: 1
-    - __DotSize: 0.7
+    - __Padding: 0.2
     - __NumChars: 2
     - __NumSegments: 15
     - __SegmentType: 0

--- a/VisualPinball.Unity/Assets/Resources/Materials/DotMatrixDisplay.mat
+++ b/VisualPinball.Unity/Assets/Resources/Materials/DotMatrixDisplay.mat
@@ -10,8 +10,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: da692e001514ec24dbc4cca1949ff7e8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   version: 11
 --- !u!21 &2100000
 Material:
@@ -127,7 +127,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - __Data:
-        m_Texture: {fileID: 2800000, guid: a1ce5429ec1062b479416ab08326d360, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - __SegmentData:
@@ -265,7 +265,7 @@ Material:
     - _ZTestGBuffer: 4
     - _ZTestTransparent: 4
     - _ZWrite: 1
-    - __DotSize2: 1.7
+    - __DotSize: 0.7
     - __NumChars: 2
     - __NumSegments: 15
     - __SegmentType: 0
@@ -291,7 +291,7 @@ Material:
     - _UVDetailsMappingMask: {r: 1, g: 0, b: 0, a: 0}
     - _UVMappingMask: {r: 1, g: 0, b: 0, a: 0}
     - _UVMappingMaskEmissive: {r: 1, g: 0, b: 0, a: 0}
-    - __Dimensions: {r: 128, g: 32, b: 0, a: 0}
+    - __Dimensions: {r: 12, g: 7, b: 0, a: 0}
     - __LitColor: {r: 1, g: 0.39999998, b: 0, a: 0}
     - __Padding: {r: 0.3, g: 0.5, b: 0, a: 0}
     - __UnlitColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}

--- a/VisualPinball.Unity/Assets/Resources/Materials/DotMatrixDisplayBuiltin.mat
+++ b/VisualPinball.Unity/Assets/Resources/Materials/DotMatrixDisplayBuiltin.mat
@@ -9,7 +9,7 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: DotMatrixDisplayBuiltin
   m_Shader: {fileID: 4800000, guid: 7130383a7e4e55b429fe3af74b2f192e, type: 3}
-  m_ShaderKeywords: 
+  m_ShaderKeywords:
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -43,7 +43,7 @@ Material:
     - _TargetHeight: 118.01
     - _TargetWidth: 1450.11
     - _Width: 128
-    - __DotSize2: 0.83
+    - __DotSize: 0.7
     m_Colors:
     - _Color: {r: 1, g: 0.9, b: 0, a: 1}
     - __Dimensions: {r: 128, g: 32, b: 0, a: 0}

--- a/VisualPinball.Unity/Assets/Resources/Materials/DotMatrixDisplayBuiltin.mat
+++ b/VisualPinball.Unity/Assets/Resources/Materials/DotMatrixDisplayBuiltin.mat
@@ -43,7 +43,7 @@ Material:
     - _TargetHeight: 118.01
     - _TargetWidth: 1450.11
     - _Width: 128
-    - __DotSize: 0.7
+    - __Padding: 0.2
     m_Colors:
     - _Color: {r: 1, g: 0.9, b: 0, a: 1}
     - __Dimensions: {r: 128, g: 32, b: 0, a: 0}

--- a/VisualPinball.Unity/Assets/Shaders/Builtin/DotMatrixDisplayShader.shader
+++ b/VisualPinball.Unity/Assets/Shaders/Builtin/DotMatrixDisplayShader.shader
@@ -4,8 +4,8 @@
 	{
 		_MainTex ("Texture", 2D) = "white" {}
 		__Dimensions ("Dimensions", Vector) = (128, 32, 0, 0)
-		__DotSize ("Dot Size", Float) = 0.7
-		__Sharpness ("Sharpness", Float) = .3
+		__Padding ("Padding", Range(0.0, 0.8)) = .2
+		__Roundness ("Roundness", Range(0.0, 0.5)) = .35
 	}
 	SubShader
 	{
@@ -39,8 +39,8 @@
 			float4 _MainTex_ST;
 
 			float2 __Dimensions;
-			float __DotSize;
-			float __Sharpness;
+			float __Padding;
+			float __Roundness;
 
 			v2f vert (appdata v)
 			{
@@ -58,8 +58,7 @@
 
 				float4 pixelColor = tex2D(_MainTex, dotCenter);
 				float4 outColor;
-
-				RoundDot_float(i.uv, __Dimensions, __DotSize, __Sharpness, pixelColor, outColor);
+				Dot_float(i.uv, __Dimensions, __Padding, __Roundness, pixelColor, outColor);
 
 				return outColor;
 			}

--- a/VisualPinball.Unity/Assets/Shaders/Builtin/DotMatrixDisplayShader.shader
+++ b/VisualPinball.Unity/Assets/Shaders/Builtin/DotMatrixDisplayShader.shader
@@ -4,7 +4,8 @@
 	{
 		_MainTex ("Texture", 2D) = "white" {}
 		__Dimensions ("Dimensions", Vector) = (128, 32, 0, 0)
-		__DotSize2 ("Dot Size", Float) = 1.25
+		__DotSize ("Dot Size", Float) = 0.7
+		__Sharpness ("Sharpness", Float) = .3
 	}
 	SubShader
 	{
@@ -37,8 +38,9 @@
 			sampler2D _MainTex;
 			float4 _MainTex_ST;
 
-			float __DotSize2;
 			float2 __Dimensions;
+			float __DotSize;
+			float __Sharpness;
 
 			v2f vert (appdata v)
 			{
@@ -55,9 +57,9 @@
 				SamplePosition_float(i.uv, __Dimensions, dotCenter);
 
 				float4 pixelColor = tex2D(_MainTex, dotCenter);
-
 				float4 outColor;
-				RoundDot_float(i.uv, __Dimensions, __DotSize2, pixelColor, dotCenter, outColor);
+
+				RoundDot_float(i.uv, __Dimensions, __DotSize, __Sharpness, pixelColor, outColor);
 
 				return outColor;
 			}

--- a/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.hlsl
+++ b/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.hlsl
@@ -1,8 +1,7 @@
 ﻿// this shader is identical to the one in ../Srp, the only
 // difference is that it uses sampler2D instead of UnityTexture2D.
 
-float _SegmentWidth;
-int _SegmentType;
+float _SegmentWeight;
 float _Height;
 float _NumChars;
 float _NumSegments;
@@ -115,7 +114,7 @@ float LongLine(float2 a, float2 b, float2 p)
 	float2 pa = p - float2(a.x, -a.y);
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
 	float t = clamp(dot(pa, ba) / dot(ba, ba), SegmentGap, 1.0 - SegmentGap);
-	float2 v = abs(pa - ba * t) / _SegmentWidth * 0.5;
+	float2 v = abs(pa - ba * t) / _SegmentWeight * 0.5;
 
 	return Rounder2(1 - v.x, 1 - v.y - v.x);
 }
@@ -125,7 +124,7 @@ float LongLine2(float2 a, float2 b, float2 p)
 	float2 pa = p - float2(a.x, -a.y);
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
 	float t = clamp(dot(pa, ba) / dot(ba, ba), SegmentGap, 1.0 - SegmentGap);
-	float2 v = abs(pa - ba * t) / _SegmentWidth * 0.5;
+	float2 v = abs(pa - ba * t) / _SegmentWeight * 0.5;
 
 	return Rounder2(1 - v.x, 1 - v.y - v.x);
 }
@@ -135,7 +134,7 @@ float ShortLine(float2 a, float2 b, float2 p)
 	float2 pa = p - float2(a.x, -a.y);
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
 	float t = clamp(dot(pa, ba) / dot(ba, ba), SegmentGap * 2.0, 1.0 - SegmentGap * 2.0);
-	float2 v = abs(pa - ba * t) / _SegmentWidth * 0.5;
+	float2 v = abs(pa - ba * t) / _SegmentWeight * 0.5;
 
 	return Rounder2(1 - v.x, 1 - v.y - v.x);
 }
@@ -145,7 +144,7 @@ float MidLine(float2 a, float2 b, float2 p)
 	float2 pa = p - float2(a.x, -a.y);
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
 	float t = clamp(dot(pa, ba) / dot(ba, ba), SegmentGap * 1.1, 1.0 - SegmentGap * 1.1);
-	float2 v = abs(pa - ba * t) / _SegmentWidth * 0.5;
+	float2 v = abs(pa - ba * t) / _SegmentWeight * 0.5;
 
 	return Rounder2(1 - v.x, 1 - v.y - v.x);
 }
@@ -156,15 +155,15 @@ float DiagLine(float2 a, float2 b, float2 p)
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
 	float t = pa.x / ba.x;
 	float2 intersectP = abs(pa - ba * t);
-	float xl = clamp(1 - (p.x - a.x + SegmentGap + _SegmentWidth) / _SegmentWidth * 0.5, -9999, 1);
-	float xr = clamp(0 + (p.x - b.x - SegmentGap + _SegmentWidth) / _SegmentWidth * 0.5, -9999, 1);
+	float xl = clamp(1 - (p.x - a.x + SegmentGap + _SegmentWeight) / _SegmentWeight * 0.5, -9999, 1);
+	float xr = clamp(0 + (p.x - b.x - SegmentGap + _SegmentWeight) / _SegmentWeight * 0.5, -9999, 1);
 
 	float t2 = pa.y / ba.y;
 	float yu = clamp(t2 + 1.0 - SegmentGap * 2, -9999, 1);
 	float yd = clamp(2 - t2 - SegmentGap * 2, -9999, 1);
 
 	return Rounder(
-		1 - intersectP.y / (_SegmentWidth * 4.0),
+		1 - intersectP.y / (_SegmentWeight * 4.0),
 		xl * xr,
 		(yd * yu) / SegmentGap * 0.5 - 4.0
 	);
@@ -176,15 +175,15 @@ float DiagLine2(float2 a, float2 b, float2 p)
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
 	float t = pa.x / ba.x;
 	float2 intersectP = abs(pa - ba * t);
-	float xr = clamp(0 + (p.x - a.x - SegmentGap + _SegmentWidth) / _SegmentWidth * 0.5, -9999, 1);
-	float xl = clamp(1 - (p.x - b.x + SegmentGap + _SegmentWidth) / _SegmentWidth * 0.5, -9999, 1);
+	float xr = clamp(0 + (p.x - a.x - SegmentGap + _SegmentWeight) / _SegmentWeight * 0.5, -9999, 1);
+	float xl = clamp(1 - (p.x - b.x + SegmentGap + _SegmentWeight) / _SegmentWeight * 0.5, -9999, 1);
 
 	float t2 = pa.y / ba.y;
 	float yu = clamp(t2 + 1.0 - SegmentGap * 2, -9999, 1);
 	float yd = clamp(2 - t2 - SegmentGap * 2, -9999, 1);
 
 	return Rounder(
-		1 - intersectP.y / (_SegmentWidth * 4.0),
+		1 - intersectP.y / (_SegmentWeight * 4.0),
 		xl * xr,
 		(yd * yu) / SegmentGap * 0.5 - 4.0
 	);
@@ -196,15 +195,15 @@ float DiagLine3(float2 a, float2 b, float2 p)
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
 	float t = pa.x / ba.x;
 	float2 intersectP = abs(pa - ba * t);
-	float xl = clamp(1 - (p.x - a.x + SegmentGap + _SegmentWidth) / _SegmentWidth * 0.5, -9999, 1);
-	float xr = clamp(0 + (p.x - b.x - SegmentGap + _SegmentWidth) / _SegmentWidth * 0.5, -9999, 1);
+	float xl = clamp(1 - (p.x - a.x + SegmentGap + _SegmentWeight) / _SegmentWeight * 0.5, -9999, 1);
+	float xr = clamp(0 + (p.x - b.x - SegmentGap + _SegmentWeight) / _SegmentWeight * 0.5, -9999, 1);
 
 	float t2 = pa.y / ba.y;
 	float yu = clamp(t2 + 1.0 - SegmentGap * 2, -9999, 1);
 	float yd = clamp(2 - t2 - SegmentGap * 2, -9999, 1);
 
 	return Rounder(
-		1 - intersectP.y / (_SegmentWidth * 3.0),
+		1 - intersectP.y / (_SegmentWeight * 3.0),
 		xl * xr,
 		(yd * yu) / SegmentGap * 0.5 - 4.0
 	);
@@ -254,12 +253,7 @@ float3 Combine(float3 accu, float val, bool showSeg)
 
 bool ShowSeg(sampler2D data, int charIndex, int segIndex)
 {
-	int numSegs = 1;
-	switch (_SegmentType) {
-		case 0: numSegs = 15; break;
-		case 4: numSegs = 8; break;
-	}
-	float2 d = float2(1. / numSegs, 1. / _NumChars);
+	float2 d = float2(1. / 16, 1. / _NumChars);
 	float2 pos = float2(float(segIndex), float(charIndex));
 	float4 pixel = tex2Dlod(data, float4(d.x * (pos.x + .5), d.y * (pos.y + .5), 0., 0.));
 	if (pixel.b > .5) {
@@ -291,7 +285,7 @@ float3 SegDispSeparator(sampler2D data, int charIndex, int segIndex, float2 p, f
 	return r;
 }
 
-float3 SegDisp8(sampler2D data, int charIndex, float2 p, float3 r)
+float3 SegDisp7(sampler2D data, int charIndex, float2 p, float3 r)
 {
 	r = Combine(r, MidLine(tl, tr, p), ShowSeg(data, charIndex, 0));
 	r = Combine(r, LongLine(tr, mr, p), ShowSeg(data, charIndex, 1));
@@ -305,7 +299,7 @@ float3 SegDisp8(sampler2D data, int charIndex, float2 p, float3 r)
 	return r;
 }
 
-float3 SegDisp10(sampler2D data, int charIndex, float2 p, float3 r)
+float3 SegDisp9(sampler2D data, int charIndex, float2 p, float3 r)
 {
 	r = Combine(r, MidLine(tl, tr, p), ShowSeg(data, charIndex, 0));
 	r = Combine(r, LongLine(tr, mr, p), ShowSeg(data, charIndex, 1));
@@ -321,7 +315,7 @@ float3 SegDisp10(sampler2D data, int charIndex, float2 p, float3 r)
 	return r;
 }
 
-float3 SegDisp15(sampler2D data, int charIndex, float2 p, float3 r)
+float3 SegDisp14(sampler2D data, int charIndex, float2 p, float3 r)
 {
 	r = Combine(r, MidLine(tl, tr, p), ShowSeg(data, charIndex, 0));
 	r = Combine(r, LongLine(tr, mr, p), ShowSeg(data, charIndex, 1));
@@ -346,20 +340,19 @@ float3 SegDisp(sampler2D data, int charIndex, float2 p)
 {
 	float3 r = (0.);
 	p.x -= p.y * -_SkewAngle;
-	switch (_SegmentType) {
-		case 0: return SegDisp15(data, charIndex, p, r);
-		case 2: return SegDisp10(data, charIndex, p, r);
-		case 4: return SegDisp8(data, charIndex, p, r);
+	switch (_NumSegments) {
+		case 7: return SegDisp7(data, charIndex, p, r);
+		case 9: return SegDisp9(data, charIndex, p, r);
+		case 14: return SegDisp14(data, charIndex, p, r);
 	}
 	return r;
 }
 
-void SegmentDisplay_float(float2 coords, sampler2D data, float segmentType, float numChars,
-	float numSegments, int separatorType, int separatorEveryThreeOnly, float2 separatorPos,
-	float segmentWidth, float horizontalMiddle, float skewAngle, float2 padding, out float output)
+void SegmentDisplay_float(float2 coords, sampler2D data, float numChars, float numSegments,
+	int separatorType, int separatorEveryThreeOnly, float2 separatorPos, float segmentWeight,
+	float horizontalMiddle, float skewAngle, float2 padding, out float output)
 {
-	_SegmentWidth = segmentWidth;
-	_SegmentType = segmentType;
+	_SegmentWeight = segmentWeight;
 	_NumChars = numChars;
 	_NumSegments = numSegments;
 	_SkewAngle = skewAngle;
@@ -368,14 +361,14 @@ void SegmentDisplay_float(float2 coords, sampler2D data, float segmentType, floa
 	_SeparatorEveryThreeOnly = separatorEveryThreeOnly;
 	_SeparatorPos = separatorPos;
 
-	SegmentGap = segmentWidth * 1.5;
-	dtl = tl + float2(0.0, -segmentWidth);
-	dtr = tr + float2(0.0, -segmentWidth);
-	dtm = mm + float2(0.0 + _HorizontalMiddle, segmentWidth);
-	dbm = mm + float2(0.0 + _HorizontalMiddle, -segmentWidth);
-	dbl = bl + float2(0.0, segmentWidth);
-	dbr = br + float2(0.0, segmentWidth);
-	dp = br + float2(segmentWidth * 4.0, SegmentGap);
+	SegmentGap = segmentWeight * 1.5;
+	dtl = tl + float2(0.0, -segmentWeight);
+	dtr = tr + float2(0.0, -segmentWeight);
+	dtm = mm + float2(0.0 + _HorizontalMiddle, segmentWeight);
+	dbm = mm + float2(0.0 + _HorizontalMiddle, -segmentWeight);
+	dbl = bl + float2(0.0, segmentWeight);
+	dbr = br + float2(0.0, segmentWeight);
+	dp = br + float2(segmentWeight * 4.0, SegmentGap);
 	mm = float2(.0 + _HorizontalMiddle, 0);   // middle
 	tm = float2(.0 + _HorizontalMiddle, 1);
 	bm = float2(.0 + _HorizontalMiddle, -1);
@@ -396,7 +389,7 @@ void SegmentDisplay_float(float2 coords, sampler2D data, float segmentType, floa
 	float2 pos = originPos;
 	float3 d = (0.);
 
-	float2 f = float2(numChars * (1. + padding.x + segmentWidth * 2.), 1. + (padding.y + segmentWidth));
+	float2 f = float2(numChars * (1. + padding.x + segmentWeight * 2.), 1. + (padding.y + segmentWeight));
 	for (int character = 0; character < numChars; character++) {
 
 		d += SegDisp(data, character, (uv - pos) * f);

--- a/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.hlsl
+++ b/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.hlsl
@@ -205,9 +205,12 @@ float DiagLine3(float2 a, float2 b, float2 p)
 	);
 }
 
-float Circle(float2 _st, float _radius)
+float2 Translate(float2 coord, float2 translate) {
+	return coord - translate;
+}
+
+float Circle(float2 _st, float _radius, float smooth)
 {
-	float smooth = 2.;
 	_st.x += _st.y * -_SkewAngle; // un-angle
 	_st.x += _SkewAngle * 0.5; // un-angle
 	_st.y *= 0.9; // unstretch
@@ -217,6 +220,18 @@ float Circle(float2 _st, float _radius)
 		_radius + (_radius * smooth),
 		dot(dist, dist) * 4.0
 	);
+}
+
+float Comma(float2 uv)
+{
+	if (uv.y < 0.61) {
+		return 0.;
+	}
+
+	float c = Circle(Translate(uv, float2(-0.15, 0.1)), 0.15, .7);   // plus
+	c *= 1. - Circle(Translate(uv, float2(-0.01, 0.05)), 0.01, 2.5); // minus top
+	c *= 1. - Circle(Translate(uv, float2(-0.42, .13)), 0.48, .3);   // minus left
+	return c;
 }
 
 float3 Combine(float3 accu, float val, bool showSeg)
@@ -257,7 +272,7 @@ float3 SegDisp8(sampler2D data, int charIndex, float2 p, float3 r)
 	r = Combine(r, LongLine(bl, ml, p), ShowSeg(data, charIndex, 4));
 	r = Combine(r, LongLine(ml, tl, p), ShowSeg(data, charIndex, 5));
 	r = Combine(r, MidLine(mr, ml, p), ShowSeg(data, charIndex, 6));
-	r = Combine(r, Circle(float2(p.x - 0.2, p.y - 0.43), 0.025), ShowSeg(data, charIndex, 7));
+	r = Combine(r, Circle(float2(p.x - 0.2, p.y - 0.43), 0.025, 1.5), ShowSeg(data, charIndex, 7));
 	return r;
 }
 
@@ -270,7 +285,7 @@ float3 SegDisp10(sampler2D data, int charIndex, float2 p, float3 r)
 	r = Combine(r, LongLine(bl, ml, p), ShowSeg(data, charIndex, 4));
 	r = Combine(r, LongLine(ml, tl, p), ShowSeg(data, charIndex, 5));
 	r = Combine(r, MidLine(mr, ml, p), ShowSeg(data, charIndex, 6));
-	r = Combine(r, Circle(float2(p.x - 0.2, p.y - 0.43), 0.025), ShowSeg(data, charIndex, 7));
+	r = Combine(r, Circle(float2(p.x - 0.2, p.y - 0.43), 0.025, 1.5), ShowSeg(data, charIndex, 7));
 	r = Combine(r, DiagLine3(dtr, dtm, p), ShowSeg(data, charIndex, 8));
 	r = Combine(r, DiagLine3(dbm, dbl, p), ShowSeg(data, charIndex, 9));
 
@@ -286,7 +301,7 @@ float3 SegDisp15(sampler2D data, int charIndex, float2 p, float3 r)
 	r = Combine(r, LongLine(bl, ml, p), ShowSeg(data, charIndex, 4));
 	r = Combine(r, LongLine(ml, tl, p), ShowSeg(data, charIndex, 5));
 	r = Combine(r, ShortLine(mm, ml, p), ShowSeg(data, charIndex, 6));
-	r = Combine(r, Circle(float2(p.x - 0.2, p.y - 0.43), 0.025), ShowSeg(data, charIndex, 7));
+	r = Combine(r, Circle(float2(p.x - 0.2, p.y - 0.43), 0.025, 1.5), ShowSeg(data, charIndex, 7));
 	r = Combine(r, DiagLine2(dtl, dtm, p), ShowSeg(data, charIndex, 8));
 	r = Combine(r, LongLine2(tm, mm, p), ShowSeg(data, charIndex, 9));
 	r = Combine(r, DiagLine(dtr, dtm, p), ShowSeg(data, charIndex, 10));
@@ -294,6 +309,7 @@ float3 SegDisp15(sampler2D data, int charIndex, float2 p, float3 r)
 	r = Combine(r, DiagLine2(dbm, dbr, p), ShowSeg(data, charIndex, 12));
 	r = Combine(r, LongLine(mm, bm, p), ShowSeg(data, charIndex, 13));
 	r = Combine(r, DiagLine(dbm, dbl, p), ShowSeg(data, charIndex, 14));
+	r = Combine(r, Comma(float2(p.x - 0.2, p.y - 0.43)), ShowSeg(data, charIndex, 15));
 
 	return r;
 }

--- a/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.hlsl
+++ b/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.hlsl
@@ -309,8 +309,8 @@ float3 SegDisp9(sampler2D data, int charIndex, float2 p, float3 r)
 	r = Combine(r, LongLine(ml, tl, p), ShowSeg(data, charIndex, 5));
 	r = Combine(r, MidLine(mr, ml, p), ShowSeg(data, charIndex, 6));
 	r = SegDispSeparator(data, charIndex, 7, p, r);
-	r = Combine(r, DiagLine3(dtr, dtm, p), ShowSeg(data, charIndex, 8));
-	r = Combine(r, DiagLine3(dbm, dbl, p), ShowSeg(data, charIndex, 9));
+	r = Combine(r, LongLine2(tm, mm, p), ShowSeg(data, charIndex, 8));
+	r = Combine(r, LongLine(mm, bm, p), ShowSeg(data, charIndex, 9));
 
 	return r;
 }

--- a/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.hlsl
+++ b/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.hlsl
@@ -109,23 +109,15 @@ float DiagDist(float2 v)
 	return abs(v.x);
 }
 
-float LongLine(float2 a, float2 b, float2 p)
+float LongLine(float2 a, float2 b, float2 p, bool topFlat, bool bottomFlat)
 {
+	if ((topFlat && p.y < min(-a.y, -b.y) + SegmentGap) || (bottomFlat && p.y > max(-a.y, -b.y) - SegmentGap)) {
+		return 0;
+	}
 	float2 pa = p - float2(a.x, -a.y);
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
 	float t = clamp(dot(pa, ba) / dot(ba, ba), SegmentGap, 1.0 - SegmentGap);
 	float2 v = abs(pa - ba * t) / _SegmentWeight * 0.5;
-
-	return Rounder2(1 - v.x, 1 - v.y - v.x);
-}
-
-float LongLine2(float2 a, float2 b, float2 p)
-{
-	float2 pa = p - float2(a.x, -a.y);
-	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
-	float t = clamp(dot(pa, ba) / dot(ba, ba), SegmentGap, 1.0 - SegmentGap);
-	float2 v = abs(pa - ba * t) / _SegmentWeight * 0.5;
-
 	return Rounder2(1 - v.x, 1 - v.y - v.x);
 }
 
@@ -149,7 +141,7 @@ float MidLine(float2 a, float2 b, float2 p)
 	return Rounder2(1 - v.x, 1 - v.y - v.x);
 }
 
-float DiagLine(float2 a, float2 b, float2 p)
+float DiagLineForward(float2 a, float2 b, float2 p)
 {
 	float2 pa = p - float2(a.x, -a.y);
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
@@ -169,7 +161,7 @@ float DiagLine(float2 a, float2 b, float2 p)
 	);
 }
 
-float DiagLine2(float2 a, float2 b, float2 p)
+float DiagLineBackward(float2 a, float2 b, float2 p)
 {
 	float2 pa = p - float2(a.x, -a.y);
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
@@ -184,26 +176,6 @@ float DiagLine2(float2 a, float2 b, float2 p)
 
 	return Rounder(
 		1 - intersectP.y / (_SegmentWeight * 4.0),
-		xl * xr,
-		(yd * yu) / SegmentGap * 0.5 - 4.0
-	);
-}
-
-float DiagLine3(float2 a, float2 b, float2 p)
-{
-	float2 pa = p - float2(a.x, -a.y);
-	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
-	float t = pa.x / ba.x;
-	float2 intersectP = abs(pa - ba * t);
-	float xl = clamp(1 - (p.x - a.x + SegmentGap + _SegmentWeight) / _SegmentWeight * 0.5, -9999, 1);
-	float xr = clamp(0 + (p.x - b.x - SegmentGap + _SegmentWeight) / _SegmentWeight * 0.5, -9999, 1);
-
-	float t2 = pa.y / ba.y;
-	float yu = clamp(t2 + 1.0 - SegmentGap * 2, -9999, 1);
-	float yd = clamp(2 - t2 - SegmentGap * 2, -9999, 1);
-
-	return Rounder(
-		1 - intersectP.y / (_SegmentWeight * 3.0),
 		xl * xr,
 		(yd * yu) / SegmentGap * 0.5 - 4.0
 	);
@@ -288,11 +260,11 @@ float3 SegDispSeparator(sampler2D data, int charIndex, int segIndex, float2 p, f
 float3 SegDisp7(sampler2D data, int charIndex, float2 p, float3 r)
 {
 	r = Combine(r, MidLine(tl, tr, p), ShowSeg(data, charIndex, 0));
-	r = Combine(r, LongLine(tr, mr, p), ShowSeg(data, charIndex, 1));
-	r = Combine(r, LongLine(mr, br, p), ShowSeg(data, charIndex, 2));
+	r = Combine(r, LongLine(tr, mr, p, false, false), ShowSeg(data, charIndex, 1));
+	r = Combine(r, LongLine(mr, br, p, false, false), ShowSeg(data, charIndex, 2));
 	r = Combine(r, MidLine(br, bl, p), ShowSeg(data, charIndex, 3));
-	r = Combine(r, LongLine(bl, ml, p), ShowSeg(data, charIndex, 4));
-	r = Combine(r, LongLine(ml, tl, p), ShowSeg(data, charIndex, 5));
+	r = Combine(r, LongLine(bl, ml, p, false, false), ShowSeg(data, charIndex, 4));
+	r = Combine(r, LongLine(ml, tl, p, false, false), ShowSeg(data, charIndex, 5));
 	r = Combine(r, MidLine(mr, ml, p), ShowSeg(data, charIndex, 6));
 	r = SegDispSeparator(data, charIndex, 7, p, r);
 
@@ -302,15 +274,15 @@ float3 SegDisp7(sampler2D data, int charIndex, float2 p, float3 r)
 float3 SegDisp9(sampler2D data, int charIndex, float2 p, float3 r)
 {
 	r = Combine(r, MidLine(tl, tr, p), ShowSeg(data, charIndex, 0));
-	r = Combine(r, LongLine(tr, mr, p), ShowSeg(data, charIndex, 1));
-	r = Combine(r, LongLine(mr, br, p), ShowSeg(data, charIndex, 2));
+	r = Combine(r, LongLine(tr, mr, p, false, false), ShowSeg(data, charIndex, 1));
+	r = Combine(r, LongLine(mr, br, p, false, false), ShowSeg(data, charIndex, 2));
 	r = Combine(r, MidLine(br, bl, p), ShowSeg(data, charIndex, 3));
-	r = Combine(r, LongLine(bl, ml, p), ShowSeg(data, charIndex, 4));
-	r = Combine(r, LongLine(ml, tl, p), ShowSeg(data, charIndex, 5));
+	r = Combine(r, LongLine(bl, ml, p, false, false), ShowSeg(data, charIndex, 4));
+	r = Combine(r, LongLine(ml, tl, p, false, false), ShowSeg(data, charIndex, 5));
 	r = Combine(r, MidLine(mr, ml, p), ShowSeg(data, charIndex, 6));
 	r = SegDispSeparator(data, charIndex, 7, p, r);
-	r = Combine(r, LongLine2(tm, mm, p), ShowSeg(data, charIndex, 8));
-	r = Combine(r, LongLine(mm, bm, p), ShowSeg(data, charIndex, 9));
+	r = Combine(r, LongLine(tm, mm, p, true, true), ShowSeg(data, charIndex, 8));
+	r = Combine(r, LongLine(mm, bm, p, true, true), ShowSeg(data, charIndex, 9));
 
 	return r;
 }
@@ -318,20 +290,20 @@ float3 SegDisp9(sampler2D data, int charIndex, float2 p, float3 r)
 float3 SegDisp14(sampler2D data, int charIndex, float2 p, float3 r)
 {
 	r = Combine(r, MidLine(tl, tr, p), ShowSeg(data, charIndex, 0));
-	r = Combine(r, LongLine(tr, mr, p), ShowSeg(data, charIndex, 1));
-	r = Combine(r, LongLine(mr, br, p), ShowSeg(data, charIndex, 2));
+	r = Combine(r, LongLine(tr, mr, p, false, false), ShowSeg(data, charIndex, 1));
+	r = Combine(r, LongLine(mr, br, p, false, false), ShowSeg(data, charIndex, 2));
 	r = Combine(r, MidLine(br, bl, p), ShowSeg(data, charIndex, 3));
-	r = Combine(r, LongLine(bl, ml, p), ShowSeg(data, charIndex, 4));
-	r = Combine(r, LongLine(ml, tl, p), ShowSeg(data, charIndex, 5));
+	r = Combine(r, LongLine(bl, ml, p, false, false), ShowSeg(data, charIndex, 4));
+	r = Combine(r, LongLine(ml, tl, p, false, false), ShowSeg(data, charIndex, 5));
 	r = Combine(r, ShortLine(mm, ml, p), ShowSeg(data, charIndex, 6));
 	r = SegDispSeparator(data, charIndex, 7, p, r);
-	r = Combine(r, DiagLine2(dtl, dtm, p), ShowSeg(data, charIndex, 8));
-	r = Combine(r, LongLine2(tm, mm, p), ShowSeg(data, charIndex, 9));
-	r = Combine(r, DiagLine(dtr, dtm, p), ShowSeg(data, charIndex, 10));
+	r = Combine(r, DiagLineBackward(dtl, dtm, p), ShowSeg(data, charIndex, 8));
+	r = Combine(r, LongLine(tm, mm, p, true, false), ShowSeg(data, charIndex, 9));
+	r = Combine(r, DiagLineForward(dtr, dtm, p), ShowSeg(data, charIndex, 10));
 	r = Combine(r, ShortLine(mm, mr, p), ShowSeg(data, charIndex, 11));
-	r = Combine(r, DiagLine2(dbm, dbr, p), ShowSeg(data, charIndex, 12));
-	r = Combine(r, LongLine(mm, bm, p), ShowSeg(data, charIndex, 13));
-	r = Combine(r, DiagLine(dbm, dbl, p), ShowSeg(data, charIndex, 14));
+	r = Combine(r, DiagLineBackward(dbm, dbr, p), ShowSeg(data, charIndex, 12));
+	r = Combine(r, LongLine(mm, bm, p, false, true), ShowSeg(data, charIndex, 13));
+	r = Combine(r, DiagLineForward(dbm, dbl, p), ShowSeg(data, charIndex, 14));
 
 	return r;
 }
@@ -340,19 +312,19 @@ float3 SegDisp16(sampler2D data, int charIndex, float2 p, float3 r)
 {
 	r = Combine(r, ShortLine(tl, tm, p), ShowSeg(data, charIndex, 0)); // a
 	r = Combine(r, ShortLine(tm, tr, p), ShowSeg(data, charIndex, 1)); // b
-	r = Combine(r, LongLine(tr, mr, p), ShowSeg(data, charIndex, 2));  // c
-	r = Combine(r, LongLine(mr, br, p), ShowSeg(data, charIndex, 3));  // d
+	r = Combine(r, LongLine(tr, mr, p, false, false), ShowSeg(data, charIndex, 2));  // c
+	r = Combine(r, LongLine(mr, br, p, false, false), ShowSeg(data, charIndex, 3));  // d
 	r = Combine(r, ShortLine(br, bm, p), ShowSeg(data, charIndex, 4)); // e
 	r = Combine(r, ShortLine(bm, bl, p), ShowSeg(data, charIndex, 5)); // f
-	r = Combine(r, LongLine(bl, ml, p), ShowSeg(data, charIndex, 6));  // g
-	r = Combine(r, LongLine(ml, tl, p), ShowSeg(data, charIndex, 7));  // h
-	r = Combine(r, DiagLine2(dtl, dtm, p), ShowSeg(data, charIndex, 8)); // i
-	r = Combine(r, LongLine2(tm, mm, p), ShowSeg(data, charIndex, 9));   // j
-	r = Combine(r, DiagLine(dtr, dtm, p), ShowSeg(data, charIndex, 10)); // k
+	r = Combine(r, LongLine(bl, ml, p, false, false), ShowSeg(data, charIndex, 6));  // g
+	r = Combine(r, LongLine(ml, tl, p, false, false), ShowSeg(data, charIndex, 7));  // h
+	r = Combine(r, DiagLineBackward(dtl, dtm, p), ShowSeg(data, charIndex, 8)); // i
+	r = Combine(r, LongLine(tm, mm, p, false, false), ShowSeg(data, charIndex, 9));   // j
+	r = Combine(r, DiagLineForward(dtr, dtm, p), ShowSeg(data, charIndex, 10)); // k
 	r = Combine(r, ShortLine(mm, mr, p), ShowSeg(data, charIndex, 11));  // l
-	r = Combine(r, DiagLine2(dbm, dbr, p), ShowSeg(data, charIndex, 12));// m
-	r = Combine(r, LongLine(mm, bm, p), ShowSeg(data, charIndex, 13));   // n
-	r = Combine(r, DiagLine(dbm, dbl, p), ShowSeg(data, charIndex, 14)); // o
+	r = Combine(r, DiagLineBackward(dbm, dbr, p), ShowSeg(data, charIndex, 12));// m
+	r = Combine(r, LongLine(mm, bm, p, false, false), ShowSeg(data, charIndex, 13));   // n
+	r = Combine(r, DiagLineForward(dbm, dbl, p), ShowSeg(data, charIndex, 14)); // o
 	r = Combine(r, ShortLine(mm, ml, p), ShowSeg(data, charIndex, 15));   // p
 
 	return r;
@@ -385,6 +357,10 @@ void SegmentDisplay_float(float2 coords, sampler2D data, float numChars, float n
 	_SeparatorPos = separatorPos;
 
 	SegmentGap = segmentWeight * 1.5;
+	mm = float2(.0 + _HorizontalMiddle, 0);   // middle
+	tm = float2(.0 + _HorizontalMiddle, 1);
+	bm = float2(.0 + _HorizontalMiddle, -1);
+
 	dtl = tl + float2(0.0, -segmentWeight);
 	dtr = tr + float2(0.0, -segmentWeight);
 	dtm = mm + float2(0.0 + _HorizontalMiddle, segmentWeight);
@@ -392,9 +368,7 @@ void SegmentDisplay_float(float2 coords, sampler2D data, float numChars, float n
 	dbl = bl + float2(0.0, segmentWeight);
 	dbr = br + float2(0.0, segmentWeight);
 	dp = br + float2(segmentWeight * 4.0, SegmentGap);
-	mm = float2(.0 + _HorizontalMiddle, 0);   // middle
-	tm = float2(.0 + _HorizontalMiddle, 1);
-	bm = float2(.0 + _HorizontalMiddle, -1);
+
 
 
 	float cellWidth = 1. / _NumChars;

--- a/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.hlsl
+++ b/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.hlsl
@@ -336,6 +336,28 @@ float3 SegDisp14(sampler2D data, int charIndex, float2 p, float3 r)
 	return r;
 }
 
+float3 SegDisp16(sampler2D data, int charIndex, float2 p, float3 r)
+{
+	r = Combine(r, ShortLine(tl, tm, p), ShowSeg(data, charIndex, 0)); // a
+	r = Combine(r, ShortLine(tm, tr, p), ShowSeg(data, charIndex, 1)); // b
+	r = Combine(r, LongLine(tr, mr, p), ShowSeg(data, charIndex, 2));  // c
+	r = Combine(r, LongLine(mr, br, p), ShowSeg(data, charIndex, 3));  // d
+	r = Combine(r, ShortLine(br, bm, p), ShowSeg(data, charIndex, 4)); // e
+	r = Combine(r, ShortLine(bm, bl, p), ShowSeg(data, charIndex, 5)); // f
+	r = Combine(r, LongLine(bl, ml, p), ShowSeg(data, charIndex, 6));  // g
+	r = Combine(r, LongLine(ml, tl, p), ShowSeg(data, charIndex, 7));  // h
+	r = Combine(r, DiagLine2(dtl, dtm, p), ShowSeg(data, charIndex, 8)); // i
+	r = Combine(r, LongLine2(tm, mm, p), ShowSeg(data, charIndex, 9));   // j
+	r = Combine(r, DiagLine(dtr, dtm, p), ShowSeg(data, charIndex, 10)); // k
+	r = Combine(r, ShortLine(mm, mr, p), ShowSeg(data, charIndex, 11));  // l
+	r = Combine(r, DiagLine2(dbm, dbr, p), ShowSeg(data, charIndex, 12));// m
+	r = Combine(r, LongLine(mm, bm, p), ShowSeg(data, charIndex, 13));   // n
+	r = Combine(r, DiagLine(dbm, dbl, p), ShowSeg(data, charIndex, 14)); // o
+	r = Combine(r, ShortLine(mm, ml, p), ShowSeg(data, charIndex, 15));   // p
+
+	return r;
+}
+
 float3 SegDisp(sampler2D data, int charIndex, float2 p)
 {
 	float3 r = (0.);
@@ -344,6 +366,7 @@ float3 SegDisp(sampler2D data, int charIndex, float2 p)
 		case 7: return SegDisp7(data, charIndex, p, r);
 		case 9: return SegDisp9(data, charIndex, p, r);
 		case 14: return SegDisp14(data, charIndex, p, r);
+		case 16: return SegDisp16(data, charIndex, p, r);
 	}
 	return r;
 }

--- a/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.hlsl
+++ b/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.hlsl
@@ -7,6 +7,7 @@ float _Height;
 float _NumChars;
 float _NumSegments;
 float _SkewAngle;
+float _HorizontalMiddle;
 
 float2 _SeparatorPos;
 int _SeparatorType; // 0 = none, 1 = dot, 2 = 2-segment comma
@@ -28,9 +29,9 @@ static float2 ml = float2(-.5, 0);  // mid    left  corner
 static float2 mr = float2(.5, 0);   // mid    right corner
 static float2 bl = float2(-.5, -1); // bottom left  corner
 static float2 br = float2(.5, -1);  // bottom right corner
-static float2 tm = float2(.0, 1);
-static float2 mm = float2(.0, 0);   // middle
-static float2 bm = float2(.0, -1);
+static float2 tm;
+static float2 mm; // middle
+static float2 bm;
 
 static float2 dtl;
 static float2 dtr;
@@ -355,13 +356,14 @@ float3 SegDisp(sampler2D data, int charIndex, float2 p)
 
 void SegmentDisplay_float(float2 coords, sampler2D data, float segmentType, float numChars,
 	float numSegments, int separatorType, int separatorEveryThreeOnly, float2 separatorPos,
-	float segmentWidth, float skewAngle, float2 padding, out float output)
+	float segmentWidth, float horizontalMiddle, float skewAngle, float2 padding, out float output)
 {
 	_SegmentWidth = segmentWidth;
 	_SegmentType = segmentType;
 	_NumChars = numChars;
 	_NumSegments = numSegments;
 	_SkewAngle = skewAngle;
+	_HorizontalMiddle = horizontalMiddle;
 	_SeparatorType = separatorType;
 	_SeparatorEveryThreeOnly = separatorEveryThreeOnly;
 	_SeparatorPos = separatorPos;
@@ -369,11 +371,15 @@ void SegmentDisplay_float(float2 coords, sampler2D data, float segmentType, floa
 	SegmentGap = segmentWidth * 1.5;
 	dtl = tl + float2(0.0, -segmentWidth);
 	dtr = tr + float2(0.0, -segmentWidth);
-	dtm = mm + float2(0.0, segmentWidth);
-	dbm = mm + float2(0.0, -segmentWidth);
+	dtm = mm + float2(0.0 + _HorizontalMiddle, segmentWidth);
+	dbm = mm + float2(0.0 + _HorizontalMiddle, -segmentWidth);
 	dbl = bl + float2(0.0, segmentWidth);
 	dbr = br + float2(0.0, segmentWidth);
 	dp = br + float2(segmentWidth * 4.0, SegmentGap);
+	mm = float2(.0 + _HorizontalMiddle, 0);   // middle
+	tm = float2(.0 + _HorizontalMiddle, 1);
+	bm = float2(.0 + _HorizontalMiddle, -1);
+
 
 	float cellWidth = 1. / _NumChars;
 

--- a/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.hlsl
+++ b/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.hlsl
@@ -8,6 +8,7 @@ float _NumChars;
 float _NumSegments;
 float _SkewAngle;
 
+float2 _SeparatorPos;
 int _SeparatorType; // 0 = none, 1 = dot, 2 = 2-segment comma
 int _SeparatorEveryThreeOnly;
 
@@ -270,17 +271,19 @@ float3 SegDispSeparator(sampler2D data, int charIndex, int segIndex, float2 p, f
 {
 	bool isThree = fmod(_NumChars - charIndex + 2, 3) == 0 && charIndex != _NumChars - 1;
 	bool separatorEveryThreeOnly = _SeparatorEveryThreeOnly == 1;
+	float2 pos = float2(-0.5, 0.43);
+
 	if (!separatorEveryThreeOnly || isThree) {
 
 		switch (_SeparatorType) {
 			case 0:
 				return r;
 			case 1:
-				r = Combine(r, Circle(float2(p.x - 0.2, p.y - 0.43), 0.025, 1.5), ShowSeg(data, charIndex, segIndex));
+				r = Combine(r, Circle(p - pos - _SeparatorPos / 2., 0.025, 1.5), ShowSeg(data, charIndex, segIndex));
 				break;
 			case 2:
-				r = Combine(r, Circle(float2(p.x - 0.2, p.y - 0.43), 0.025, 1.5), ShowSeg(data, charIndex, segIndex));
-				r = Combine(r, Comma(float2(p.x - 0.2, p.y - 0.43)), ShowSeg(data, charIndex, segIndex));
+				r = Combine(r, Circle(p - pos - _SeparatorPos / 2., 0.025, 1.5), ShowSeg(data, charIndex, segIndex));
+				r = Combine(r, Comma(p - pos - _SeparatorPos / 2.), ShowSeg(data, charIndex, segIndex));
 				break;
 		}
 	}
@@ -351,7 +354,8 @@ float3 SegDisp(sampler2D data, int charIndex, float2 p)
 }
 
 void SegmentDisplay_float(float2 coords, sampler2D data, float segmentType, float numChars,
-	float numSegments, int separatorType, int separatorEveryThreeOnly, float segmentWidth, float skewAngle, float2 padding, out float output)
+	float numSegments, int separatorType, int separatorEveryThreeOnly, float2 separatorPos,
+	float segmentWidth, float skewAngle, float2 padding, out float output)
 {
 	_SegmentWidth = segmentWidth;
 	_SegmentType = segmentType;
@@ -360,6 +364,7 @@ void SegmentDisplay_float(float2 coords, sampler2D data, float segmentType, floa
 	_SkewAngle = skewAngle;
 	_SeparatorType = separatorType;
 	_SeparatorEveryThreeOnly = separatorEveryThreeOnly;
+	_SeparatorPos = separatorPos;
 
 	SegmentGap = segmentWidth * 1.5;
 	dtl = tl + float2(0.0, -segmentWidth);

--- a/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.shader
+++ b/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.shader
@@ -8,6 +8,9 @@
 		__SegmentType ("Segment Type", Int) = 0
 		__NumSegments ("Segments", Float) = 16
 
+		__SeparatorType ("Separator Type", Int) = 2
+		__SeparatorEveryThreeOnly ("Separator Every Three Only", Int) = 0
+
 		__LitColor ("Color", Color) = (1.0, 0.4, 0, 1.0)
 		__SegmentWeight ("Weight", Float) = 0.05
 		__SkewAngle ("Skew Angle", Float) = 0.2
@@ -48,6 +51,10 @@
 			float __NumChars;
 			int __SegmentType;
 			int __NumSegments;
+
+			int __SeparatorType;
+			int __SeparatorEveryThreeOnly;
+
 			fixed4 __LitColor;
 			float __SegmentWeight;
 			float __SkewAngle;
@@ -65,8 +72,8 @@
 			fixed4 frag(v2f i) : SV_Target
 			{
 				float pixelAlpha;
-				SegmentDisplay_float(i.uv, _MainTex, __SegmentType, __NumChars,
-					__NumSegments, __SegmentWeight, __SkewAngle, __Padding, pixelAlpha);
+				SegmentDisplay_float(i.uv, _MainTex, __SegmentType, __NumChars, __NumSegments,
+					__SeparatorType, __SeparatorEveryThreeOnly, __SegmentWeight, __SkewAngle, __Padding, pixelAlpha);
 
 				return pixelAlpha * __LitColor;
 			}

--- a/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.shader
+++ b/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.shader
@@ -10,6 +10,7 @@
 
 		__SeparatorType ("Separator Type", Int) = 2
 		__SeparatorEveryThreeOnly ("Separator Every Three Only", Int) = 0
+		__SeparatorPos ("Separator Position", Vector) = (1.5, 0.0, 0, 0)
 
 		__LitColor ("Color", Color) = (1.0, 0.4, 0, 1.0)
 		__SegmentWeight ("Weight", Float) = 0.05
@@ -54,6 +55,7 @@
 
 			int __SeparatorType;
 			int __SeparatorEveryThreeOnly;
+			float2 __SeparatorPos;
 
 			fixed4 __LitColor;
 			float __SegmentWeight;
@@ -73,7 +75,8 @@
 			{
 				float pixelAlpha;
 				SegmentDisplay_float(i.uv, _MainTex, __SegmentType, __NumChars, __NumSegments,
-					__SeparatorType, __SeparatorEveryThreeOnly, __SegmentWeight, __SkewAngle, __Padding, pixelAlpha);
+					__SeparatorType, __SeparatorEveryThreeOnly, __SeparatorPos, __SegmentWeight,
+					__SkewAngle, __Padding, pixelAlpha);
 
 				return pixelAlpha * __LitColor;
 			}

--- a/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.shader
+++ b/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.shader
@@ -14,6 +14,7 @@
 
 		__LitColor ("Color", Color) = (1.0, 0.4, 0, 1.0)
 		__SegmentWeight ("Weight", Float) = 0.05
+		__HorizontalMiddle ("Horizontal Middle", Float) = 0.0
 		__SkewAngle ("Skew Angle", Float) = 0.2
 		__Padding ("Padding", Vector) = (0.4, 0.15, 0, 0)
 	}
@@ -59,6 +60,7 @@
 
 			fixed4 __LitColor;
 			float __SegmentWeight;
+			float __HorizontalMiddle;
 			float __SkewAngle;
 			float2 __Padding;
 
@@ -76,7 +78,7 @@
 				float pixelAlpha;
 				SegmentDisplay_float(i.uv, _MainTex, __SegmentType, __NumChars, __NumSegments,
 					__SeparatorType, __SeparatorEveryThreeOnly, __SeparatorPos, __SegmentWeight,
-					__SkewAngle, __Padding, pixelAlpha);
+					__HorizontalMiddle, __SkewAngle, __Padding, pixelAlpha);
 
 				return pixelAlpha * __LitColor;
 			}

--- a/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.shader
+++ b/VisualPinball.Unity/Assets/Shaders/Builtin/SegmentDisplayShader.shader
@@ -5,7 +5,6 @@
 		_MainTex ("Texture", 2D) = "white" {}
 
 		__NumChars ("Num Chars", Float) = 7
-		__SegmentType ("Segment Type", Int) = 0
 		__NumSegments ("Segments", Float) = 16
 
 		__SeparatorType ("Separator Type", Int) = 2
@@ -51,7 +50,6 @@
 			float4 _MainTex_ST;
 
 			float __NumChars;
-			int __SegmentType;
 			int __NumSegments;
 
 			int __SeparatorType;
@@ -76,7 +74,7 @@
 			fixed4 frag(v2f i) : SV_Target
 			{
 				float pixelAlpha;
-				SegmentDisplay_float(i.uv, _MainTex, __SegmentType, __NumChars, __NumSegments,
+				SegmentDisplay_float(i.uv, _MainTex, __NumChars, __NumSegments,
 					__SeparatorType, __SeparatorEveryThreeOnly, __SeparatorPos, __SegmentWeight,
 					__HorizontalMiddle, __SkewAngle, __Padding, pixelAlpha);
 

--- a/VisualPinball.Unity/Assets/Shaders/Srp.meta
+++ b/VisualPinball.Unity/Assets/Shaders/Srp.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: fb205d34c17ef1e4baf456ee0d61f22f
+guid: 4fc548ea63a345e48acb6a597cd09dc8
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/VisualPinball.Unity/Assets/Shaders/Srp/Display/DotMatrixDisplayGraph.shadergraph
+++ b/VisualPinball.Unity/Assets/Shaders/Srp/Display/DotMatrixDisplayGraph.shadergraph
@@ -64,9 +64,6 @@
             "m_Id": "aee0986619fa4301bc63d4c56d4c4106"
         },
         {
-            "m_Id": "a78397a5148844159f6262c4a2e259ed"
-        },
-        {
             "m_Id": "915771b37c834feb95561bee0773591f"
         },
         {
@@ -79,10 +76,13 @@
             "m_Id": "fbac3e4b734444fab8825a2dbf5c0fbc"
         },
         {
-            "m_Id": "6d6a3d51753c4bcb98db58f727cb74b5"
+            "m_Id": "f7da6b7b2e0446f38d88298acf0238db"
         },
         {
-            "m_Id": "f7da6b7b2e0446f38d88298acf0238db"
+            "m_Id": "c5116295dcd042ccb7bc0444728c5971"
+        },
+        {
+            "m_Id": "3930f3e174464ad483bf5dfc32f941dd"
         }
     ],
     "m_GroupDatas": [],
@@ -105,7 +105,7 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "6d6a3d51753c4bcb98db58f727cb74b5"
+                    "m_Id": "3930f3e174464ad483bf5dfc32f941dd"
                 },
                 "m_SlotId": 0
             },
@@ -119,7 +119,7 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "6d6a3d51753c4bcb98db58f727cb74b5"
+                    "m_Id": "3930f3e174464ad483bf5dfc32f941dd"
                 },
                 "m_SlotId": 0
             },
@@ -217,34 +217,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "a78397a5148844159f6262c4a2e259ed"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "386fcbc47636417199e958b1ab89b4b7"
-                },
-                "m_SlotId": 4
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "a78397a5148844159f6262c4a2e259ed"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "915771b37c834feb95561bee0773591f"
-                },
-                "m_SlotId": 4
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "aee0986619fa4301bc63d4c56d4c4106"
                 },
                 "m_SlotId": 0
@@ -282,6 +254,34 @@
                     "m_Id": "fbac3e4b734444fab8825a2dbf5c0fbc"
                 },
                 "m_SlotId": 3
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "c5116295dcd042ccb7bc0444728c5971"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "386fcbc47636417199e958b1ab89b4b7"
+                },
+                "m_SlotId": 4
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "c5116295dcd042ccb7bc0444728c5971"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "915771b37c834feb95561bee0773591f"
+                },
+                "m_SlotId": 4
             }
         },
         {
@@ -410,6 +410,21 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "07299a5f78274e3dabe583776592f43a",
+    "m_Id": 7,
+    "m_DisplayName": "Roundness",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Roundness",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "081ad3938075431982f086b05dd69e15",
     "m_Id": 1,
@@ -501,12 +516,12 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "224d6ba75d7d40bb8a5742ecfc4fd570",
-    "m_Id": 6,
-    "m_DisplayName": "Sharpness",
-    "m_SlotType": 0,
+    "m_ObjectId": "2be1458f479f476898796621d23467a1",
+    "m_Id": 0,
+    "m_DisplayName": "Padding",
+    "m_SlotType": 1,
     "m_Hidden": false,
-    "m_ShaderOutputName": "Sharpness",
+    "m_ShaderOutputName": "Out",
     "m_StageCapability": 3,
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
@@ -553,15 +568,15 @@
     "m_Guid": {
         "m_GuidSerialized": "396c817a-7ee7-471a-a8f5-40d94d28797a"
     },
-    "m_Name": "Sharpness",
+    "m_Name": "Roundness",
     "m_DefaultReferenceName": "Vector1_355af990f31d4b91969f5a1d85c0e524",
-    "m_OverrideReferenceName": "__Sharpness",
+    "m_OverrideReferenceName": "__Roundness",
     "m_GeneratePropertyBlock": true,
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
     "m_Hidden": false,
-    "m_Value": 0.30000001192092898,
+    "m_Value": 0.3499999940395355,
     "m_FloatType": 0,
     "m_RangeValues": {
         "x": 0.0,
@@ -624,7 +639,7 @@
     "m_Group": {
         "m_Id": ""
     },
-    "m_Name": "RoundDot (Custom Function)",
+    "m_Name": "Dot (Custom Function)",
     "m_DrawState": {
         "m_Expanded": true,
         "m_Position": {
@@ -637,22 +652,22 @@
     },
     "m_Slots": [
         {
-            "m_Id": "69c05ac636344b43a1a82079fa6f8f8a"
-        },
-        {
             "m_Id": "081ad3938075431982f086b05dd69e15"
         },
         {
             "m_Id": "7832cd0837064233bff0dc7207f2038f"
         },
         {
-            "m_Id": "7764b67d9777411aaf26f7efd59f1675"
+            "m_Id": "7406c78a6db049b988f3506e8be38940"
         },
         {
-            "m_Id": "224d6ba75d7d40bb8a5742ecfc4fd570"
+            "m_Id": "4c97b199b8b34c519e133d26ecd7fadd"
         },
         {
             "m_Id": "3d4094e856994450a1bbd5f65abf553f"
+        },
+        {
+            "m_Id": "69c05ac636344b43a1a82079fa6f8f8a"
         }
     ],
     "synonyms": [],
@@ -663,9 +678,44 @@
         "m_SerializableColors": []
     },
     "m_SourceType": 0,
-    "m_FunctionName": "RoundDot",
+    "m_FunctionName": "Dot",
     "m_FunctionSource": "4a60f979fa395074196e146817eba7c1",
     "m_FunctionBody": "Enter function body here..."
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "3930f3e174464ad483bf5dfc32f941dd",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1722.66650390625,
+            "y": -616.0,
+            "width": 134.22216796875,
+            "height": 33.77777099609375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "6f3abcccdf9f41f19817fb5aa54cd22c"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "355af990f31d4b91969f5a1d85c0e524"
+    }
 }
 
 {
@@ -700,15 +750,15 @@
     "m_Guid": {
         "m_GuidSerialized": "d9937412-01ab-4bdd-aacd-d00afd1a8dbe"
     },
-    "m_Name": "DotSize",
+    "m_Name": "Padding",
     "m_DefaultReferenceName": "Vector1_3ebae42385484fdab87c4c0493f74e5a",
-    "m_OverrideReferenceName": "__DotSize",
+    "m_OverrideReferenceName": "__Padding",
     "m_GeneratePropertyBlock": true,
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
     "m_Hidden": false,
-    "m_Value": 0.4000000059604645,
+    "m_Value": 0.20000000298023225,
     "m_FloatType": 1,
     "m_RangeValues": {
         "x": 0.10000000149011612,
@@ -732,6 +782,21 @@
         "m_Guid": ""
     },
     "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "4c97b199b8b34c519e133d26ecd7fadd",
+    "m_Id": 6,
+    "m_DisplayName": "Roundness",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Roundness",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {
@@ -957,37 +1022,17 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "6d6a3d51753c4bcb98db58f727cb74b5",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -1721.3333740234375,
-            "y": -617.3334350585938,
-            "width": 132.0,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "9bee43e24ff44efda133ef29ff361178"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "355af990f31d4b91969f5a1d85c0e524"
-    }
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "6f3abcccdf9f41f19817fb5aa54cd22c",
+    "m_Id": 0,
+    "m_DisplayName": "Roundness",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {
@@ -1026,12 +1071,12 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "7764b67d9777411aaf26f7efd59f1675",
+    "m_ObjectId": "7406c78a6db049b988f3506e8be38940",
     "m_Id": 4,
-    "m_DisplayName": "DotSize",
+    "m_DisplayName": "Padding",
     "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "DotSize",
+    "m_ShaderOutputName": "Padding",
     "m_StageCapability": 3,
     "m_Value": 0.4000000059604645,
     "m_DefaultValue": 0.0,
@@ -1268,7 +1313,7 @@
     "m_Group": {
         "m_Id": ""
     },
-    "m_Name": "RoundDot (Custom Function)",
+    "m_Name": "Dot (Custom Function)",
     "m_DrawState": {
         "m_Expanded": true,
         "m_Position": {
@@ -1281,22 +1326,22 @@
     },
     "m_Slots": [
         {
-            "m_Id": "af198d9380f942d196cfeb55101afa63"
-        },
-        {
             "m_Id": "f30625042d294d0b86970f1751a25245"
         },
         {
             "m_Id": "85b95d7894ed4a2c823ab7d346fe3d05"
         },
         {
-            "m_Id": "d13e50e3c6144ca1915bcc732b490b8e"
+            "m_Id": "d529af3e5c7742819dea2c0338a407bd"
         },
         {
-            "m_Id": "d2b2c84c432045b587fc629f3c10c986"
+            "m_Id": "07299a5f78274e3dabe583776592f43a"
         },
         {
             "m_Id": "881b7e63db61402a8e60082878c0d585"
+        },
+        {
+            "m_Id": "af198d9380f942d196cfeb55101afa63"
         }
     ],
     "synonyms": [],
@@ -1307,7 +1352,7 @@
         "m_SerializableColors": []
     },
     "m_SourceType": 0,
-    "m_FunctionName": "RoundDot",
+    "m_FunctionName": "Dot",
     "m_FunctionSource": "4a60f979fa395074196e146817eba7c1",
     "m_FunctionBody": "Enter function body here..."
 }
@@ -1396,36 +1441,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "9bee43e24ff44efda133ef29ff361178",
-    "m_Id": 0,
-    "m_DisplayName": "Sharpness",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "9d5f16a6720a4479a7730cf2a9a344d7",
-    "m_Id": 0,
-    "m_DisplayName": "DotSize",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.UVNode",
     "m_ObjectId": "9fb97a9787244043aeebf4b3d7a02812",
     "m_Group": {
@@ -1494,41 +1509,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "a78397a5148844159f6262c4a2e259ed",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -1721.3333740234375,
-            "y": -651.3334350585938,
-            "width": 117.99999237060547,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "9d5f16a6720a4479a7730cf2a9a344d7"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "3ebae42385484fdab87c4c0493f74e5a"
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "ae939763d74547dfaa3ea55597380156",
     "m_Id": 6,
@@ -1554,10 +1534,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1721.3333740234375,
-            "y": -683.3334350585938,
-            "width": 140.0,
-            "height": 34.0
+            "x": -1722.66650390625,
+            "y": -683.5555419921875,
+            "width": 140.4444580078125,
+            "height": 33.77777099609375
         }
     },
     "m_Slots": [
@@ -1722,6 +1702,41 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "c5116295dcd042ccb7bc0444728c5971",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1722.66650390625,
+            "y": -649.7777709960938,
+            "width": 119.5555419921875,
+            "height": 33.77777099609375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "2be1458f479f476898796621d23467a1"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "3ebae42385484fdab87c4c0493f74e5a"
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "c5825dda7ba74ef1ab363901deb74f5a",
     "m_Id": 4,
@@ -1738,29 +1753,14 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "d13e50e3c6144ca1915bcc732b490b8e",
+    "m_ObjectId": "d529af3e5c7742819dea2c0338a407bd",
     "m_Id": 4,
-    "m_DisplayName": "DotSize",
+    "m_DisplayName": "Padding",
     "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "DotSize",
+    "m_ShaderOutputName": "Padding",
     "m_StageCapability": 3,
     "m_Value": 0.4000000059604645,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "d2b2c84c432045b587fc629f3c10c986",
-    "m_Id": 7,
-    "m_DisplayName": "Sharpness",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Sharpness",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
 }

--- a/VisualPinball.Unity/Assets/Shaders/Srp/Display/DotMatrixDisplayGraph.shadergraph
+++ b/VisualPinball.Unity/Assets/Shaders/Srp/Display/DotMatrixDisplayGraph.shadergraph
@@ -14,6 +14,9 @@
         },
         {
             "m_Id": "3ebae42385484fdab87c4c0493f74e5a"
+        },
+        {
+            "m_Id": "355af990f31d4b91969f5a1d85c0e524"
         }
     ],
     "m_Keywords": [],
@@ -74,6 +77,12 @@
         },
         {
             "m_Id": "fbac3e4b734444fab8825a2dbf5c0fbc"
+        },
+        {
+            "m_Id": "6d6a3d51753c4bcb98db58f727cb74b5"
+        },
+        {
+            "m_Id": "f7da6b7b2e0446f38d88298acf0238db"
         }
     ],
     "m_GroupDatas": [],
@@ -91,6 +100,34 @@
                     "m_Id": "5e3f39ce35b74ffcb64ad89380f95b94"
                 },
                 "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "6d6a3d51753c4bcb98db58f727cb74b5"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "386fcbc47636417199e958b1ab89b4b7"
+                },
+                "m_SlotId": 6
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "6d6a3d51753c4bcb98db58f727cb74b5"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "915771b37c834feb95561bee0773591f"
+                },
+                "m_SlotId": 7
             }
         },
         {
@@ -270,34 +307,6 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "386fcbc47636417199e958b1ab89b4b7"
-                },
-                "m_SlotId": 6
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "fbac3e4b734444fab8825a2dbf5c0fbc"
-                },
-                "m_SlotId": 8
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "915771b37c834feb95561bee0773591f"
-                },
-                "m_SlotId": 6
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "fbac3e4b734444fab8825a2dbf5c0fbc"
-                },
-                "m_SlotId": 8
-            },
-            "m_InputSlot": {
-                "m_Node": {
                     "m_Id": "f3d6bf1febf343b0a78bdc1ae2fffac5"
                 },
                 "m_SlotId": 2
@@ -306,8 +315,8 @@
     ],
     "m_VertexContext": {
         "m_Position": {
-            "x": 10.666691780090332,
-            "y": -1028.66650390625
+            "x": 10.66672134399414,
+            "y": -948.6666259765625
         },
         "m_Blocks": [
             {
@@ -323,10 +332,13 @@
     },
     "m_FragmentContext": {
         "m_Position": {
-            "x": -10.666657447814942,
-            "y": -668.6666259765625
+            "x": 10.66672134399414,
+            "y": -560.0
         },
         "m_Blocks": [
+            {
+                "m_Id": "5e3f39ce35b74ffcb64ad89380f95b94"
+            },
             {
                 "m_Id": "5989918dd1294dc48c01714e8dab3238"
             },
@@ -337,9 +349,6 @@
                 "m_Id": "d8326c1ced644423a0ea6e92bcecf480"
             },
             {
-                "m_Id": "5e3f39ce35b74ffcb64ad89380f95b94"
-            },
-            {
                 "m_Id": "0d75beb7272b4521b42e1dcaf150973d"
             },
             {
@@ -347,6 +356,9 @@
             },
             {
                 "m_Id": "b3d8175ca262420ebb21eb8aa266a8b0"
+            },
+            {
+                "m_Id": "f7da6b7b2e0446f38d88298acf0238db"
             }
         ]
     },
@@ -488,6 +500,21 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "224d6ba75d7d40bb8a5742ecfc4fd570",
+    "m_Id": 6,
+    "m_DisplayName": "Sharpness",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Sharpness",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BlockNode",
     "m_ObjectId": "346762cc484a44bc8fb6b9db055b7988",
     "m_Group": {
@@ -517,6 +544,29 @@
         "m_SerializableColors": []
     },
     "m_SerializedDescriptor": "SurfaceDescription.NormalTS"
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "355af990f31d4b91969f5a1d85c0e524",
+    "m_Guid": {
+        "m_GuidSerialized": "396c817a-7ee7-471a-a8f5-40d94d28797a"
+    },
+    "m_Name": "Sharpness",
+    "m_DefaultReferenceName": "Vector1_355af990f31d4b91969f5a1d85c0e524",
+    "m_OverrideReferenceName": "__Sharpness",
+    "m_GeneratePropertyBlock": true,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.30000001192092898,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
 }
 
 {
@@ -579,13 +629,16 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -443.3334045410156,
-            "y": -1119.333251953125,
-            "width": 214.66665649414063,
-            "height": 373.99993896484377
+            "x": -444.6667785644531,
+            "y": -948.6666870117188,
+            "width": 214.6666717529297,
+            "height": 374.0
         }
     },
     "m_Slots": [
+        {
+            "m_Id": "69c05ac636344b43a1a82079fa6f8f8a"
+        },
         {
             "m_Id": "081ad3938075431982f086b05dd69e15"
         },
@@ -596,13 +649,10 @@
             "m_Id": "7764b67d9777411aaf26f7efd59f1675"
         },
         {
+            "m_Id": "224d6ba75d7d40bb8a5742ecfc4fd570"
+        },
+        {
             "m_Id": "3d4094e856994450a1bbd5f65abf553f"
-        },
-        {
-            "m_Id": "819a609498b744759061355df8095eba"
-        },
-        {
-            "m_Id": "69c05ac636344b43a1a82079fa6f8f8a"
         }
     ],
     "synonyms": [],
@@ -652,7 +702,7 @@
     },
     "m_Name": "DotSize",
     "m_DefaultReferenceName": "Vector1_3ebae42385484fdab87c4c0493f74e5a",
-    "m_OverrideReferenceName": "__DotSize2",
+    "m_OverrideReferenceName": "__DotSize",
     "m_GeneratePropertyBlock": true,
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
@@ -743,6 +793,21 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "5a71e243a514409c9987178112e21b6b",
+    "m_Id": 0,
+    "m_DisplayName": "Alpha",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Alpha",
+    "m_StageCapability": 2,
+    "m_Value": 1.0,
+    "m_DefaultValue": 1.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "5b4c24fd56fd42fa9d2faf550d4233cf",
     "m_Id": 3,
@@ -774,10 +839,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
+            "x": 0.6666711568832398,
+            "y": -635.3333129882813,
+            "width": 200.0,
+            "height": 40.66668701171875
         }
     },
     "m_Slots": [
@@ -888,6 +953,41 @@
         "w": 0.0
     },
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "6d6a3d51753c4bcb98db58f727cb74b5",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1721.3333740234375,
+            "y": -617.3334350585938,
+            "width": 132.0,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "9bee43e24ff44efda133ef29ff361178"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "355af990f31d4b91969f5a1d85c0e524"
+    }
 }
 
 {
@@ -1088,27 +1188,6 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
-    "m_ObjectId": "819a609498b744759061355df8095eba",
-    "m_Id": 6,
-    "m_DisplayName": "DotCenter",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "DotCenter",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "85b95d7894ed4a2c823ab7d346fe3d05",
     "m_Id": 3,
     "m_DisplayName": "Dimensions",
@@ -1202,6 +1281,9 @@
     },
     "m_Slots": [
         {
+            "m_Id": "af198d9380f942d196cfeb55101afa63"
+        },
+        {
             "m_Id": "f30625042d294d0b86970f1751a25245"
         },
         {
@@ -1211,13 +1293,10 @@
             "m_Id": "d13e50e3c6144ca1915bcc732b490b8e"
         },
         {
+            "m_Id": "d2b2c84c432045b587fc629f3c10c986"
+        },
+        {
             "m_Id": "881b7e63db61402a8e60082878c0d585"
-        },
-        {
-            "m_Id": "acb1d3be27d642bc9d7fd2d5fd68c0d9"
-        },
-        {
-            "m_Id": "af198d9380f942d196cfeb55101afa63"
         }
     ],
     "synonyms": [],
@@ -1245,10 +1324,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1614.6666259765625,
-            "y": -365.3332824707031,
+            "x": -1722.666748046875,
+            "y": -559.3333740234375,
             "width": 132.666748046875,
-            "height": 33.999996185302737
+            "height": 34.000030517578128
         }
     },
     "m_Slots": [
@@ -1318,6 +1397,21 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "9bee43e24ff44efda133ef29ff361178",
+    "m_Id": 0,
+    "m_DisplayName": "Sharpness",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "9d5f16a6720a4479a7730cf2a9a344d7",
     "m_Id": 0,
     "m_DisplayName": "DotSize",
@@ -1342,10 +1436,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1713.3333740234375,
-            "y": -1124.6666259765625,
-            "width": 207.99998474121095,
-            "height": 312.66668701171877
+            "x": -1784.0,
+            "y": -1419.333251953125,
+            "width": 208.0,
+            "height": 312.6666259765625
         }
     },
     "m_Slots": [
@@ -1375,10 +1469,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1614.666748046875,
-            "y": -466.66668701171877,
+            "x": -1722.666748046875,
+            "y": -761.3334350585938,
             "width": 109.33336639404297,
-            "height": 33.999996185302737
+            "height": 34.0
         }
     },
     "m_Slots": [
@@ -1410,10 +1504,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1614.666748046875,
-            "y": -399.3333740234375,
+            "x": -1721.3333740234375,
+            "y": -651.3334350585938,
             "width": 117.99999237060547,
-            "height": 33.999996185302737
+            "height": 34.0
         }
     },
     "m_Slots": [
@@ -1431,27 +1525,6 @@
     "m_Property": {
         "m_Id": "3ebae42385484fdab87c4c0493f74e5a"
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
-    "m_ObjectId": "acb1d3be27d642bc9d7fd2d5fd68c0d9",
-    "m_Id": 6,
-    "m_DisplayName": "DotCenter",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "DotCenter",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0
-    },
-    "m_Labels": []
 }
 
 {
@@ -1481,10 +1554,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1614.666748046875,
-            "y": -432.0,
+            "x": -1721.3333740234375,
+            "y": -683.3334350585938,
             "width": 140.0,
-            "height": 33.999996185302737
+            "height": 34.0
         }
     },
     "m_Slots": [
@@ -1673,6 +1746,21 @@
     "m_ShaderOutputName": "DotSize",
     "m_StageCapability": 3,
     "m_Value": 0.4000000059604645,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "d2b2c84c432045b587fc629f3c10c986",
+    "m_Id": 7,
+    "m_DisplayName": "Sharpness",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Sharpness",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
 }
@@ -1948,10 +2036,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -828.0000610351563,
-            "y": -1124.6666259765625,
-            "width": 207.99998474121095,
-            "height": 434.66668701171877
+            "x": -918.6666259765625,
+            "y": -1419.333251953125,
+            "width": 208.0,
+            "height": 434.6665954589844
         }
     },
     "m_Slots": [
@@ -1992,6 +2080,39 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "f7da6b7b2e0446f38d88298acf0238db",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Alpha",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "5a71e243a514409c9987178112e21b6b"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Alpha"
+}
+
+{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.CustomFunctionNode",
     "m_ObjectId": "fbac3e4b734444fab8825a2dbf5c0fbc",
@@ -2003,10 +2124,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1321.3333740234375,
-            "y": -1124.6666259765625,
-            "width": 246.66661071777345,
-            "height": 301.9999694824219
+            "x": -1302.0,
+            "y": -1419.333251953125,
+            "width": 246.6666259765625,
+            "height": 302.0
         }
     },
     "m_Slots": [

--- a/VisualPinball.Unity/Assets/Shaders/Srp/Display/DotMatrixDisplayShader.hlsl
+++ b/VisualPinball.Unity/Assets/Shaders/Srp/Display/DotMatrixDisplayShader.hlsl
@@ -2,28 +2,20 @@
 {
 	float2 dimensionsPerDot = 1. / dimensions;
 	float2 dotPos = floor(uv * dimensions);
-	dotCenter = dotPos * dimensionsPerDot + dimensionsPerDot * 0.5;
+	dotCenter = dimensionsPerDot * (dotPos + 0.5);
 }
 
-void RoundDot_float(float2 uv, float2 dimensions, float dotSize, float4 dotColor, float2 dotCenter, out float4 output)
+float Circle(float2 uv, float _radius, float _sharpness) {
+	float2 dist = uv - float2(0.5, 0.5);
+	return 1. - smoothstep(
+		_radius - (_radius * _sharpness),
+		_radius + (_radius * _sharpness),
+		dot(dist, dist) * 4.0
+	);
+}
+
+void RoundDot_float(float2 uv, float2 dimensions, float scale, float sharpness, float4 color, out float4 output)
 {
-	// Scale coordinates back to original ratio for rounding
-	float aspectRatio = dimensions.x / dimensions.y;
-	float2 uvScaled = float2(uv.x * aspectRatio, uv.y);
-	float2 dotCenterScaled = float2(dotCenter.x * aspectRatio, dotCenter.y);
-
-	// Round the dot by testing the distance of the pixel coordinate to the center
-	float dist = length(uvScaled - dotCenterScaled) * dimensions;
-
-	float4 outsideColor = dotColor;
-	outsideColor.r = 0;
-	outsideColor.g = 0;
-	outsideColor.b = 0;
-	outsideColor.a = 0;
-
-	float distFromEdge = dotSize - dist;  // positive when inside the circle
-	float thresholdWidth = .22;  // a constant you'd tune to get the right level of softness
-	float antialiasedCircle = saturate((distFromEdge / thresholdWidth) + 0.5);
-
-	output = lerp(outsideColor, dotColor, antialiasedCircle);
+	float2 pos = frac(uv * dimensions);
+	output = color * Circle(pos, scale, sharpness);
 }

--- a/VisualPinball.Unity/Assets/Shaders/Srp/Display/SegmentDisplayGraph.shadergraph
+++ b/VisualPinball.Unity/Assets/Shaders/Srp/Display/SegmentDisplayGraph.shadergraph
@@ -802,7 +802,7 @@
     },
     "m_Name": "Data",
     "m_DefaultReferenceName": "Texture2D_28cb878a5da744d2aecfe399a3254ec8",
-    "m_OverrideReferenceName": "__SegmentData",
+    "m_OverrideReferenceName": "__Data",
     "m_GeneratePropertyBlock": true,
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,

--- a/VisualPinball.Unity/Assets/Shaders/Srp/Display/SegmentDisplayGraph.shadergraph
+++ b/VisualPinball.Unity/Assets/Shaders/Srp/Display/SegmentDisplayGraph.shadergraph
@@ -13,9 +13,6 @@
             "m_Id": "28cb878a5da744d2aecfe399a3254ec8"
         },
         {
-            "m_Id": "78a66e5d29d14bd2954daf3fb60bb4aa"
-        },
-        {
             "m_Id": "48868e3f644c4f8d9dc2d14907d07c46"
         },
         {
@@ -86,9 +83,6 @@
         },
         {
             "m_Id": "f71a08ad5b5942d2a6c6570577349a10"
-        },
-        {
-            "m_Id": "b2cf59949b3247f58f67c9c8c9848a56"
         },
         {
             "m_Id": "9822db09ed324678ba43ee8fdd6c8339"
@@ -405,34 +399,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "b2cf59949b3247f58f67c9c8c9848a56"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "6fc45a230484496eb0a637a0d40a3541"
-                },
-                "m_SlotId": 7
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "b2cf59949b3247f58f67c9c8c9848a56"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "a94cb738cee9426e8bf076adaa3b6811"
-                },
-                "m_SlotId": 7
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "bbf02ed4cd92417c804bb3108b4a9b6a"
                 },
                 "m_SlotId": 2
@@ -567,6 +533,9 @@
         },
         "m_Blocks": [
             {
+                "m_Id": "e1130d45aea34d8abdb72ba39be96139"
+            },
+            {
                 "m_Id": "fb147419f0af4cc0b9446cb2737e6054"
             },
             {
@@ -577,9 +546,6 @@
             },
             {
                 "m_Id": "3c772f87db964b8f93dcf520f8d02280"
-            },
-            {
-                "m_Id": "e1130d45aea34d8abdb72ba39be96139"
             },
             {
                 "m_Id": "fb67e6fbd8a7452693558a6412fa914c"
@@ -764,21 +730,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "185b82df00ee4409af67c7f06f5e4306",
-    "m_Id": 7,
-    "m_DisplayName": "SegmentType",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "SegmentType",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "1992e3425efe471aa2dbf036e09c2c7f",
     "m_Group": {
@@ -789,8 +740,8 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1042.0,
-            "y": -29.333335876464845,
+            "x": -1032.0,
+            "y": -342.6666564941406,
             "width": 187.99993896484376,
             "height": 34.0
         }
@@ -910,10 +861,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
+            "x": 110.666748046875,
+            "y": -414.6665954589844,
+            "width": 200.0,
+            "height": 41.333343505859378
         }
     },
     "m_Slots": [
@@ -1112,10 +1063,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1042.0,
-            "y": -127.33330535888672,
-            "width": 122.66663360595703,
-            "height": 33.999996185302737
+            "x": -1032.0,
+            "y": -90.0,
+            "width": 122.6666259765625,
+            "height": 34.0
         }
     },
     "m_Slots": [
@@ -1147,9 +1098,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1042.0,
-            "y": -194.6667022705078,
-            "width": 113.99994659423828,
+            "x": -1032.0,
+            "y": -228.0,
+            "width": 113.99993896484375,
             "height": 34.0
         }
     },
@@ -1413,10 +1364,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -638.0,
-            "y": -860.0,
+            "x": -637.9998779296875,
+            "y": -788.6666259765625,
             "width": 267.3333435058594,
-            "height": 541.3333129882813
+            "height": 518.0
         }
     },
     "m_Slots": [
@@ -1428,9 +1379,6 @@
         },
         {
             "m_Id": "3afe634e26ca4761a79137da801c5b7c"
-        },
-        {
-            "m_Id": "185b82df00ee4409af67c7f06f5e4306"
         },
         {
             "m_Id": "848fa978888949d9b92a5effb184c1c3"
@@ -1591,29 +1539,6 @@
         "a": 0.0
     },
     "m_ColorMode": 0
-}
-
-{
-    "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
-    "m_ObjectId": "78a66e5d29d14bd2954daf3fb60bb4aa",
-    "m_Guid": {
-        "m_GuidSerialized": "c7cfff2a-dbac-4fc2-9df4-aafa6194742f"
-    },
-    "m_Name": "SegmentType",
-    "m_DefaultReferenceName": "Vector1_78a66e5d29d14bd2954daf3fb60bb4aa",
-    "m_OverrideReferenceName": "__SegmentType",
-    "m_GeneratePropertyBlock": true,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
-    "m_Hidden": false,
-    "m_Value": 0.0,
-    "m_FloatType": 2,
-    "m_RangeValues": {
-        "x": 0.0,
-        "y": 1.0
-    }
 }
 
 {
@@ -1890,10 +1815,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1042.0,
-            "y": 57.333335876464847,
+            "x": -1032.0,
+            "y": -194.0,
             "width": 168.6666259765625,
-            "height": 34.0
+            "height": 33.99999237060547
         }
     },
     "m_Slots": [
@@ -1943,9 +1868,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1041.3333740234375,
-            "y": -64.0000228881836,
-            "width": 154.66668701171876,
+            "x": -1032.0,
+            "y": -376.6666564941406,
+            "width": 154.6666259765625,
             "height": 34.0
         }
     },
@@ -2022,9 +1947,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1042.0,
-            "y": -262.6666259765625,
-            "width": 131.3333282470703,
+            "x": -1032.0,
+            "y": -486.6666564941406,
+            "width": 131.33331298828126,
             "height": 34.0
         }
     },
@@ -2078,10 +2003,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1042.0,
-            "y": -160.6666717529297,
+            "x": -1032.0,
+            "y": -124.0,
             "width": 134.6666259765625,
-            "height": 34.0
+            "height": 34.000003814697269
         }
     },
     "m_Slots": [
@@ -2212,9 +2137,6 @@
             "m_Id": "9217f4a049174ddc9ae5913982cc2350"
         },
         {
-            "m_Id": "cd38b06a2ea54f3ebf01aedca52d7d57"
-        },
-        {
             "m_Id": "e6ce7322840741eebc1f891a8681c381"
         },
         {
@@ -2274,41 +2196,6 @@
         "y": 0.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "b2cf59949b3247f58f67c9c8c9848a56",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -1042.0,
-            "y": -296.66668701171877,
-            "width": 149.3333282470703,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "d30bba20ae2f473d936707a63a4ac488"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "78a66e5d29d14bd2954daf3fb60bb4aa"
-    }
 }
 
 {
@@ -2657,21 +2544,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "cd38b06a2ea54f3ebf01aedca52d7d57",
-    "m_Id": 7,
-    "m_DisplayName": "SegmentType",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "SegmentType",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "d0418c29d8be4b799e0d59eed2008d20",
     "m_Group": {
@@ -2682,10 +2554,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1040.0,
-            "y": 4.666668891906738,
-            "width": 150.66661071777345,
-            "height": 34.000003814697269
+            "x": -1032.0,
+            "y": -308.6666564941406,
+            "width": 150.6666259765625,
+            "height": 34.0
         }
     },
     "m_Slots": [
@@ -2717,21 +2589,6 @@
     "m_StageCapability": 2,
     "m_Value": 1.0,
     "m_DefaultValue": 1.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "d30bba20ae2f473d936707a63a4ac488",
-    "m_Id": 0,
-    "m_DisplayName": "SegmentType",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
     "m_Labels": []
 }
 
@@ -2819,10 +2676,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1042.0,
-            "y": -708.0000610351563,
-            "width": 207.9999542236328,
-            "height": 313.3333435058594
+            "x": -1032.0,
+            "y": -643.9999389648438,
+            "width": 207.99993896484376,
+            "height": 312.6666564941406
         }
     },
     "m_Slots": [
@@ -2832,7 +2689,7 @@
     ],
     "synonyms": [],
     "m_Precision": 0,
-    "m_PreviewExpanded": true,
+    "m_PreviewExpanded": false,
     "m_PreviewMode": 0,
     "m_CustomColors": {
         "m_SerializableColors": []
@@ -2866,10 +2723,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
+            "x": 107.33334350585938,
+            "y": -596.6666259765625,
+            "width": 200.0,
+            "height": 41.333309173583987
         }
     },
     "m_Slots": [
@@ -3117,9 +2974,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1042.0,
-            "y": -228.0,
-            "width": 152.66664123535157,
+            "x": -1032.0,
+            "y": -452.6666564941406,
+            "width": 152.6666259765625,
             "height": 34.0
         }
     },
@@ -3152,9 +3009,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1042.0,
-            "y": -330.66668701171877,
-            "width": 109.33331298828125,
+            "x": -823.9999389648438,
+            "y": -782.6666259765625,
+            "width": 109.3333740234375,
             "height": 34.0
         }
     },
@@ -3271,7 +3128,7 @@
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
     "m_Hidden": false,
-    "m_Value": 15.0,
+    "m_Value": 14.0,
     "m_FloatType": 2,
     "m_RangeValues": {
         "x": 0.0,

--- a/VisualPinball.Unity/Assets/Shaders/Srp/Display/SegmentDisplayGraph.shadergraph
+++ b/VisualPinball.Unity/Assets/Shaders/Srp/Display/SegmentDisplayGraph.shadergraph
@@ -22,7 +22,19 @@
             "m_Id": "ff8f18b4de9c472795505b7861bcd5f6"
         },
         {
+            "m_Id": "885913bc9f394469916eb1eff59f6e0e"
+        },
+        {
+            "m_Id": "0e8c53492f934592a66021f09b9dd22e"
+        },
+        {
+            "m_Id": "9800f604e2a64d6380194b87512b9b4b"
+        },
+        {
             "m_Id": "e518c40b4b094c54becc0f5fb35aa295"
+        },
+        {
+            "m_Id": "04a952dbfa6a4f0bad190f4802a047d6"
         },
         {
             "m_Id": "e477e5b9842248acb44b5c1d441b88b8"
@@ -100,32 +112,30 @@
             "m_Id": "89baeb3daa6d4db0ae8d03670faef7ec"
         },
         {
-            "m_Id": "0563660bc71f4f08a7f5351963cc7f5f"
-        },
-        {
             "m_Id": "0b15008e18274f6997842ed9c9548aa8"
         },
         {
             "m_Id": "6361a299e2994475a3838b7822b52f33"
+        },
+        {
+            "m_Id": "95785eec48b745a4808fe060f489b5d4"
+        },
+        {
+            "m_Id": "1992e3425efe471aa2dbf036e09c2c7f"
+        },
+        {
+            "m_Id": "d0418c29d8be4b799e0d59eed2008d20"
+        },
+        {
+            "m_Id": "901d8950486c419ab94fa357f94db1c2"
+        },
+        {
+            "m_Id": "6fc45a230484496eb0a637a0d40a3541"
         }
     ],
     "m_GroupDatas": [],
     "m_StickyNoteDatas": [],
     "m_Edges": [
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "0563660bc71f4f08a7f5351963cc7f5f"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "0b15008e18274f6997842ed9c9548aa8"
-                },
-                "m_SlotId": 1
-            }
-        },
         {
             "m_OutputSlot": {
                 "m_Node": {
@@ -138,6 +148,34 @@
                     "m_Id": "fb147419f0af4cc0b9446cb2737e6054"
                 },
                 "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "1992e3425efe471aa2dbf036e09c2c7f"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6fc45a230484496eb0a637a0d40a3541"
+                },
+                "m_SlotId": 10
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "1992e3425efe471aa2dbf036e09c2c7f"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "a94cb738cee9426e8bf076adaa3b6811"
+                },
+                "m_SlotId": 10
             }
         },
         {
@@ -163,7 +201,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "0563660bc71f4f08a7f5351963cc7f5f"
+                    "m_Id": "6fc45a230484496eb0a637a0d40a3541"
                 },
                 "m_SlotId": 6
             }
@@ -191,7 +229,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "0563660bc71f4f08a7f5351963cc7f5f"
+                    "m_Id": "6fc45a230484496eb0a637a0d40a3541"
                 },
                 "m_SlotId": 8
             }
@@ -213,6 +251,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "6fc45a230484496eb0a637a0d40a3541"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "bbf02ed4cd92417c804bb3108b4a9b6a"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "89baeb3daa6d4db0ae8d03670faef7ec"
                 },
                 "m_SlotId": 0
@@ -227,13 +279,69 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "901d8950486c419ab94fa357f94db1c2"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6fc45a230484496eb0a637a0d40a3541"
+                },
+                "m_SlotId": 12
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "901d8950486c419ab94fa357f94db1c2"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "a94cb738cee9426e8bf076adaa3b6811"
+                },
+                "m_SlotId": 12
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "95785eec48b745a4808fe060f489b5d4"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6fc45a230484496eb0a637a0d40a3541"
+                },
+                "m_SlotId": 9
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "95785eec48b745a4808fe060f489b5d4"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "a94cb738cee9426e8bf076adaa3b6811"
+                },
+                "m_SlotId": 9
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "9822db09ed324678ba43ee8fdd6c8339"
                 },
                 "m_SlotId": 0
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "0563660bc71f4f08a7f5351963cc7f5f"
+                    "m_Id": "6fc45a230484496eb0a637a0d40a3541"
                 },
                 "m_SlotId": 3
             }
@@ -261,7 +369,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "0563660bc71f4f08a7f5351963cc7f5f"
+                    "m_Id": "6fc45a230484496eb0a637a0d40a3541"
                 },
                 "m_SlotId": 5
             }
@@ -289,7 +397,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "bbf02ed4cd92417c804bb3108b4a9b6a"
+                    "m_Id": "0b15008e18274f6997842ed9c9548aa8"
                 },
                 "m_SlotId": 1
             }
@@ -303,7 +411,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "0563660bc71f4f08a7f5351963cc7f5f"
+                    "m_Id": "6fc45a230484496eb0a637a0d40a3541"
                 },
                 "m_SlotId": 7
             }
@@ -339,13 +447,41 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "d0418c29d8be4b799e0d59eed2008d20"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6fc45a230484496eb0a637a0d40a3541"
+                },
+                "m_SlotId": 11
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "d0418c29d8be4b799e0d59eed2008d20"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "a94cb738cee9426e8bf076adaa3b6811"
+                },
+                "m_SlotId": 11
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "da26bb7b7abc4e11a380b3946d1a8ab4"
                 },
                 "m_SlotId": 0
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "0563660bc71f4f08a7f5351963cc7f5f"
+                    "m_Id": "6fc45a230484496eb0a637a0d40a3541"
                 },
                 "m_SlotId": 1
             }
@@ -373,7 +509,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "0563660bc71f4f08a7f5351963cc7f5f"
+                    "m_Id": "6fc45a230484496eb0a637a0d40a3541"
                 },
                 "m_SlotId": 4
             }
@@ -401,7 +537,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "a94cb738cee9426e8bf076adaa3b6811"
+                    "m_Id": "6fc45a230484496eb0a637a0d40a3541"
                 },
                 "m_SlotId": 2
             }
@@ -480,62 +616,46 @@
 
 {
     "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.CustomFunctionNode",
-    "m_ObjectId": "0563660bc71f4f08a7f5351963cc7f5f",
-    "m_Group": {
-        "m_Id": ""
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "04a952dbfa6a4f0bad190f4802a047d6",
+    "m_Guid": {
+        "m_GuidSerialized": "c46d2a4b-0b92-4892-85b2-189b6345f7a6"
     },
-    "m_Name": "SegmentDisplay (Custom Function)",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -680.6666259765625,
-            "y": -156.0,
-            "width": 251.9999542236328,
-            "height": 446.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "d178bc6212d342269dd2cd53cac3326c"
-        },
-        {
-            "m_Id": "cf996e2b77924b0ea275312da53324c6"
-        },
-        {
-            "m_Id": "3cae4397d0144dcda318d080d3a19428"
-        },
-        {
-            "m_Id": "16e7342118c642a69c3d60f3ec9286d2"
-        },
-        {
-            "m_Id": "668737df6ef24813bf559e498eaac3b1"
-        },
-        {
-            "m_Id": "bb35815675584ed0b143c482b5a8136e"
-        },
-        {
-            "m_Id": "1ad2b2a7716b496ab26f25d46e0fc915"
-        },
-        {
-            "m_Id": "da5ad31dc61a4a9d86ee074fa3227004"
-        },
-        {
-            "m_Id": "6092ffe487064ed193e1bc96aa746b7b"
-        }
-    ],
-    "synonyms": [],
+    "m_Name": "HorizontalMiddle",
+    "m_DefaultReferenceName": "Vector1_04a952dbfa6a4f0bad190f4802a047d6",
+    "m_OverrideReferenceName": "__HorizontalMiddle",
+    "m_GeneratePropertyBlock": true,
     "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
+    "m_ObjectId": "0838d85768c24202863e85685b68bc20",
+    "m_Id": 11,
+    "m_DisplayName": "SeparatorPos",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "SeparatorPos",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
     },
-    "m_SourceType": 0,
-    "m_FunctionName": "SegmentDisplay",
-    "m_FunctionSource": "f52e22b29fa2471449033035256abdb4",
-    "m_FunctionBody": "Enter function body here..."
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -550,10 +670,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -332.6667175292969,
-            "y": -496.66668701171877,
-            "width": 208.0,
-            "height": 301.33331298828127
+            "x": -266.66668701171877,
+            "y": -530.0,
+            "width": 208.00001525878907,
+            "height": 301.9999694824219
         }
     },
     "m_Slots": [
@@ -596,6 +716,29 @@
 }
 
 {
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "0e8c53492f934592a66021f09b9dd22e",
+    "m_Guid": {
+        "m_GuidSerialized": "15930973-d875-41d9-8fb8-5fc4a72dd2a4"
+    },
+    "m_Name": "SeparatorEveryThree",
+    "m_DefaultReferenceName": "Vector1_0e8c53492f934592a66021f09b9dd22e",
+    "m_OverrideReferenceName": "__SeparatorEveryThree",
+    "m_GeneratePropertyBlock": true,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.TangentMaterialSlot",
     "m_ObjectId": "155a5c24386948dc8a3efb60592fe32b",
@@ -622,31 +765,51 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "16e7342118c642a69c3d60f3ec9286d2",
-    "m_Id": 3,
-    "m_DisplayName": "NumChars",
+    "m_ObjectId": "185b82df00ee4409af67c7f06f5e4306",
+    "m_Id": 7,
+    "m_DisplayName": "SegmentType",
     "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "NumChars",
+    "m_ShaderOutputName": "SegmentType",
     "m_StageCapability": 3,
-    "m_Value": 2.0,
+    "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
 }
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "1ad2b2a7716b496ab26f25d46e0fc915",
-    "m_Id": 5,
-    "m_DisplayName": "SkewAngle",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "SkewAngle",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "1992e3425efe471aa2dbf036e09c2c7f",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1042.0,
+            "y": -29.333335876464845,
+            "width": 187.99993896484376,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "e3b006adfea346d38073040a461b5515"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "0e8c53492f934592a66021f09b9dd22e"
+    }
 }
 
 {
@@ -719,6 +882,24 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "3afe634e26ca4761a79137da801c5b7c",
+    "m_Id": 2,
+    "m_DisplayName": "SegmentData",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "SegmentData",
+    "m_StageCapability": 3,
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_Guid": ""
+    },
+    "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BlockNode",
     "m_ObjectId": "3c772f87db964b8f93dcf520f8d02280",
     "m_Group": {
@@ -748,21 +929,6 @@
         "m_SerializableColors": []
     },
     "m_SerializedDescriptor": "SurfaceDescription.Metallic"
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "3cae4397d0144dcda318d080d3a19428",
-    "m_Id": 7,
-    "m_DisplayName": "SegmentType",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "SegmentType",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
 }
 
 {
@@ -810,6 +976,21 @@
     "m_StageCapability": 2,
     "m_Value": 1.0,
     "m_DefaultValue": 1.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "4344b62cd0604c728b5a53c2fafd64c3",
+    "m_Id": 4,
+    "m_DisplayName": "NumSegments",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "NumSegments",
+    "m_StageCapability": 3,
+    "m_Value": 15.0,
+    "m_DefaultValue": 0.0,
     "m_Labels": []
 }
 
@@ -1048,12 +1229,12 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "6092ffe487064ed193e1bc96aa746b7b",
-    "m_Id": 0,
-    "m_DisplayName": "Alpha",
-    "m_SlotType": 1,
+    "m_ObjectId": "624001b956b84cc1a6c348ecb77a1fda",
+    "m_Id": 9,
+    "m_DisplayName": "SeparatorType",
+    "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "Alpha",
+    "m_ShaderOutputName": "SeparatorType",
     "m_StageCapability": 3,
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
@@ -1096,14 +1277,14 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "668737df6ef24813bf559e498eaac3b1",
-    "m_Id": 4,
-    "m_DisplayName": "NumSegments",
+    "m_ObjectId": "677c43fdd95d4e928b501697279af40b",
+    "m_Id": 8,
+    "m_DisplayName": "Weight",
     "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "NumSegments",
+    "m_ShaderOutputName": "Weight",
     "m_StageCapability": 3,
-    "m_Value": 15.0,
+    "m_Value": 0.05000000074505806,
     "m_DefaultValue": 0.0,
     "m_Labels": []
 }
@@ -1221,6 +1402,78 @@
 }
 
 {
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.CustomFunctionNode",
+    "m_ObjectId": "6fc45a230484496eb0a637a0d40a3541",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SegmentDisplay (Custom Function)",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -638.0,
+            "y": -860.0,
+            "width": 267.3333435058594,
+            "height": 541.3333129882813
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "726ff61b4bdf4f3b9f72513671fdbd7e"
+        },
+        {
+            "m_Id": "96a5f39a430e4076b9b8c2d06eb016c2"
+        },
+        {
+            "m_Id": "3afe634e26ca4761a79137da801c5b7c"
+        },
+        {
+            "m_Id": "185b82df00ee4409af67c7f06f5e4306"
+        },
+        {
+            "m_Id": "848fa978888949d9b92a5effb184c1c3"
+        },
+        {
+            "m_Id": "4344b62cd0604c728b5a53c2fafd64c3"
+        },
+        {
+            "m_Id": "f2b7fe7119134a3890c494eebd960a4b"
+        },
+        {
+            "m_Id": "b6384e34e02b4cc5bb4431c3ab5d33c4"
+        },
+        {
+            "m_Id": "0838d85768c24202863e85685b68bc20"
+        },
+        {
+            "m_Id": "677c43fdd95d4e928b501697279af40b"
+        },
+        {
+            "m_Id": "98ed3fa5d0ac4a7bbf73dc16f8be967d"
+        },
+        {
+            "m_Id": "7b72d0fbd6d14317891f378284414ed7"
+        },
+        {
+            "m_Id": "888699ffa7b84a15b5130fd2e44dd2b3"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SourceType": 0,
+    "m_FunctionName": "SegmentDisplay",
+    "m_FunctionSource": "f52e22b29fa2471449033035256abdb4",
+    "m_FunctionBody": "Enter function body here..."
+}
+
+{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.Rendering.HighDefinition.ShaderGraph.HDTarget",
     "m_ObjectId": "70b7c54e19f74cd191c6c4e86e048608",
@@ -1242,6 +1495,21 @@
         }
     ],
     "m_CustomEditorGUI": ""
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "726ff61b4bdf4f3b9f72513671fdbd7e",
+    "m_Id": 0,
+    "m_DisplayName": "Alpha",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Alpha",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {
@@ -1362,6 +1630,36 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "7b72d0fbd6d14317891f378284414ed7",
+    "m_Id": 5,
+    "m_DisplayName": "SkewAngle",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "SkewAngle",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "7c128f49c5f2443fbffc659e7c8a465d",
+    "m_Id": 0,
+    "m_DisplayName": "HorizontalMiddle",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
     "m_ObjectId": "7ccdfbab72444042a5ee7f9f1ea95126",
     "m_Id": 2,
@@ -1473,6 +1771,65 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "848fa978888949d9b92a5effb184c1c3",
+    "m_Id": 3,
+    "m_DisplayName": "NumChars",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "NumChars",
+    "m_StageCapability": 3,
+    "m_Value": 2.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "885913bc9f394469916eb1eff59f6e0e",
+    "m_Guid": {
+        "m_GuidSerialized": "0a499c3f-35f7-4631-a501-bad900343765"
+    },
+    "m_Name": "SeparatorType",
+    "m_DefaultReferenceName": "Vector1_885913bc9f394469916eb1eff59f6e0e",
+    "m_OverrideReferenceName": "__SeparatorType",
+    "m_GeneratePropertyBlock": true,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 2.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
+    "m_ObjectId": "888699ffa7b84a15b5130fd2e44dd2b3",
+    "m_Id": 6,
+    "m_DisplayName": "Padding",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Padding",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.23999999463558198,
+        "y": 0.1899999976158142
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "89baeb3daa6d4db0ae8d03670faef7ec",
     "m_Group": {
@@ -1508,6 +1865,56 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "8e750e59ca6e4cba85236eb7faed73d1",
+    "m_Id": 0,
+    "m_DisplayName": "SeparatorType",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "901d8950486c419ab94fa357f94db1c2",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1042.0,
+            "y": 57.333335876464847,
+            "width": 168.6666259765625,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "7c128f49c5f2443fbffc659e7c8a465d"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "04a952dbfa6a4f0bad190f4802a047d6"
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
     "m_ObjectId": "9217f4a049174ddc9ae5913982cc2350",
     "m_Id": 2,
@@ -1522,6 +1929,85 @@
         "m_Guid": ""
     },
     "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "95785eec48b745a4808fe060f489b5d4",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1041.3333740234375,
+            "y": -64.0000228881836,
+            "width": 154.66668701171876,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "8e750e59ca6e4cba85236eb7faed73d1"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "885913bc9f394469916eb1eff59f6e0e"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
+    "m_ObjectId": "96a5f39a430e4076b9b8c2d06eb016c2",
+    "m_Id": 1,
+    "m_DisplayName": "UV",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "UV",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector2ShaderProperty",
+    "m_ObjectId": "9800f604e2a64d6380194b87512b9b4b",
+    "m_Guid": {
+        "m_GuidSerialized": "f9fed30d-ccdd-4d9a-bfe8-bc44f9dcca14"
+    },
+    "m_Name": "SeparatorPos",
+    "m_DefaultReferenceName": "Vector2_9800f604e2a64d6380194b87512b9b4b",
+    "m_OverrideReferenceName": "__SeparatorPos",
+    "m_GeneratePropertyBlock": true,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": {
+        "x": 1.399999976158142,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
 }
 
 {
@@ -1557,6 +2043,21 @@
     "m_Property": {
         "m_Id": "48868e3f644c4f8d9dc2d14907d07c46"
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "98ed3fa5d0ac4a7bbf73dc16f8be967d",
+    "m_Id": 12,
+    "m_DisplayName": "HorizontalMiddle",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "HorizontalMiddle",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {
@@ -1694,13 +2195,16 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -680.6666870117188,
-            "y": -640.666748046875,
-            "width": 251.99998474121095,
-            "height": 446.0000305175781
+            "x": -638.0,
+            "y": -248.6666717529297,
+            "width": 267.3333435058594,
+            "height": 541.9999389648438
         }
     },
     "m_Slots": [
+        {
+            "m_Id": "d31a164eae9d45dfaa3fe1438ac873e8"
+        },
         {
             "m_Id": "b65cd42e932f4185b29ddd13b22afff3"
         },
@@ -1717,16 +2221,25 @@
             "m_Id": "c68d74fb05534f7fbdee4c1d4040c9f1"
         },
         {
+            "m_Id": "624001b956b84cc1a6c348ecb77a1fda"
+        },
+        {
+            "m_Id": "d648839e7bc24b12bc3b96ad6ccb6858"
+        },
+        {
+            "m_Id": "ad11a38fae924069821397cff1b204df"
+        },
+        {
             "m_Id": "c7302840f46d44528fb37adb2f9e46c9"
+        },
+        {
+            "m_Id": "f97a6ea199be4204b745c2fd5fb7d160"
         },
         {
             "m_Id": "c38406a3a8f344fda30eeac8cbaad371"
         },
         {
             "m_Id": "d644481f2a7c40cf9e3b4daa2b9ca58c"
-        },
-        {
-            "m_Id": "d31a164eae9d45dfaa3fe1438ac873e8"
         }
     ],
     "synonyms": [],
@@ -1740,6 +2253,27 @@
     "m_FunctionName": "SegmentDisplay",
     "m_FunctionSource": "f52e22b29fa2471449033035256abdb4",
     "m_FunctionBody": "Enter function body here..."
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
+    "m_ObjectId": "ad11a38fae924069821397cff1b204df",
+    "m_Id": 11,
+    "m_DisplayName": "SeparatorPos",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "SeparatorPos",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -1779,6 +2313,21 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "b6384e34e02b4cc5bb4431c3ab5d33c4",
+    "m_Id": 10,
+    "m_DisplayName": "SeparatorEveryThreeOnly",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "SeparatorEveryThreeOnly",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "b65cd42e932f4185b29ddd13b22afff3",
     "m_Id": 1,
@@ -1800,21 +2349,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "bb35815675584ed0b143c482b5a8136e",
-    "m_Id": 8,
-    "m_DisplayName": "Weight",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Weight",
-    "m_StageCapability": 3,
-    "m_Value": 0.05000000074505806,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
     "m_ObjectId": "bbf02ed4cd92417c804bb3108b4a9b6a",
     "m_Group": {
@@ -1825,10 +2359,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -331.9999694824219,
-            "y": -859.3333740234375,
-            "width": 208.0,
-            "height": 302.0
+            "x": -266.0000305175781,
+            "y": -859.9999389648438,
+            "width": 207.99996948242188,
+            "height": 301.9999694824219
         }
     },
     "m_Slots": [
@@ -2138,20 +2672,37 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
-    "m_ObjectId": "cf996e2b77924b0ea275312da53324c6",
-    "m_Id": 2,
-    "m_DisplayName": "SegmentData",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "SegmentData",
-    "m_StageCapability": 3,
-    "m_BareResource": false,
-    "m_Texture": {
-        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
-        "m_Guid": ""
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "d0418c29d8be4b799e0d59eed2008d20",
+    "m_Group": {
+        "m_Id": ""
     },
-    "m_DefaultType": 0
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1040.0,
+            "y": 4.666668891906738,
+            "width": 150.66661071777345,
+            "height": 34.000003814697269
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "d94d76a4c97942c38c155f916959aefb"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "9800f604e2a64d6380194b87512b9b4b"
+    }
 }
 
 {
@@ -2166,27 +2717,6 @@
     "m_StageCapability": 2,
     "m_Value": 1.0,
     "m_DefaultValue": 1.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
-    "m_ObjectId": "d178bc6212d342269dd2cd53cac3326c",
-    "m_Id": 1,
-    "m_DisplayName": "UV",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "UV",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0
-    },
     "m_Labels": []
 }
 
@@ -2243,6 +2773,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "d648839e7bc24b12bc3b96ad6ccb6858",
+    "m_Id": 10,
+    "m_DisplayName": "SeparatorEveryThreeOnly",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "SeparatorEveryThreeOnly",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
+    "m_ObjectId": "d94d76a4c97942c38c155f916959aefb",
+    "m_Id": 0,
+    "m_DisplayName": "SeparatorPos",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.UVNode",
     "m_ObjectId": "da26bb7b7abc4e11a380b3946d1a8ab4",
     "m_Group": {
@@ -2272,27 +2838,6 @@
         "m_SerializableColors": []
     },
     "m_OutputChannel": 0
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
-    "m_ObjectId": "da5ad31dc61a4a9d86ee074fa3227004",
-    "m_Id": 6,
-    "m_DisplayName": "Padding",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Padding",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.23999999463558198,
-        "y": 0.1899999976158142
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0
-    },
-    "m_Labels": []
 }
 
 {
@@ -2364,6 +2909,21 @@
     },
     "m_Labels": [],
     "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "e3b006adfea346d38073040a461b5515",
+    "m_Id": 0,
+    "m_DisplayName": "SeparatorEveryThree",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {
@@ -2532,6 +3092,21 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "f2b7fe7119134a3890c494eebd960a4b",
+    "m_Id": 9,
+    "m_DisplayName": "SeparatorType",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "SeparatorType",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "f3244293662447d4b0f9b21f28086b11",
     "m_Group": {
@@ -2598,6 +3173,21 @@
     "m_Property": {
         "m_Id": "28cb878a5da744d2aecfe399a3254ec8"
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "f97a6ea199be4204b745c2fd5fb7d160",
+    "m_Id": 12,
+    "m_DisplayName": "HorizontalMiddle",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "HorizontalMiddle",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {

--- a/VisualPinball.Unity/Assets/Shaders/Srp/Display/SegmentDisplayShader.hlsl
+++ b/VisualPinball.Unity/Assets/Shaders/Srp/Display/SegmentDisplayShader.hlsl
@@ -1,5 +1,4 @@
-﻿float _SegmentWidth;
-int _SegmentType;
+﻿float _SegmentWeight;
 float _Height;
 float _NumChars;
 float _NumSegments;
@@ -112,7 +111,7 @@ float LongLine(float2 a, float2 b, float2 p)
 	float2 pa = p - float2(a.x, -a.y);
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
 	float t = clamp(dot(pa, ba) / dot(ba, ba), SegmentGap, 1.0 - SegmentGap);
-	float2 v = abs(pa - ba * t) / _SegmentWidth * 0.5;
+	float2 v = abs(pa - ba * t) / _SegmentWeight * 0.5;
 
 	return Rounder2(1 - v.x, 1 - v.y - v.x);
 }
@@ -122,7 +121,7 @@ float LongLine2(float2 a, float2 b, float2 p)
 	float2 pa = p - float2(a.x, -a.y);
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
 	float t = clamp(dot(pa, ba) / dot(ba, ba), SegmentGap, 1.0 - SegmentGap);
-	float2 v = abs(pa - ba * t) / _SegmentWidth * 0.5;
+	float2 v = abs(pa - ba * t) / _SegmentWeight * 0.5;
 
 	return Rounder2(1 - v.x, 1 - v.y - v.x);
 }
@@ -132,7 +131,7 @@ float ShortLine(float2 a, float2 b, float2 p)
 	float2 pa = p - float2(a.x, -a.y);
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
 	float t = clamp(dot(pa, ba) / dot(ba, ba), SegmentGap * 2.0, 1.0 - SegmentGap * 2.0);
-	float2 v = abs(pa - ba * t) / _SegmentWidth * 0.5;
+	float2 v = abs(pa - ba * t) / _SegmentWeight * 0.5;
 
 	return Rounder2(1 - v.x, 1 - v.y - v.x);
 }
@@ -142,7 +141,7 @@ float MidLine(float2 a, float2 b, float2 p)
 	float2 pa = p - float2(a.x, -a.y);
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
 	float t = clamp(dot(pa, ba) / dot(ba, ba), SegmentGap * 1.1, 1.0 - SegmentGap * 1.1);
-	float2 v = abs(pa - ba * t) / _SegmentWidth * 0.5;
+	float2 v = abs(pa - ba * t) / _SegmentWeight * 0.5;
 
 	return Rounder2(1 - v.x, 1 - v.y - v.x);
 }
@@ -153,15 +152,15 @@ float DiagLine(float2 a, float2 b, float2 p)
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
 	float t = pa.x / ba.x;
 	float2 intersectP = abs(pa - ba * t);
-	float xl = clamp(1 - (p.x - a.x + SegmentGap + _SegmentWidth) / _SegmentWidth * 0.5, -9999, 1);
-	float xr = clamp(0 + (p.x - b.x - SegmentGap + _SegmentWidth) / _SegmentWidth * 0.5, -9999, 1);
+	float xl = clamp(1 - (p.x - a.x + SegmentGap + _SegmentWeight) / _SegmentWeight * 0.5, -9999, 1);
+	float xr = clamp(0 + (p.x - b.x - SegmentGap + _SegmentWeight) / _SegmentWeight * 0.5, -9999, 1);
 
 	float t2 = pa.y / ba.y;
 	float yu = clamp(t2 + 1.0 - SegmentGap * 2, -9999, 1);
 	float yd = clamp(2 - t2 - SegmentGap * 2, -9999, 1);
 
 	return Rounder(
-		1 - intersectP.y / (_SegmentWidth * 4.0),
+		1 - intersectP.y / (_SegmentWeight * 4.0),
 		xl * xr,
 		(yd * yu) / SegmentGap * 0.5 - 4.0
 	);
@@ -173,15 +172,15 @@ float DiagLine2(float2 a, float2 b, float2 p)
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
 	float t = pa.x / ba.x;
 	float2 intersectP = abs(pa - ba * t);
-	float xr = clamp(0 + (p.x - a.x - SegmentGap + _SegmentWidth) / _SegmentWidth * 0.5, -9999, 1);
-	float xl = clamp(1 - (p.x - b.x + SegmentGap + _SegmentWidth) / _SegmentWidth * 0.5, -9999, 1);
+	float xr = clamp(0 + (p.x - a.x - SegmentGap + _SegmentWeight) / _SegmentWeight * 0.5, -9999, 1);
+	float xl = clamp(1 - (p.x - b.x + SegmentGap + _SegmentWeight) / _SegmentWeight * 0.5, -9999, 1);
 
 	float t2 = pa.y / ba.y;
 	float yu = clamp(t2 + 1.0 - SegmentGap * 2, -9999, 1);
 	float yd = clamp(2 - t2 - SegmentGap * 2, -9999, 1);
 
 	return Rounder(
-		1 - intersectP.y / (_SegmentWidth * 4.0),
+		1 - intersectP.y / (_SegmentWeight * 4.0),
 		xl * xr,
 		(yd * yu) / SegmentGap * 0.5 - 4.0
 	);
@@ -193,15 +192,15 @@ float DiagLine3(float2 a, float2 b, float2 p)
 	float2 ba = float2(b.x, -b.y) - float2(a.x, -a.y);
 	float t = pa.x / ba.x;
 	float2 intersectP = abs(pa - ba * t);
-	float xl = clamp(1 - (p.x - a.x + SegmentGap + _SegmentWidth) / _SegmentWidth * 0.5, -9999, 1);
-	float xr = clamp(0 + (p.x - b.x - SegmentGap + _SegmentWidth) / _SegmentWidth * 0.5, -9999, 1);
+	float xl = clamp(1 - (p.x - a.x + SegmentGap + _SegmentWeight) / _SegmentWeight * 0.5, -9999, 1);
+	float xr = clamp(0 + (p.x - b.x - SegmentGap + _SegmentWeight) / _SegmentWeight * 0.5, -9999, 1);
 
 	float t2 = pa.y / ba.y;
 	float yu = clamp(t2 + 1.0 - SegmentGap * 2, -9999, 1);
 	float yd = clamp(2 - t2 - SegmentGap * 2, -9999, 1);
 
 	return Rounder(
-		1 - intersectP.y / (_SegmentWidth * 3.0),
+		1 - intersectP.y / (_SegmentWeight * 3.0),
 		xl * xr,
 		(yd * yu) / SegmentGap * 0.5 - 4.0
 	);
@@ -251,12 +250,7 @@ float3 Combine(float3 accu, float val, bool showSeg)
 
 bool ShowSeg(UnityTexture2D data, int charIndex, int segIndex)
 {
-	int numSegs = 1;
-	switch (_SegmentType) {
-		case 0: numSegs = 15; break;
-		case 4: numSegs = 8; break;
-	}
-	float2 d = float2(1. / numSegs, 1. / _NumChars);
+	float2 d = float2(1. / 16, 1. / _NumChars);
 	float2 pos = float2(float(segIndex), float(charIndex));
 	float4 pixel = tex2Dlod(data, float4(d.x * (pos.x + .5), d.y * (pos.y + .5), 0., 0.));
 	if (pixel.b > .5) {
@@ -288,7 +282,7 @@ float3 SegDispSeparator(UnityTexture2D data, int charIndex, int segIndex, float2
 	return r;
 }
 
-float3 SegDisp8(UnityTexture2D data, int charIndex, float2 p, float3 r)
+float3 SegDisp7(UnityTexture2D data, int charIndex, float2 p, float3 r)
 {
 	r = Combine(r, MidLine(tl, tr, p), ShowSeg(data, charIndex, 0));
 	r = Combine(r, LongLine(tr, mr, p), ShowSeg(data, charIndex, 1));
@@ -302,7 +296,7 @@ float3 SegDisp8(UnityTexture2D data, int charIndex, float2 p, float3 r)
 	return r;
 }
 
-float3 SegDisp10(UnityTexture2D data, int charIndex, float2 p, float3 r)
+float3 SegDisp9(UnityTexture2D data, int charIndex, float2 p, float3 r)
 {
 	r = Combine(r, MidLine(tl, tr, p), ShowSeg(data, charIndex, 0));
 	r = Combine(r, LongLine(tr, mr, p), ShowSeg(data, charIndex, 1));
@@ -318,7 +312,7 @@ float3 SegDisp10(UnityTexture2D data, int charIndex, float2 p, float3 r)
 	return r;
 }
 
-float3 SegDisp15(UnityTexture2D data, int charIndex, float2 p, float3 r)
+float3 SegDisp14(UnityTexture2D data, int charIndex, float2 p, float3 r)
 {
 	r = Combine(r, MidLine(tl, tr, p), ShowSeg(data, charIndex, 0));
 	r = Combine(r, LongLine(tr, mr, p), ShowSeg(data, charIndex, 1));
@@ -343,20 +337,19 @@ float3 SegDisp(UnityTexture2D data, int charIndex, float2 p)
 {
 	float3 r = (0.);
 	p.x -= p.y * -_SkewAngle;
-	switch (_SegmentType) {
-		case 0: return SegDisp15(data, charIndex, p, r);
-		case 2: return SegDisp10(data, charIndex, p, r);
-		case 4: return SegDisp8(data, charIndex, p, r);
+	switch (_NumSegments) {
+		case 7: return SegDisp7(data, charIndex, p, r);
+		case 9: return SegDisp9(data, charIndex, p, r);
+		case 14: return SegDisp14(data, charIndex, p, r);
 	}
 	return r;
 }
 
-void SegmentDisplay_float(float2 coords, UnityTexture2D data, float segmentType, float numChars,
-	float numSegments, int separatorType, int separatorEveryThreeOnly, float2 separatorPos,
-	float segmentWidth, float horizontalMiddle, float skewAngle, float2 padding, out float output)
+void SegmentDisplay_float(float2 coords, UnityTexture2D data, float numChars, float numSegments,
+	int separatorType, int separatorEveryThreeOnly, float2 separatorPos, float segmentWeight,
+	float horizontalMiddle, float skewAngle, float2 padding, out float output)
 {
-	_SegmentWidth = segmentWidth;
-	_SegmentType = segmentType;
+	_SegmentWeight = segmentWeight;
 	_NumChars = numChars;
 	_NumSegments = numSegments;
 	_SkewAngle = skewAngle;
@@ -365,14 +358,14 @@ void SegmentDisplay_float(float2 coords, UnityTexture2D data, float segmentType,
 	_SeparatorEveryThreeOnly = separatorEveryThreeOnly;
 	_SeparatorPos = separatorPos;
 
-	SegmentGap = segmentWidth * 1.5;
-	dtl = tl + float2(0.0, -segmentWidth);
-	dtr = tr + float2(0.0, -segmentWidth);
-	dtm = mm + float2(0.0 + _HorizontalMiddle, segmentWidth);
-	dbm = mm + float2(0.0 + _HorizontalMiddle, -segmentWidth);
-	dbl = bl + float2(0.0, segmentWidth);
-	dbr = br + float2(0.0, segmentWidth);
-	dp = br + float2(segmentWidth * 4.0, SegmentGap);
+	SegmentGap = segmentWeight * 1.5;
+	dtl = tl + float2(0.0, -segmentWeight);
+	dtr = tr + float2(0.0, -segmentWeight);
+	dtm = mm + float2(0.0 + _HorizontalMiddle, segmentWeight);
+	dbm = mm + float2(0.0 + _HorizontalMiddle, -segmentWeight);
+	dbl = bl + float2(0.0, segmentWeight);
+	dbr = br + float2(0.0, segmentWeight);
+	dp = br + float2(segmentWeight * 4.0, SegmentGap);
 	mm = float2(.0 + _HorizontalMiddle, 0);   // middle
 	tm = float2(.0 + _HorizontalMiddle, 1);
 	bm = float2(.0 + _HorizontalMiddle, -1);
@@ -393,7 +386,7 @@ void SegmentDisplay_float(float2 coords, UnityTexture2D data, float segmentType,
 	float2 pos = originPos;
 	float3 d = (0.);
 
-	float2 f = float2(numChars * (1. + padding.x + segmentWidth * 2.), 1. + (padding.y + segmentWidth));
+	float2 f = float2(numChars * (1. + padding.x + segmentWeight * 2.), 1. + (padding.y + segmentWeight));
 	for (int character = 0; character < numChars; character++) {
 
 		d += SegDisp(data, character, (uv - pos) * f);

--- a/VisualPinball.Unity/Assets/Shaders/Srp/Display/SegmentDisplayShader.hlsl
+++ b/VisualPinball.Unity/Assets/Shaders/Srp/Display/SegmentDisplayShader.hlsl
@@ -333,6 +333,29 @@ float3 SegDisp14(UnityTexture2D data, int charIndex, float2 p, float3 r)
 	return r;
 }
 
+float3 SegDisp16(UnityTexture2D data, int charIndex, float2 p, float3 r)
+{
+	r = Combine(r, ShortLine(tl, tm, p), ShowSeg(data, charIndex, 0)); // a
+	r = Combine(r, ShortLine(tm, tr, p), ShowSeg(data, charIndex, 1)); // b
+	r = Combine(r, LongLine(tr, mr, p), ShowSeg(data, charIndex, 2));  // c
+	r = Combine(r, LongLine(mr, br, p), ShowSeg(data, charIndex, 3));  // d
+	r = Combine(r, ShortLine(br, bm, p), ShowSeg(data, charIndex, 4)); // e
+	r = Combine(r, ShortLine(bm, bl, p), ShowSeg(data, charIndex, 5)); // f
+	r = Combine(r, LongLine(bl, ml, p), ShowSeg(data, charIndex, 6));  // g
+	r = Combine(r, LongLine(ml, tl, p), ShowSeg(data, charIndex, 7));  // h
+	r = Combine(r, DiagLine2(dtl, dtm, p), ShowSeg(data, charIndex, 8)); // i
+	r = Combine(r, LongLine2(tm, mm, p), ShowSeg(data, charIndex, 9));   // j
+	r = Combine(r, DiagLine(dtr, dtm, p), ShowSeg(data, charIndex, 10)); // k
+	r = Combine(r, ShortLine(mm, mr, p), ShowSeg(data, charIndex, 11));  // l
+	r = Combine(r, DiagLine2(dbm, dbr, p), ShowSeg(data, charIndex, 12));// m
+	r = Combine(r, LongLine(mm, bm, p), ShowSeg(data, charIndex, 13));   // n
+	r = Combine(r, DiagLine(dbm, dbl, p), ShowSeg(data, charIndex, 14)); // o
+	r = Combine(r, ShortLine(mm, ml, p), ShowSeg(data, charIndex, 15));   // p
+
+	return r;
+}
+
+
 float3 SegDisp(UnityTexture2D data, int charIndex, float2 p)
 {
 	float3 r = (0.);
@@ -341,6 +364,7 @@ float3 SegDisp(UnityTexture2D data, int charIndex, float2 p)
 		case 7: return SegDisp7(data, charIndex, p, r);
 		case 9: return SegDisp9(data, charIndex, p, r);
 		case 14: return SegDisp14(data, charIndex, p, r);
+		case 16: return SegDisp16(data, charIndex, p, r);
 	}
 	return r;
 }

--- a/VisualPinball.Unity/Assets/Shaders/Srp/Display/SegmentDisplayShader.hlsl
+++ b/VisualPinball.Unity/Assets/Shaders/Srp/Display/SegmentDisplayShader.hlsl
@@ -202,9 +202,12 @@ float DiagLine3(float2 a, float2 b, float2 p)
 	);
 }
 
-float Circle(float2 _st, float _radius)
+float2 Translate(float2 coord, float2 translate) {
+	return coord - translate;
+}
+
+float Circle(float2 _st, float _radius, float smooth)
 {
-	float smooth = 2.;
 	_st.x += _st.y * -_SkewAngle; // un-angle
 	_st.x += _SkewAngle * 0.5; // un-angle
 	_st.y *= 0.9; // unstretch
@@ -214,6 +217,19 @@ float Circle(float2 _st, float _radius)
 		_radius + (_radius * smooth),
 		dot(dist, dist) * 4.0
 	);
+}
+
+
+float Comma(float2 uv)
+{
+	if (uv.y < 0.61) {
+		return 0.;
+	}
+
+	float c = Circle(Translate(uv, float2(-0.15, 0.1)), 0.15, .7);   // plus
+	c *= 1. - Circle(Translate(uv, float2(-0.01, 0.05)), 0.01, 2.5); // minus top
+	c *= 1. - Circle(Translate(uv, float2(-0.42, .13)), 0.48, .3);   // minus left
+	return c;
 }
 
 float3 Combine(float3 accu, float val, bool showSeg)
@@ -254,7 +270,7 @@ float3 SegDisp8(UnityTexture2D data, int charIndex, float2 p, float3 r)
 	r = Combine(r, LongLine(bl, ml, p), ShowSeg(data, charIndex, 4));
 	r = Combine(r, LongLine(ml, tl, p), ShowSeg(data, charIndex, 5));
 	r = Combine(r, MidLine(mr, ml, p), ShowSeg(data, charIndex, 6));
-	r = Combine(r, Circle(float2(p.x - 0.2, p.y - 0.43), 0.025), ShowSeg(data, charIndex, 7));
+	r = Combine(r, Circle(float2(p.x - 0.2, p.y - 0.43), 0.025, 1.5), ShowSeg(data, charIndex, 7));
 	return r;
 }
 
@@ -267,11 +283,32 @@ float3 SegDisp10(UnityTexture2D data, int charIndex, float2 p, float3 r)
 	r = Combine(r, LongLine(bl, ml, p), ShowSeg(data, charIndex, 4));
 	r = Combine(r, LongLine(ml, tl, p), ShowSeg(data, charIndex, 5));
 	r = Combine(r, MidLine(mr, ml, p), ShowSeg(data, charIndex, 6));
-	r = Combine(r, Circle(float2(p.x - 0.2, p.y - 0.43), 0.025), ShowSeg(data, charIndex, 7));
+	r = Combine(r, Circle(float2(p.x - 0.2, p.y - 0.43), 0.025, 1.5), ShowSeg(data, charIndex, 7));
 	r = Combine(r, DiagLine3(dtr, dtm, p), ShowSeg(data, charIndex, 8));
 	r = Combine(r, DiagLine3(dbm, dbl, p), ShowSeg(data, charIndex, 9));
 
 	return r;
+}
+
+// float draw_circle(in float2 _st, in float _radius){
+// 	float2 dist = _st - float2(0.5);
+// 	return 1. - smoothstep(_radius-(_radius*0.02), _radius+(_radius*0.02), dot(dist,dist)*4.0);
+// }
+//
+// float draw_circle2(float2 coord, float radius) {
+// 	return smoothstep(length(coord), radius-0.01, radius+0.01);
+// }
+
+float2 translate(float2 coord, float2 translate) {
+	return coord - translate;
+}
+
+float2 comma(float2 uv)
+{
+	float c = Circle(translate(uv, float2(0.0, 0.8)), 0.03);
+	// c *= (1. - Circle(translate(uv, float2(0.5, 0.5)), 0.6));
+	// c *= (1. - Circle(translate(uv, float2(1.2, 0.7)), 0.25));
+	return c;
 }
 
 float3 SegDisp15(UnityTexture2D data, int charIndex, float2 p, float3 r)
@@ -283,7 +320,7 @@ float3 SegDisp15(UnityTexture2D data, int charIndex, float2 p, float3 r)
 	r = Combine(r, LongLine(bl, ml, p), ShowSeg(data, charIndex, 4));
 	r = Combine(r, LongLine(ml, tl, p), ShowSeg(data, charIndex, 5));
 	r = Combine(r, ShortLine(mm, ml, p), ShowSeg(data, charIndex, 6));
-	r = Combine(r, Circle(float2(p.x - 0.2, p.y - 0.43), 0.025), ShowSeg(data, charIndex, 7));
+	r = Combine(r, Circle(float2(p.x - 0.2, p.y - 0.43), 0.025, 1.5), ShowSeg(data, charIndex, 7));
 	r = Combine(r, DiagLine2(dtl, dtm, p), ShowSeg(data, charIndex, 8));
 	r = Combine(r, LongLine2(tm, mm, p), ShowSeg(data, charIndex, 9));
 	r = Combine(r, DiagLine(dtr, dtm, p), ShowSeg(data, charIndex, 10));
@@ -291,6 +328,7 @@ float3 SegDisp15(UnityTexture2D data, int charIndex, float2 p, float3 r)
 	r = Combine(r, DiagLine2(dbm, dbr, p), ShowSeg(data, charIndex, 12));
 	r = Combine(r, LongLine(mm, bm, p), ShowSeg(data, charIndex, 13));
 	r = Combine(r, DiagLine(dbm, dbl, p), ShowSeg(data, charIndex, 14));
+	r = Combine(r, Comma(float2(p.x - 0.2, p.y - 0.43)), ShowSeg(data, charIndex, 15));
 
 	return r;
 }

--- a/VisualPinball.Unity/Assets/Shaders/Srp/Display/SegmentDisplayShader.hlsl
+++ b/VisualPinball.Unity/Assets/Shaders/Srp/Display/SegmentDisplayShader.hlsl
@@ -306,8 +306,8 @@ float3 SegDisp9(UnityTexture2D data, int charIndex, float2 p, float3 r)
 	r = Combine(r, LongLine(ml, tl, p), ShowSeg(data, charIndex, 5));
 	r = Combine(r, MidLine(mr, ml, p), ShowSeg(data, charIndex, 6));
 	r = SegDispSeparator(data, charIndex, 7, p, r);
-	r = Combine(r, DiagLine3(dtr, dtm, p), ShowSeg(data, charIndex, 8));
-	r = Combine(r, DiagLine3(dbm, dbl, p), ShowSeg(data, charIndex, 9));
+	r = Combine(r, LongLine2(tm, mm, p), ShowSeg(data, charIndex, 8));
+	r = Combine(r, LongLine(mm, bm, p), ShowSeg(data, charIndex, 9));
 
 	return r;
 }

--- a/VisualPinball.Unity/Assets/Shaders/Srp/LerpVertex.shadergraph.meta
+++ b/VisualPinball.Unity/Assets/Shaders/Srp/LerpVertex.shadergraph.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 399f55b568dd1cd4fbe1a77f595f9c1b
+guid: ff23d09bd53285242b917860824fbd69
 ScriptedImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/VisualPinball.Unity/Assets/Shaders/Srp/Subgraphs.meta
+++ b/VisualPinball.Unity/Assets/Shaders/Srp/Subgraphs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: efa0596b432a04f438dbe40aa4076e69
+guid: d8e88b3855845064cadabf756f54a775
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/VisualPinball.Unity/Assets/Shaders/Srp/Subgraphs/VertexPositionLerp.shadersubgraph.meta
+++ b/VisualPinball.Unity/Assets/Shaders/Srp/Subgraphs/VertexPositionLerp.shadersubgraph.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 47d0d1a172ca2f04b952baaa26c2df93
+guid: 9f17a7bc6ff8f25429e4b33aea964502
 ScriptedImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/VisualPinball.Unity/Documentation~/creators-guide/introduction/features.md
+++ b/VisualPinball.Unity/Documentation~/creators-guide/introduction/features.md
@@ -85,31 +85,6 @@ There are common patterns for VPX tables that are obsolete in VPE. For instance,
 
 Of course the changes don't apply to the table data itself but to how we convert it into the Unity scene. You can read more about it [here](https://github.com/freezy/VisualPinball.Engine/tree/master/VisualPinball.Unity/VisualPinball.Unity.Patcher#unity-patching-system).
 
+## Display Support
 
-# Missing Features
-
-There are some things you might expect to work, but don't, because they're not yet implemented. Here's an incomplete list of those things.
-
-## Key Assignments
-
-Currently, we grab left and right shift and map it to `LeftFlipper` and `RightFlipper` respectively. If the flippers are named differently, it doesn't work.
-
-VPE will provide a simple mapping mechanism where authors can link semantic key events to table logic and users can link keyboard keys to those key events.
-
-## Performance
-
-When building the table, performance is okay but still not satisfactory. We think we can still do better.
-
-## Runtime Import
-
-Right now, when you "build" your game and run it, Unity will compile it into binary assets. We want to avoid authors distributing those binaries, because they hide how things are done prevent further modding by other creators.
-
-Both of these aspects are crucial in building an ecosystem, so the goal is to only compile the player itself and load the tables at runtime.
-
-## Ball Destruction
-
-Currently balls can't be destroyed during gameplay, so every drain will just leave them on the table, resulting in poor performance.
-
-# Planned Features
-
-This section will at some point contain a list of major new features.
+VPE provides high-quality rendering of dot matrix and segment displays. Displays can be placed anywhere in the scene, multiple at once, and are easily linked to the game logic engine. For DMDs, dot size, shape and color can be customized, and for segment displays it's the segment weight, skew angle and color.

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/DisplayInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/DisplayInspector.cs
@@ -31,7 +31,6 @@ namespace VisualPinball.Unity.Editor
 		[NonSerialized] private DisplayAuthoring _mb;
 		[NonSerialized] private DisplayAuthoring[] _mbs;
 
-
 		protected void OnEnable()
 		{
 			_mb = target as DisplayAuthoring;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/DisplayInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/DisplayInspector.cs
@@ -17,6 +17,8 @@
 using System;
 using System.Linq;
 using UnityEditor;
+using UnityEngine;
+using Object = System.Object;
 
 namespace VisualPinball.Unity.Editor
 {
@@ -40,6 +42,7 @@ namespace VisualPinball.Unity.Editor
 		{
 			var color = EditorGUILayout.ColorField("Lit Color", _mb.LitColor);
 			if (color != _mb.LitColor) {
+				RecordUndo("Change Segment Lit Color", this);
 				foreach (var mb in _mbs) {
 					mb.UpdateColor(color);
 				}
@@ -47,10 +50,20 @@ namespace VisualPinball.Unity.Editor
 
 			color = EditorGUILayout.ColorField("Unlit Color", _mb.UnlitColor);
 			if (color != _mb.UnlitColor) {
+				RecordUndo("Change Segment Unlit Color", this);
 				foreach (var mb in _mbs) {
 					mb.UnlitColor = color;
 				}
 			}
+		}
+
+		protected void RecordUndo(string description, DisplayInspector inspector)
+		{
+			var objs = _mbs
+				.Select(mb => mb.GetComponent<MeshRenderer>().sharedMaterial as UnityEngine.Object)
+				.Concat(_mbs.Select(mb => mb as UnityEngine.Object))
+				.Concat(new UnityEngine.Object[] {inspector});
+			Undo.RecordObjects(objs.ToArray(), description);
 		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/DotMatrixDisplayInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/DotMatrixDisplayInspector.cs
@@ -53,19 +53,19 @@ namespace VisualPinball.Unity.Editor
 				_mb.Height = height;
 			}
 
-			var dotSize = EditorGUILayout.Slider("Dot Size", _mb.DotSize, 0.05f, 1.0f);
-			if (dotSize != _mb.DotSize) {
-				RecordUndo("Change DMD Dot Size", this);
+			var padding = EditorGUILayout.Slider("Padding", _mb.Padding, 0.0f, 0.8f);
+			if (padding != _mb.Padding) {
+				RecordUndo("Change DMD Padding", this);
 				foreach (var mb in _mbs) {
-					mb.DotSize = dotSize;
+					mb.Padding = padding;
 				}
 			}
 
-			var sharpness = EditorGUILayout.Slider("Dot Sharpness", _mb.Sharpness, 0.0f, 0.5f);
-			if (sharpness != _mb.Sharpness) {
-				RecordUndo("Change DMD Dot Sharpness", this);
+			var roundness = EditorGUILayout.Slider("Dot Roundness", _mb.Roundness, 0.0f, 0.5f);
+			if (roundness != _mb.Roundness) {
+				RecordUndo("Change DMD Dot Roundness", this);
 				foreach (var mb in _mbs) {
-					mb.Sharpness = sharpness;
+					mb.Roundness = roundness;
 				}
 			}
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/DotMatrixDisplayInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/DotMatrixDisplayInspector.cs
@@ -18,15 +18,17 @@
 // ReSharper disable CompareOfFloatsByEqualityOperator
 
 using System;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
 namespace VisualPinball.Unity.Editor
 {
 	[CustomEditor(typeof(DotMatrixDisplayAuthoring)), CanEditMultipleObjects]
-	public class DmdInspector : DisplayInspector
+	public class DotMatrixDisplayInspector : DisplayInspector
 	{
 		[NonSerialized] private DotMatrixDisplayAuthoring _mb;
+		[NonSerialized] private DotMatrixDisplayAuthoring[] _mbs;
 
 		private void OnEnable()
 		{
@@ -37,6 +39,7 @@ namespace VisualPinball.Unity.Editor
 		public override void OnInspectorGUI()
 		{
 			_mb.Id = EditorGUILayout.TextField("Id", _mb.Id);
+			_mbs = targets.Select(t => t as DotMatrixDisplayAuthoring).ToArray();
 
 			base.OnInspectorGUI();
 
@@ -50,9 +53,20 @@ namespace VisualPinball.Unity.Editor
 				_mb.Height = height;
 			}
 
-			var dotSize = EditorGUILayout.Slider("Dot Size", _mb.DotSize, 0.1f, 5.0f);
+			var dotSize = EditorGUILayout.Slider("Dot Size", _mb.DotSize, 0.05f, 1.0f);
 			if (dotSize != _mb.DotSize) {
-				_mb.DotSize = dotSize;
+				RecordUndo("Change DMD Dot Size", this);
+				foreach (var mb in _mbs) {
+					mb.DotSize = dotSize;
+				}
+			}
+
+			var sharpness = EditorGUILayout.Slider("Dot Sharpness", _mb.Sharpness, 0.0f, 0.5f);
+			if (sharpness != _mb.Sharpness) {
+				RecordUndo("Change DMD Dot Sharpness", this);
+				foreach (var mb in _mbs) {
+					mb.Sharpness = sharpness;
+				}
 			}
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/SegmentDisplayInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/SegmentDisplayInspector.cs
@@ -48,6 +48,7 @@ namespace VisualPinball.Unity.Editor
 		public override void OnInspectorGUI()
 		{
 			_mb.Id = EditorGUILayout.TextField("Id", _mb.Id);
+			EditorGUILayout.LabelField("Segment Type", _mb.SegmentTypeName);
 
 			base.OnInspectorGUI();
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/SegmentDisplayInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/SegmentDisplayInspector.cs
@@ -34,6 +34,7 @@ namespace VisualPinball.Unity.Editor
 			(7, "Seven-segment"),
 			(9, "Nine-segment"),
 			(14, "Fourteen-segment"),
+			(16, "Sixteen-segment"),
 		};
 
 		private static readonly (int, string)[] SeparatorTypes = {

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/SegmentDisplayInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/SegmentDisplayInspector.cs
@@ -56,7 +56,6 @@ namespace VisualPinball.Unity.Editor
 			_mb = target as SegmentDisplayAuthoring;
 			_mbs = targets.Select(t => t as SegmentDisplayAuthoring).ToArray();
 			_skewAngleDeg = math.degrees(_mb.SkewAngle);
-			Debug.Log("Finding seg " + _mb.NumSegments);
 			_numSegmentsIndex = NumSegmentsTypes
 				.Select((tuple, index) => new {tuple, index})
 				.First(pair => pair.tuple.Item1 == _mb.NumSegments).index;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/SegmentDisplayInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/SegmentDisplayInspector.cs
@@ -27,7 +27,7 @@ namespace VisualPinball.Unity.Editor
 {
 	[CanEditMultipleObjects]
 	[CustomEditor(typeof(SegmentDisplayAuthoring))]
-	public class SegDispInspector : DisplayInspector
+	public class SegmentDisplayInspector : DisplayInspector
 	{
 		[NonSerialized] private SegmentDisplayAuthoring _mb;
 		[NonSerialized] private SegmentDisplayAuthoring[] _mbs;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/SegmentDisplayInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/SegmentDisplayInspector.cs
@@ -78,6 +78,7 @@ namespace VisualPinball.Unity.Editor
 				RecordUndo("Change Number of Segments", this);
 				foreach (var mb in _mbs) {
 					mb.NumSegments = NumSegmentsTypes[typeIndex].Item1;
+					mb.HorizontalMiddle = 0f;
 				}
 			}
 
@@ -115,13 +116,24 @@ namespace VisualPinball.Unity.Editor
 					foreach (var mb in _mbs) {
 						mb.SkewAngle = math.radians(skewAngleDeg);
 					}
+					_skewAngleDeg = skewAngleDeg;
 				}
 
-				var segWidth = EditorGUILayout.Slider("Weight", _mb.SegmentWeight, 0.005f, 0.11f);
-				if (segWidth != _mb.SegmentWeight) {
+				var segWeight = EditorGUILayout.Slider("Weight", _mb.SegmentWeight, 0.005f, 0.11f);
+				if (segWeight != _mb.SegmentWeight) {
 					RecordUndo("Change Segment Weight", this);
 					foreach (var mb in _mbs) {
-						mb.SegmentWeight = segWidth;
+						mb.SegmentWeight = segWeight;
+					}
+				}
+
+				if (_mb.NumSegments == 9) {
+					var hPos = EditorGUILayout.Slider("Middle Shift", _mb.HorizontalMiddle, -0.5f, 0.5f);
+					if (hPos != _mb.HorizontalMiddle) {
+						RecordUndo("Change Segment Middle", this);
+						foreach (var mb in _mbs) {
+							mb.HorizontalMiddle = hPos;
+						}
 					}
 				}
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Switch/SwitchListViewItemRenderer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Switch/SwitchListViewItemRenderer.cs
@@ -178,6 +178,7 @@ namespace VisualPinball.Unity.Editor
 			}
 
 			// otherwise, let the user toggle
+			EditorGUI.BeginChangeCheck();
 			var value = EditorGUI.Toggle(cellRect, switchListData.NormallyClosed);
 			if (EditorGUI.EndChangeCheck()) {
 				switchListData.NormallyClosed = value;

--- a/VisualPinball.Unity/VisualPinball.Unity.Test/Physics/DOTS/DynamicStructTests.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Test/Physics/DOTS/DynamicStructTests.cs
@@ -25,22 +25,22 @@ namespace VisualPinball.Unity.Test
 	[TestFixture]
 	public class DynamicStructTests
 	{
-		[Test]
-		public unsafe void ShouldSerializeBlobAssetReference()
-		{
-			var quadTreeBlobAssetRef = QuadTree.CreateBlobAssetReference();
-
-			ref var collider1 = ref quadTreeBlobAssetRef.Value.Colliders[0].Value;
-			ref var collider2 = ref quadTreeBlobAssetRef.Value.Colliders[1].Value;
-
-			Assert.AreEqual(ColliderType.Line, collider1.Type);
-			//Assert.AreEqual(new Aabb(1f, 3f, 20f, 4f, 5f, 6f), collider1.Aabb);
-			fixed (Collider* collider = &collider1) {
-				Assert.AreEqual(new float2(1f, 20f), ((LineCollider*)collider)->V1);
-				Assert.AreEqual(new float2(1f, 20f), ((LineCollider*)collider)->GetV1());
-			}
-			Assert.AreEqual(ColliderType.Point, collider2.Type);
-		}
+		// [Test]
+		// public unsafe void ShouldSerializeBlobAssetReference()
+		// {
+		// 	var quadTreeBlobAssetRef = QuadTree.CreateBlobAssetReference();
+		//
+		// 	ref var collider1 = ref quadTreeBlobAssetRef.Value.Colliders[0].Value;
+		// 	ref var collider2 = ref quadTreeBlobAssetRef.Value.Colliders[1].Value;
+		//
+		// 	Assert.AreEqual(ColliderType.Line, collider1.Type);
+		// 	//Assert.AreEqual(new Aabb(1f, 3f, 20f, 4f, 5f, 6f), collider1.Aabb);
+		// 	fixed (Collider* collider = &collider1) {
+		// 		Assert.AreEqual(new float2(1f, 20f), ((LineCollider*)collider)->V1);
+		// 		Assert.AreEqual(new float2(1f, 20f), ((LineCollider*)collider)->GetV1());
+		// 	}
+		// 	Assert.AreEqual(ColliderType.Point, collider2.Type);
+		// }
 
 		[Test]
 		public unsafe void ShouldSerializeStruc()

--- a/VisualPinball.Unity/VisualPinball.Unity/Common/Logging.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Common/Logging.cs
@@ -26,7 +26,7 @@ namespace VisualPinball.Unity
 		{
 			var config = new NLog.Config.LoggingConfiguration();
 			var logConsole = new UnityTarget();
-			config.AddRule(LogLevel.Trace, LogLevel.Fatal, logConsole);
+			config.AddRule(LogLevel.Info, LogLevel.Fatal, logConsole);
 			LogManager.Configuration = config;
 		}
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DisplayAuthoring.cs
@@ -29,6 +29,8 @@ namespace VisualPinball.Unity
 		public abstract Color LitColor { get; set; }
 		public abstract Color UnlitColor { get; set; }
 
+		private static readonly int DataProp = Shader.PropertyToID("__Data");
+
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
 		protected Texture2D _texture;
@@ -56,6 +58,8 @@ namespace VisualPinball.Unity
 				mr.sharedMaterial = CreateMaterial();
 			}
 			mr.sharedMaterial.mainTexture = _texture;
+			mr.sharedMaterial.SetTexture(DataProp, _texture);
+
 
 			var mf = gameObject.GetComponent<MeshFilter>();
 			if (mf == null) {

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DisplayAuthoring.cs
@@ -54,7 +54,7 @@ namespace VisualPinball.Unity
 			if (mr == null) {
 				mr = gameObject.AddComponent<MeshRenderer>();
 			}
-			mr.material = CreateMaterial();
+			mr.sharedMaterial = CreateMaterial();
 
 			var mf = gameObject.GetComponent<MeshFilter>();
 			if (mf == null) {

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DisplayAuthoring.cs
@@ -36,8 +36,8 @@ namespace VisualPinball.Unity
 		protected Texture2D _texture;
 
 		public abstract void UpdateFrame(DisplayFrameFormat format, byte[] data);
-
 		public abstract void UpdateDimensions(int width, int height, bool flipX = false);
+		public abstract void Clear();
 
 		public virtual void UpdateColor(Color color)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DisplayAuthoring.cs
@@ -55,6 +55,7 @@ namespace VisualPinball.Unity
 				mr = gameObject.AddComponent<MeshRenderer>();
 				mr.sharedMaterial = CreateMaterial();
 			}
+			mr.sharedMaterial.mainTexture = _texture;
 
 			var mf = gameObject.GetComponent<MeshFilter>();
 			if (mf == null) {

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DisplayAuthoring.cs
@@ -53,8 +53,8 @@ namespace VisualPinball.Unity
 			var mr = gameObject.GetComponent<MeshRenderer>();
 			if (mr == null) {
 				mr = gameObject.AddComponent<MeshRenderer>();
+				mr.sharedMaterial = CreateMaterial();
 			}
-			mr.sharedMaterial = CreateMaterial();
 
 			var mf = gameObject.GetComponent<MeshFilter>();
 			if (mf == null) {

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayAuthoring.cs
@@ -86,7 +86,7 @@ namespace VisualPinball.Unity
 				_unlitColor = value;
 				var mr = gameObject.GetComponent<MeshRenderer>();
 				if (mr != null) {
-					mr.material = CreateMaterial();
+					mr.sharedMaterial.SetColor(UnlitColorProp, value);
 				}
 			}
 		}
@@ -98,7 +98,7 @@ namespace VisualPinball.Unity
 				_dotSize = value;
 				var mr = gameObject.GetComponent<MeshRenderer>();
 				if (mr != null) {
-					mr.material = CreateMaterial();
+					mr.sharedMaterial.SetFloat(DotSizeProp, value);
 				}
 			}
 		}
@@ -123,7 +123,7 @@ namespace VisualPinball.Unity
 
 		protected override Material CreateMaterial()
 		{
-			var material = RenderPipeline.Current.MaterialConverter.DotMatrixDisplay;
+			var material = Instantiate(RenderPipeline.Current.MaterialConverter.DotMatrixDisplay);
 			material.mainTexture = _texture;
 			material.SetTexture(DataProp, _texture);
 			material.SetVector(DimensionsProp, new Vector4(_width, _height));

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayAuthoring.cs
@@ -55,7 +55,6 @@ namespace VisualPinball.Unity
 
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 		private static readonly int UnlitColorProp = Shader.PropertyToID("__UnlitColor");
-		private static readonly int DataProp = Shader.PropertyToID("__Data");
 		private static readonly int DimensionsProp = Shader.PropertyToID("__Dimensions");
 		private static readonly int PaddingProp = Shader.PropertyToID("__Padding");
 		private static readonly int RoundnessProp = Shader.PropertyToID("__Roundness");
@@ -131,7 +130,6 @@ namespace VisualPinball.Unity
 
 			var mr = gameObject.GetComponent<MeshRenderer>();
 			mr.sharedMaterial.SetVector(DimensionsProp, new Vector4(_width, _height));
-			mr.sharedMaterial.SetTexture(DataProp, _texture);
 		}
 
 		public override void UpdateColor(Color color)
@@ -144,7 +142,6 @@ namespace VisualPinball.Unity
 		{
 			var material = Instantiate(RenderPipeline.Current.MaterialConverter.DotMatrixDisplay);
 			material.mainTexture = _texture;
-			material.SetTexture(DataProp, _texture);
 			material.SetVector(DimensionsProp, new Vector4(_width, _height));
 			material.SetColor(UnlitColorProp, _unlitColor);
 			material.SetFloat(PaddingProp, _padding);

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayAuthoring.cs
@@ -138,6 +138,11 @@ namespace VisualPinball.Unity
 			_map.Clear();
 		}
 
+		public override void Clear()
+		{
+			UpdateFrame(DisplayFrameFormat.Dmd2, new byte[_width * _height]);
+		}
+
 		protected override Material CreateMaterial()
 		{
 			var material = Instantiate(RenderPipeline.Current.MaterialConverter.DotMatrixDisplay);

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayAuthoring.cs
@@ -130,9 +130,8 @@ namespace VisualPinball.Unity
 			RegenerateMesh(flipX);
 
 			var mr = gameObject.GetComponent<MeshRenderer>();
-			mr.sharedMaterial.mainTexture = _texture;
 			mr.sharedMaterial.SetVector(DimensionsProp, new Vector4(_width, _height));
-
+			mr.sharedMaterial.SetTexture(DataProp, _texture);
 		}
 
 		public override void UpdateColor(Color color)

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayAuthoring.cs
@@ -45,8 +45,8 @@ namespace VisualPinball.Unity
 		[SerializeField] private Color _unlitColor = new Color(0.2f, 0.2f, 0.2f);
 		[SerializeField] private int _width = 128;
 		[SerializeField] private int _height = 32;
-		[SerializeField] private float _dotSize = 0.7f;
-		[SerializeField] private float _sharpness = 0.3f;
+		[SerializeField] private float _padding = 0.2f;
+		[SerializeField] private float _roundness = 0.35f;
 
 		[NonSerialized] private DisplayFrameFormat _frameFormat = DisplayFrameFormat.Dmd4;
 		[NonSerialized] private Color32[] _colorBuffer;
@@ -57,8 +57,8 @@ namespace VisualPinball.Unity
 		private static readonly int UnlitColorProp = Shader.PropertyToID("__UnlitColor");
 		private static readonly int DataProp = Shader.PropertyToID("__Data");
 		private static readonly int DimensionsProp = Shader.PropertyToID("__Dimensions");
-		private static readonly int DotSizeProp = Shader.PropertyToID("__DotSize");
-		private static readonly int SharpnessProp = Shader.PropertyToID("__Sharpness");
+		private static readonly int PaddingProp = Shader.PropertyToID("__Padding");
+		private static readonly int RoundnessProp = Shader.PropertyToID("__Roundness");
 
 		public int Width
 		{
@@ -93,26 +93,26 @@ namespace VisualPinball.Unity
 			}
 		}
 
-		public float DotSize
+		public float Padding
 		{
-			get => _dotSize;
+			get => _padding;
 			set {
-				_dotSize = value;
+				_padding = value;
 				var mr = gameObject.GetComponent<MeshRenderer>();
 				if (mr != null) {
-					mr.sharedMaterial.SetFloat(DotSizeProp, value);
+					mr.sharedMaterial.SetFloat(PaddingProp, value);
 				}
 			}
 		}
 
-		public float Sharpness
+		public float Roundness
 		{
-			get => _sharpness;
+			get => _roundness;
 			set {
-				_sharpness = value;
+				_roundness = value;
 				var mr = gameObject.GetComponent<MeshRenderer>();
 				if (mr != null) {
-					mr.sharedMaterial.SetFloat(SharpnessProp, value);
+					mr.sharedMaterial.SetFloat(RoundnessProp, value);
 				}
 			}
 		}
@@ -147,7 +147,7 @@ namespace VisualPinball.Unity
 			material.SetTexture(DataProp, _texture);
 			material.SetVector(DimensionsProp, new Vector4(_width, _height));
 			material.SetColor(UnlitColorProp, _unlitColor);
-			material.SetFloat(DotSizeProp, _dotSize);
+			material.SetFloat(PaddingProp, _padding);
 			return material;
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayAuthoring.cs
@@ -45,7 +45,8 @@ namespace VisualPinball.Unity
 		[SerializeField] private Color _unlitColor = new Color(0.2f, 0.2f, 0.2f);
 		[SerializeField] private int _width = 128;
 		[SerializeField] private int _height = 32;
-		[SerializeField] private float _dotSize = 1.7f;
+		[SerializeField] private float _dotSize = 0.7f;
+		[SerializeField] private float _sharpness = 0.3f;
 
 		[NonSerialized] private DisplayFrameFormat _frameFormat = DisplayFrameFormat.Dmd4;
 		[NonSerialized] private Color32[] _colorBuffer;
@@ -56,7 +57,8 @@ namespace VisualPinball.Unity
 		private static readonly int UnlitColorProp = Shader.PropertyToID("__UnlitColor");
 		private static readonly int DataProp = Shader.PropertyToID("__Data");
 		private static readonly int DimensionsProp = Shader.PropertyToID("__Dimensions");
-		private static readonly int DotSizeProp = Shader.PropertyToID("__DotSize2");
+		private static readonly int DotSizeProp = Shader.PropertyToID("__DotSize");
+		private static readonly int SharpnessProp = Shader.PropertyToID("__Sharpness");
 
 		public int Width
 		{
@@ -103,6 +105,18 @@ namespace VisualPinball.Unity
 			}
 		}
 
+		public float Sharpness
+		{
+			get => _sharpness;
+			set {
+				_sharpness = value;
+				var mr = gameObject.GetComponent<MeshRenderer>();
+				if (mr != null) {
+					mr.sharedMaterial.SetFloat(SharpnessProp, value);
+				}
+			}
+		}
+
 		public override void UpdateDimensions(int width, int height, bool flipX = false)
 		{
 			Logger.Info($"Updating dimensions for DMD \"{_id}\" to {width}x{height}.");
@@ -112,7 +126,13 @@ namespace VisualPinball.Unity
 			_texture = new Texture2D(width, height, TextureFormat.RGB24, false);
 			_texture.SetPixels32(_colorBuffer);
 			_texture.Apply();
+
 			RegenerateMesh(flipX);
+
+			var mr = gameObject.GetComponent<MeshRenderer>();
+			mr.sharedMaterial.mainTexture = _texture;
+			mr.sharedMaterial.SetVector(DimensionsProp, new Vector4(_width, _height));
+
 		}
 
 		public override void UpdateColor(Color color)

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayAuthoring.cs
@@ -105,7 +105,7 @@ namespace VisualPinball.Unity
 
 		public override void UpdateDimensions(int width, int height, bool flipX = false)
 		{
-			Logger.Info($"Updating dimensions for display \"{_id}\" to {width}x{height}.");
+			Logger.Info($"Updating dimensions for DMD \"{_id}\" to {width}x{height}.");
 			_width = width;
 			_height = height;
 			_colorBuffer = new Color32[width * height];
@@ -177,7 +177,7 @@ namespace VisualPinball.Unity
 					}
 					break;
 
-				case DisplayFrameFormat.Segment16:
+				case DisplayFrameFormat.Segment:
 					Logger.Error("This is a DMD component that cannot render segment data. Use a segment component!");
 					break;
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
@@ -31,7 +31,7 @@ namespace VisualPinball.Unity
 	{
 		public override string Id { get => _id; set => _id = value;}
 
-		public override float AspectRatio { get; set; } = 0.7f;
+		public override float AspectRatio { get; set; } = 0.6f;
 
 		private const int NumSegments = 15;
 
@@ -45,7 +45,7 @@ namespace VisualPinball.Unity
 		[SerializeField] private Color _unlitColor = new Color(0.25f, 0.25f, 0.25f);
 		[SerializeField] private float _skewAngle = math.radians(7);
 		[SerializeField] private float _segmentWidth = 0.05f;
-		[SerializeField] private float2 _innerPadding = new float2(0.4f, 0.15f);
+		[SerializeField] private float2 _innerPadding = new float2(0.5f, 0.4f);
 		[SerializeField] private int _segmentType;
 
 		[NonSerialized] private Color32[] _colorBuffer;

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
@@ -201,6 +201,9 @@ namespace VisualPinball.Unity
 			material.SetFloat(SkewAngleProp, _skewAngle);
 			material.SetFloat(SegmentWeightProp, segmentWeight);
 			material.SetVector(PaddingProp, new Vector4(_padding.x, _padding.y));
+			material.SetVector(PaddingProp, new Vector4(_padding.x, _padding.y));
+			material.SetInt(SeparatorTypeProp, _separatorType);
+			material.SetInt(SeparatorEveryThreeOnlyProp, _separatorEveryThreeOnly ? 1 : 0);
 
 			Logger.Info("Recreating segment display material!");
 
@@ -209,39 +212,9 @@ namespace VisualPinball.Unity
 
 		public override void UpdateFrame(DisplayFrameFormat format, byte[] source)
 		{
-			var numSegments = ConvertNumSegments(format);
-			if (numSegments != _numSegments) {
-				NumSegments = numSegments;
-			}
-
-			var target = new ushort[source.Length / 2];
+			var target = new ushort[source.Length / sizeof(short)];
 			Buffer.BlockCopy(source, 0, target, 0, source.Length);
 			UpdateFrame(target);
-		}
-
-		public int ConvertNumSegments(DisplayFrameFormat format)
-		{
-			switch (format) {
-				case DisplayFrameFormat.Segment7:
-				case DisplayFrameFormat.Segment7Dot:
-				case DisplayFrameFormat.Segment7Comma:
-				case DisplayFrameFormat.Segment7CommaEvery3:
-				case DisplayFrameFormat.Segment7CommaEvery3Forced:
-					return 7;
-
-				case DisplayFrameFormat.Segment9:
-				case DisplayFrameFormat.Segment9Comma:
-				case DisplayFrameFormat.Segment9CommaEvery3:
-				case DisplayFrameFormat.Segment9CommaEvery3Forced:
-					return 9;
-
-				case DisplayFrameFormat.Segment16:
-					return 14;
-				default:
-					Logger.Error($"Invalid data format, must be segment data, got {format}.");
-					break;
-			}
-			return 0;
 		}
 
 		public override void UpdateDimensions(int width, int height, bool _ = false)
@@ -261,7 +234,7 @@ namespace VisualPinball.Unity
 			if (_colorBuffer == null) {
 				UpdateDimensions(_numChars, 1);
 			}
-			UpdateFrame(DisplayFrameFormat.Segment16, target);
+			UpdateFrame(DisplayFrameFormat.Segment, target);
 		}
 
 		public void SetTestData()

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
@@ -40,7 +40,7 @@ namespace VisualPinball.Unity
 		[SerializeField] private string _id = "display0";
 		[SerializeField] private int _numChars = 7;
 		[SerializeField] private int _numSegments = 14;
-		[SerializeField] private Color _litColor = new Color(1, 0.4f, 0);
+		[SerializeField] private Color _litColor = new Color(1, 0.18f, 0);
 		[SerializeField] private Color _unlitColor = new Color(0.25f, 0.25f, 0.25f);
 		[SerializeField] private float _skewAngle = math.radians(7);
 		[SerializeField] private float segmentWeight = 0.05f;

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
@@ -124,6 +124,17 @@ namespace VisualPinball.Unity
 			}
 		}
 
+		public int SegmentType {
+			get => _segmentType;
+			set {
+				_segmentType = value;
+				var mr = gameObject.GetComponent<MeshRenderer>();
+				if (mr != null) {
+					mr.material = CreateMaterial();
+				}
+			}
+		}
+
 		public float2 InnerPadding {
 			get => _innerPadding;
 			set {
@@ -134,6 +145,8 @@ namespace VisualPinball.Unity
 				}
 			}
 		}
+
+		public string SegmentTypeName;
 
 		#endregion
 
@@ -171,13 +184,22 @@ namespace VisualPinball.Unity
 			UpdateFrame(target);
 		}
 
-		private int ConvertSegmentType(DisplayFrameFormat format)
+		public int ConvertSegmentType(DisplayFrameFormat format)
 		{
 			switch (format) {
-				case DisplayFrameFormat.Segment9:
-					return 2;
 				case DisplayFrameFormat.Segment7:
+				case DisplayFrameFormat.Segment7Dot:
+				case DisplayFrameFormat.Segment7Comma:
+				case DisplayFrameFormat.Segment7CommaEvery3:
+				case DisplayFrameFormat.Segment7CommaEvery3Forced:
 					return 4;
+
+				case DisplayFrameFormat.Segment9:
+				case DisplayFrameFormat.Segment9Comma:
+				case DisplayFrameFormat.Segment9CommaEvery3:
+				case DisplayFrameFormat.Segment9CommaEvery3Forced:
+					return 2;
+
 				case DisplayFrameFormat.Segment16:
 					return 0;
 				default:

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
@@ -44,8 +44,8 @@ namespace VisualPinball.Unity
 		[SerializeField] private Color _litColor = new Color(1, 0.4f, 0);
 		[SerializeField] private Color _unlitColor = new Color(0.25f, 0.25f, 0.25f);
 		[SerializeField] private float _skewAngle = math.radians(7);
-		[SerializeField] private float _segmentWidth = 0.05f;
-		[SerializeField] private float2 _innerPadding = new float2(0.5f, 0.4f);
+		[SerializeField] private float segmentWeight = 0.05f;
+		[SerializeField] private float2 _padding = new float2(0.5f, 0.4f);
 		[SerializeField] private int _segmentType;
 
 		[NonSerialized] private Color32[] _colorBuffer;
@@ -71,11 +71,11 @@ namespace VisualPinball.Unity
 		public int NumChars {
 			get => _numChars;
 			set {
+				_numChars = value;
 				var mr = gameObject.GetComponent<MeshRenderer>();
 				if (mr) {
-					mr.material = CreateMaterial();
+					mr.sharedMaterial.SetFloat(NumCharsProp, value);
 				}
-				_numChars = value;
 				RegenerateMesh();
 			}
 		}
@@ -86,7 +86,7 @@ namespace VisualPinball.Unity
 				_litColor = value;
 				var mr = gameObject.GetComponent<MeshRenderer>();
 				if (mr) {
-					mr.material = CreateMaterial();
+					mr.sharedMaterial.SetColor(LitColorProp, value);
 				}
 			}
 		}
@@ -97,7 +97,7 @@ namespace VisualPinball.Unity
 				_unlitColor = value;
 				var mr = gameObject.GetComponent<MeshRenderer>();
 				if (mr) {
-					mr.material = CreateMaterial();
+					mr.sharedMaterial.SetColor(UnlitColorProp, value);
 				}
 			}
 		}
@@ -107,19 +107,19 @@ namespace VisualPinball.Unity
 			set {
 				_skewAngle = value;
 				var mr = gameObject.GetComponent<MeshRenderer>();
-				if (mr != null) {
-					mr.material = CreateMaterial();
+				if (mr) {
+					mr.sharedMaterial.SetFloat(SkewAngleProp, value);
 				}
 			}
 		}
 
-		public float SegmentWidth {
-			get => _segmentWidth;
+		public float SegmentWeight {
+			get => segmentWeight;
 			set {
-				_segmentWidth = value;
+				segmentWeight = value;
 				var mr = gameObject.GetComponent<MeshRenderer>();
 				if (mr != null) {
-					mr.material = CreateMaterial();
+					mr.sharedMaterial.SetFloat(SegmentWeightProp, value);
 				}
 			}
 		}
@@ -130,18 +130,18 @@ namespace VisualPinball.Unity
 				_segmentType = value;
 				var mr = gameObject.GetComponent<MeshRenderer>();
 				if (mr != null) {
-					mr.material = CreateMaterial();
+					mr.sharedMaterial.SetFloat(SegmentTypeProp, value);
 				}
 			}
 		}
 
-		public float2 InnerPadding {
-			get => _innerPadding;
+		public float2 Padding {
+			get => _padding;
 			set {
-				_innerPadding = value;
+				_padding = value;
 				var mr = gameObject.GetComponent<MeshRenderer>();
 				if (mr != null) {
-					mr.material = CreateMaterial();
+					mr.sharedMaterial.SetVector(PaddingProp, new Vector4(value.x, value.y));
 				}
 			}
 		}
@@ -160,8 +160,8 @@ namespace VisualPinball.Unity
 			material.SetColor(LitColorProp, _litColor);
 			material.SetColor(UnlitColorProp, _unlitColor);
 			material.SetFloat(SkewAngleProp, _skewAngle);
-			material.SetFloat(SegmentWeightProp, _segmentWidth);
-			material.SetVector(PaddingProp, new Vector4(_innerPadding.x, _innerPadding.y));
+			material.SetFloat(SegmentWeightProp, segmentWeight);
+			material.SetVector(PaddingProp, new Vector4(_padding.x, _padding.y));
 
 			material.SetFloat(NumSegmentsProp, NumSegments);
 			material.SetFloat(SegmentTypeProp, _segmentType);
@@ -176,7 +176,7 @@ namespace VisualPinball.Unity
 			var shaderSegmentType = ConvertSegmentType(format);
 			if (shaderSegmentType != _segmentType) {
 				_segmentType = shaderSegmentType;
-				gameObject.GetComponent<MeshRenderer>().material = CreateMaterial();
+				gameObject.GetComponent<MeshRenderer>().sharedMaterial = CreateMaterial();
 			}
 
 			var target = new ushort[source.Length / 2];

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
@@ -209,7 +209,7 @@ namespace VisualPinball.Unity
 
 		public override void UpdateFrame(DisplayFrameFormat format, byte[] source)
 		{
-			var numSegments = ConvertSegmentType(format);
+			var numSegments = ConvertNumSegments(format);
 			if (numSegments != _numSegments) {
 				NumSegments = numSegments;
 			}
@@ -219,7 +219,7 @@ namespace VisualPinball.Unity
 			UpdateFrame(target);
 		}
 
-		public int ConvertSegmentType(DisplayFrameFormat format)
+		public int ConvertNumSegments(DisplayFrameFormat format)
 		{
 			switch (format) {
 				case DisplayFrameFormat.Segment7:

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
@@ -58,7 +58,6 @@ namespace VisualPinball.Unity
 
 		private static readonly int LitColorProp = Shader.PropertyToID("__LitColor");
 		private static readonly int UnlitColorProp = Shader.PropertyToID("__UnlitColor");
-		private static readonly int DataProp = Shader.PropertyToID("__SegmentData");
 		private static readonly int NumCharsProp = Shader.PropertyToID("__NumChars");
 		private static readonly int NumSegmentsProp = Shader.PropertyToID("__NumSegments");
 		private static readonly int SegmentWeightProp = Shader.PropertyToID("__SegmentWeight");
@@ -193,7 +192,6 @@ namespace VisualPinball.Unity
 			var material = Instantiate(RenderPipeline.Current.MaterialConverter.SegmentDisplay);
 
 			material.mainTexture = _texture;
-			material.SetTexture(DataProp, _texture);
 			material.SetFloat(NumCharsProp, _numChars);
 			material.SetFloat(NumSegmentsProp, _numSegments);
 			material.SetColor(LitColorProp, _litColor);

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
@@ -43,7 +43,8 @@ namespace VisualPinball.Unity
 		[SerializeField] private Color _litColor = new Color(1, 0.18f, 0);
 		[SerializeField] private Color _unlitColor = new Color(0.25f, 0.25f, 0.25f);
 		[SerializeField] private float _skewAngle = math.radians(7);
-		[SerializeField] private float segmentWeight = 0.05f;
+		[SerializeField] private float _segmentWeight = 0.05f;
+		[SerializeField] private float _horizontalMiddle;
 		[SerializeField] private float2 _padding = new float2(0.5f, 0.4f);
 		[SerializeField] private float2 _separatorPos = new float2(1.5f, 0.0f);
 		[SerializeField] private int _separatorType = 1;
@@ -61,6 +62,7 @@ namespace VisualPinball.Unity
 		private static readonly int NumCharsProp = Shader.PropertyToID("__NumChars");
 		private static readonly int NumSegmentsProp = Shader.PropertyToID("__NumSegments");
 		private static readonly int SegmentWeightProp = Shader.PropertyToID("__SegmentWeight");
+		private static readonly int HorizontalMiddleProp = Shader.PropertyToID("__HorizontalMiddle");
 		private static readonly int SkewAngleProp = Shader.PropertyToID("__SkewAngle");
 		private static readonly int PaddingProp = Shader.PropertyToID("__Padding");
 		private static readonly int SeparatorPosProp = Shader.PropertyToID("__SeparatorPos");
@@ -127,10 +129,21 @@ namespace VisualPinball.Unity
 			}
 		}
 
-		public float SegmentWeight {
-			get => segmentWeight;
+		public float HorizontalMiddle {
+			get => _horizontalMiddle;
 			set {
-				segmentWeight = value;
+				_horizontalMiddle = value;
+				var mr = gameObject.GetComponent<MeshRenderer>();
+				if (mr != null) {
+					mr.sharedMaterial.SetFloat(HorizontalMiddleProp, value);
+				}
+			}
+		}
+
+		public float SegmentWeight {
+			get => _segmentWeight;
+			set {
+				_segmentWeight = value;
 				var mr = gameObject.GetComponent<MeshRenderer>();
 				if (mr != null) {
 					mr.sharedMaterial.SetFloat(SegmentWeightProp, value);
@@ -197,7 +210,7 @@ namespace VisualPinball.Unity
 			material.SetColor(LitColorProp, _litColor);
 			material.SetColor(UnlitColorProp, _unlitColor);
 			material.SetFloat(SkewAngleProp, _skewAngle);
-			material.SetFloat(SegmentWeightProp, segmentWeight);
+			material.SetFloat(SegmentWeightProp, _segmentWeight);
 			material.SetVector(PaddingProp, new Vector4(_padding.x, _padding.y));
 			material.SetVector(PaddingProp, new Vector4(_padding.x, _padding.y));
 			material.SetInt(SeparatorTypeProp, _separatorType);

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayAuthoring.cs
@@ -222,6 +222,11 @@ namespace VisualPinball.Unity
 			RegenerateMesh();
 		}
 
+		public override void Clear()
+		{
+			UpdateFrame(DisplayFrameFormat.Segment, new byte[_colorBuffer.Length * sizeof(short)]);
+		}
+
 		public void SetText(string text)
 		{
 			var source = GenerateAlphaNumeric(text);

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/DisplayPlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/DisplayPlayer.cs
@@ -48,6 +48,7 @@ namespace VisualPinball.Unity
 				if (_displayGameObjects.ContainsKey(display.Id)) {
 					Logger.Info($"Updating display \"{display.Id}\" to {display.Width}x{display.Height}");
 					_displayGameObjects[display.Id].UpdateDimensions(display.Width, display.Height, display.FlipX);
+					_displayGameObjects[display.Id].Clear();
 
 				} else {
 					Logger.Error($"Cannot find DMD game object for display \"{display.Id}\"");

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/IGamelogicEngine.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/IGamelogicEngine.cs
@@ -150,9 +150,16 @@ namespace VisualPinball.Unity
 		Dmd4, // 4-bit (0-15)
 		Dmd8, // 8-bit (0-255)
 		Dmd24, // rgb (3x 0-255)
+		Segment16,
 		Segment7,
+		Segment7Comma,
+		Segment7Dot,
+		Segment7CommaEvery3,
+		Segment7CommaEvery3Forced,
 		Segment9,
-		Segment16
+		Segment9Comma,
+		Segment9CommaEvery3,
+		Segment9CommaEvery3Forced
 	}
 
 	public class DisplayFrameData

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/IGamelogicEngine.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/IGamelogicEngine.cs
@@ -150,16 +150,7 @@ namespace VisualPinball.Unity
 		Dmd4, // 4-bit (0-15)
 		Dmd8, // 8-bit (0-255)
 		Dmd24, // rgb (3x 0-255)
-		Segment16,
-		Segment7,
-		Segment7Comma,
-		Segment7Dot,
-		Segment7CommaEvery3,
-		Segment7CommaEvery3Forced,
-		Segment9,
-		Segment9Comma,
-		Segment9CommaEvery3,
-		Segment9CommaEvery3Forced
+		Segment,
 	}
 
 	public class DisplayFrameData


### PR DESCRIPTION
While there are only three segment display variants (7-, 9-, and 14-segments), there are quite a few combinations when it comes to whether and where there is a comma. Here just three examples:

![image](https://user-images.githubusercontent.com/70426/117725799-fa4e6180-b1e5-11eb-815c-28815d628f70.png)

So I've dumped a list of all displays:

<details><summary><b>Games by display type</b></summary>

```
Seg16:
     agsoccer(2) - A.G. Soccer-Ball (R18u, 2.1 Sound) (Alvin G 1993)
     usafootb(2) - U.S.A. Football (R06u) (Alvin G 1993)
     punchy(2) - Punchy The Clown (R02) (Alvin G 1993)
     dinoeggs(1) - Dinosaur Eggs (R02) (Alvin G 1993)
     usafootr(2) - U.S.A. Football (Redemption, P08) (Alvin G 1994)
     lwar_a83(2) - Laser War (8.3) (Data East 1987)
     ssvc_a26(2) - Secret Service (2.6) (Data East 1988)
     torp_e21(2) - Torpedo Alley (2.1 Europe) (Data East 1988)
     tmac_a24(2) - Time Machine (2.4) (Data East 1988)
     play_a24(2) - Playboy 35th Anniversary (2.4) (Data East 1989)
     mnfb_c29(2) - Monday Night Football (2.9, 50cts) (Data East 1989)
     robo_a34(2) - Robocop (3.4) (Data East 1989)
     poto_a32(2) - Phantom of the Opera, The (3.2) (Data East 1990)
     kiko_a10(2) - King Kong (1.0) (Data East 1990)
     bttf_a28(2) - Back to the Future (2.8) (Data East 1990)
     simp_a27(2) - Simpsons, The (2.7) (Data East 1990)
     triplay(2) - Chicago Cubs Triple Play (Gottlieb 1985)
     bountyh(2) - Bounty Hunter (Gottlieb 1985)
     tagteam(2) - Tag-Team Pinball (Gottlieb 1985)
     rock(2) - Rock (Gottlieb 1985)
     s80btest(2) - System 80B Test Fixture (Gottlieb 198?)
     raven(2) - Raven (Gottlieb 1986)
     hlywoodh(2) - Hollywood Heat (Gottlieb 1986)
     genesis(2) - Genesis (Gottlieb 1986)
     goldwing(2) - Gold Wings (Gottlieb 1986)
     mntecrlo(2) - Monte Carlo (Gottlieb 1987)
     sprbreak(2) - Spring Break (Gottlieb 1987)
     amazonh2(2) - Amazon Hunt II (French) (Gottlieb 1987)
     arena(2) - Arena (Gottlieb 1987)
     victory(2) - Victory (Gottlieb 1987)
     diamond(2) - Diamond Lady (Gottlieb 1988)
     txsector(2) - TX-Sector (Gottlieb 1988)
     robowars(2) - Robo-War (Gottlieb 1988)
     badgirls(2) - Bad Girls (Gottlieb 1988)
     excaliba(2) - Excalibur (Gottlieb 1988)
     bighouse(2) - Big House (Gottlieb 1989)
     hotshots(2) - Hot Shots (Gottlieb 1989)
     bonebstr(2) - Bone Busters Inc. (Gottlieb 1989)
     nmoves(2) - Night Moves (International Concepts 1989)
     amazonh3(2) - Amazon Hunt III (French) (Gottlieb 1991)
     ccruise(2) - Caribbean Cruise (International Concepts 1989)
     lca(2) - Lights, Camera, Action (Gottlieb 1989)
     silvslug(2) - Silver Slugger (Gottlieb 1990)
     vegas(5) - Vegas (Gottlieb 1990)
     deadweap(2) - Deadly Weapon (Gottlieb 1990)
     tfight(2) - Title Fight (Gottlieb 1990)
     bellring(2) - Bell Ringer (Gottlieb 1990)
     nudgeit(2) - Nudge It (Gottlieb 1990)
     carhop(2) - Car Hop (Gottlieb 1991)
     hoops(2) - Hoops (Gottlieb 1991)
     cactjack(2) - Cactus Jack's (Gottlieb 1991)
     clas1812(2) - Class of 1812 (Gottlieb 1991)
     surfnsaf(2) - Surf 'n Safari (Gottlieb 1991)
     opthund(2) - Operation Thunder (Gottlieb 1992)
     formula1(2) - Formula 1 (Jac Van Ham (Royal) 1988)
     topsound(2) - Top Sound (French) (ManilaMatic 1988)
     mmmaster(2) - Master (Italian) (ManilaMatic 1988)
     hypbl_l4(2) - HyperBall (L-4) (Williams 1981)
     splbn_l0(2) - Spellbinder (L-0 BETA) (Williams / Jess M. Askey 1982)
     hs_l4(2) - High Speed (L-4) (Williams 1986)
     grand_l4(2) - Grand Lizard (L-4) (Williams 1986)
     rdkng_l4(2) - Road Kings (L-4) (Williams 1986)
     pb_l5(2) - Pin-Bot (L-5) (Williams 1986)
     milln_l3(2) - Millionaire (L-3) (Williams 1987)
     f14_l1(2) - F-14 Tomcat (L-1) (Williams 1987)
     fire_l3(2) - Fire! (L-3) (Williams 1987)
     bguns_l8(2) - Big Guns (L-8) (Williams 1987)
     spstn_l5(2) - Space Station (L-5) (Williams 1988)
     cycln_l5(2) - Cyclone (L-5) (Williams 1988)
     bnzai_l3(2) - Banzai Run (L-3) (Williams 1988)
     swrds_l2(2) - Swords of Fury (L-2) (Williams 1988)
     taxi_l4(1) - Taxi (Lola) (L-4) (Williams 1988)
     esha_la3(2) - Earthshaker (LA-3) (Williams 1988)
     bk2k_l4(2) - Black Knight 2000 (L-4) (Williams 1989)
     tsptr_l3(2) - Transporter the Rescue (L-3) (Bally 1989)
     polic_l4(1) - Police Force (LA-4) (Williams 1989)
     eatpm_l4(2) - Elvira and the Party Monsters (LA-4) (Bally 1989)
     bcats_l5(2) - Bad Cats (L-5) (Williams 1989)
     rvrbt_l3(1) - Riverboat Gambler (L-3) (Williams 1990)
     mousn_l4(2) - Mousin' Around! (LA-4) (Bally 1989)
     whirl_l3(2) - Whirlwind (L-3) (Williams 1990)
     gs_lu4(2) - Game Show (LU-4 Europe) (Bally 1990)
     rollr_l2(2) - Rollergames (L-2) (Williams 1990)
     pool_l7(2) - Pool Sharks (LA-7) (Bally 1991)
     diner_l4(2) - Diner (LA-4) (Williams 1990)
     radcl_l1(2) - Radical! (L-1) (Bally 1990)
     strax_p7(2) - Star Trax (Domestic Prototype) (Williams 1990)
     dd_l2(2) - Dr. Dude (LA-2) (Bally 1990)
     bbnny_l2(2) - Bugs Bunny's Birthday Ball (L-2) (Bally 1990)

Dmd:
     wrldtour(1) - Al's Garage Band Goes On a World Tour (R01c) (Alvin G 1993)
     ghv101(1) - Goofy Hoops (Redemption) (Romstar 1994)
     pmv112(1) - Pinball Magic (1.0.12) (Capcom 1995)
     abv106(1) - Airborne (1.6) (Capcom 1996)
     bsv103(1) - Breakshot (1.3) (Capcom 1996)
     ffv104(1) - Flipper Football (1.04) (Capcom 1996)
     bbb109(1) - Big Bang Bar (Beta 1.9 US) (Capcom 1996)
     kpb105(1) - Kingpin (Beta 1.05) (Capcom 1996)
     ckpt_a17(1) - Checkpoint (1.7) (Data East 1991)
     tmnt_104(1) - Teenage Mutant Ninja Turtles (1.04) (Data East 1991)
     btmn_103(1) - Batman (1.03) (Data East 1991)
     trek_201(1) - Star Trek 25th Anniversary (2.01) (Data East 1992)
     hook_408(1) - Hook (4.08) (Data East 1992)
     lw3_208(1) - Lethal Weapon 3 (2.08) (Data East 1992)
     aar_101(1) - Aaron Spelling (1.01) (Data East 1992)
     mj_130(1) - Michael Jordan (1.30) (Data East 1992)
     stwr_104(1) - Star Wars (1.04 20th Anniversary) (Data East 2012)
     rab_320(1) - Adventures of Rocky and Bullwinkle and Friends, The (3.20) (Data East 1993)
     jupk_513(1) - Jurassic Park (5.13) (Data East 1993)
     lah_112(1) - Last Action Hero (1.12) (Data East 1993)
     tftc_303(1) - Tales from the Crypt (3.03) (Data East 1993)
     tomy_400(1) - Tommy (4.00) (Data East 1994)
     wwfr_106(1) - WWF Royal Rumble (1.06) (Data East 1994)
     gnr_300(1) - Guns N' Roses (3.00) (Data East 1994)
     mav_402(1) - Maverick (4.04, Display 4.02) (Sega 1994)
     frankst(1) - Frankenstein, Mary Shelley's (Sega 1994)
     baywatch(1) - Baywatch (4.00) (Sega 1995)
     batmanf(1) - Batman Forever (4.0) (Sega 1995)
     apollo13(1) - Apollo 13 (5.01, Display 5.00) (Sega 1995)
     gldneye(1) - Goldeneye (Sega 1996)
     twst_405(1) - Twister (4.05) (Sega 1996)
     id4(1) - ID4: Independence Day (2.02) (Sega 1996)
     spacejam(1) - Space Jam (3.00) (Sega 1997)
     swtril43(1) - Star Wars Trilogy Special Edition, The (4.03) (Sega 1997)
     jplstw22(1) - Lost World: Jurassic Park, The (2.02) (Sega 1997)
     xfiles(1) - X-Files, The (3.03) (Sega 1997)
     startrp(1) - Starship Troopers (2.01) (Sega 1997)
     wackadoo(1) - Wack-A-Doodle-Doo (Redemption) (Sega 1998)
     titanic(1) - Titanic (Coin Dropper) (Sega 1998)
     viprsega(1) - Viper Night Drivin' (2.01) (Sega 1998)
     lostspc(1) - Lost in Space (1.01, Display 1.02) (Sega 1998)
     goldcue(1) - Golden Cue (Sega 1998)
     godzilla(1) - Godzilla (2.05) (Sega 1998)
     sprk_103(1) - South Park (1.03) (Sega 1999)
     harl_a13(1) - Harley-Davidson (Sega, 1.03, Display 1.04) (Sega 1999)
     bushido(1) - Bushido (Inder/Spinball (Spain) 1993)
     mach2(1) - Mach 2 (Spinball (Spain) 1995)
     jolypark(1) - Jolly Park (Spinball (Spain) 1996)
     vrnwrld(1) - Verne's World (Spinball (Spain) 1996)
     strikext(1) - Striker Xtreme (1.02) (Stern 2000)
     shrkysht(1) - Sharkey's Shootout (2.11) (Stern 2000)
     hirolcas(1) - High Roller Casino (3.00) (Stern 2001)
     austin(1) - Austin Powers (3.02) (Stern 2001)
     monopoly(1) - Monopoly (3.20) (Stern 2001)
     nfl(1) - NFL (Stern 2001)
     monopred(1) - Monopoly (Coin Dropper) (Stern 2002)
     playboys(1) - Playboy (Stern, 5.00) (Stern 2002)
     rctycn(1) - RollerCoaster Tycoon (7.02) (Stern 2002)
     simpprty(1) - Simpsons Pinball Party, The (5.00) (Stern 2003)
     term3(1) - Terminator 3: Rise of the Machines (4.00) (Stern 2003)
     lotr(1) - Lord of the Rings, The (10.00) (Stern 2005)
     ripleys(1) - Ripley's Believe It or Not! (3.20) (Stern 2004)
     elvis(1) - Elvis (5.00) (Stern 2004)
     harl_a40(1) - Harley-Davidson (Stern, 4.00) (Stern 2004)
     sopranos(1) - Sopranos, The (5.00) (Stern 2005)
     nascar(1) - NASCAR (4.50) (Stern 2006)
     gprix(1) - Grand Prix (4.50) (Stern 2006)
     dalejr(1) - Dale Jr. (5.00) (Stern 2006)
     sf_l1(1) - Slugfest (L-1) (Williams 1991)
     hurr_l2(1) - Hurricane (L-2) (Williams 1991)
     t2_l8(1) - Terminator 2: Judgement Day (L-8) (Williams 1991)
     gi_l9(1) - Gilligan's Island (L-9) (Bally 1992)
     pz_f4(1) - Party Zone, The (F-4 Fliptronic) (Bally 1991)
     strik_l4(1) - Strike Master (L-4) (Williams 1992)
     taf_l5(1) - Addams Family, The (L-5) (Bally 1992)
     gw_l5(1) - Getaway: High Speed II, The (L-5) (Williams 1992)
     br_l4(1) - Black Rose (L-4) (Bally 1993)
     ft_l5(1) - Fish Tales (L-5) (Williams 1992)
     dw_l2(1) - Dr. Who (L-2) (Bally 1992)
     cftbl_l4(1) - Creature from the Black Lagoon (L-4) (Bally 1993)
     hshot_p8(1) - Hot Shot Basketball (P-8 Prototype) (Midway 1992)
     ww_l5(1) - White Water (L-5) (Williams 1993)
     drac_l1(1) - Bram Stoker's Dracula (L-1) (Williams 1993)
     tz_92(1) - Twilight Zone (9.2) (Bally 1995)
     ij_l7(1) - Indiana Jones: The Pinball Adventure (L-7) (Williams 1993)
     jd_l7(1) - Judge Dredd (L-7) (Bally 1993)
     afv_l4(1) - Addams Family Values (Coin Dropper) (L-4) (Williams 1993)
     sttng_l7(1) - Star Trek: The Next Generation (LX-7) (Williams 1994)
     pop_lx5(1) - Popeye Saves The Earth (LX-5) (Bally 1994)
     dm_lx4(1) - Demolition Man (LX-4) (Williams 1994)
     tafg_lx3(1) - Addams Family Special Collectors Edition Gold, The (LX-3) (Bally 1994)
     wcs_l2(1) - World Cup Soccer (LX-2) (Bally 1994)
     fs_lx5(1) - Flintstones, The (LX-5) (Williams 1994)
     corv_21(1) - Corvette (2.1) (Bally 1994)
     rs_l6(1) - Red and Ted's Road Show (L-6) (Williams 1994)
     ts_lx5(1) - Shadow, The (LX-5) (Bally 1995)
     dh_lx2(1) - Dirty Harry (LX-2) (Williams 1995)
     tom_13(1) - Theatre of Magic (1.3X) (Bally 1995)
     nf_23x(1) - No Fear: Dangerous Sports (2.3X) (Williams 1995)
     i500_11r(1) - Indianapolis 500 (1.1R) (Bally 1995)
     jb_10r(1) - Jack*Bot (1.0R) (Williams 1995)
     jm_12r(1) - Johnny Mnemonic (1.2R) (Williams 1995)
     wd_12(1) - WHO Dunnit (1.2) (Bally 1995)
     congo_21(1) - Congo (2.1) (Williams 1995)
     afm_113(1) - Attack From Mars (1.13) (Bally 1995)
     lc_11(1) - League Champ (1.1) (Bally 1996)
     ttt_10(1) - Ticket Tac Toe (1.0) (Williams 1996)
     sc_18s11(1) - Safe Cracker (1.8, Sound S1.1) (Bally 1998)
     totan_14(1) - Tales of the Arabian Nights (1.4) (Williams 1996)
     ss_15(1) - Scared Stiff (1.5) (Bally 1996)
     jy_12(1) - Junk Yard (1.2) (Williams 1996)
     nbaf_31(1) - NBA Fastbreak (3.1, Sound S3.0) (Bally 1997)
     mm_10(1) - Medieval Madness (1.0) (Williams 1997)
     cv_14(1) - Cirqus Voltaire (1.4) (Bally 1997)
     ngg_13(1) - No Good Gofers (1.3) (Williams 1997)
     cp_16(1) - Champion Pub, The (1.6) (Bally 1998)
     mb_10(1) - Monster Bash (1.0) (Williams 1998)
     cc_13(1) - Cactus Canyon (1.3) (Bally 1998)
     tfs_12(1) - WPC Test Fixture: Security (1.2) (Bally 1994)
     tf95_12(1) - WPC Test Fixture: WPC-95 (1.2) (Bally 1996)

Dmd, DmdNoAA:
     mystcast(1) - Mystery Castle (R02) (Alvin G 1993)
     pstlpkr(1) - Pistol Poker (R02) (Alvin G 1993)
     smb(1) - Super Mario Bros. (Gottlieb 1992)
     smbmush(1) - Super Mario Bros. Mushroom World (Gottlieb 1992)
     cueball(1) - Cue Ball Wizard (Gottlieb 1992)
     sfight2(1) - Street Fighter II (Gottlieb 1993)
     teedoff(1) - Tee'd Off (Gottlieb 1993)
     wipeout(1) - Wipe Out (rev. 2) (Gottlieb 1993)
     gladiatr(1) - Gladiators (Gottlieb 1993)
     wcsoccer(1) - World Challenge Soccer (rev. 1) (Gottlieb 1994)
     rescu911(1) - Rescue 911 (rev. 1) (Gottlieb 1994)
     freddy(1) - Freddy: A Nightmare on Elm Street (rev. 3) (Gottlieb 1994)
     shaqattq(1) - Shaq Attaq (rev. 5) (Gottlieb 1995)
     stargate(1) - Stargate (Gottlieb 1995)
     bighurt(1) - Big Hurt (rev. 3) (Gottlieb 1995)
     snspares(2) - Strikes N' Spares (rev. 6) (Gottlieb 1995)
     waterwld(1) - Waterworld (rev. 3) (Gottlieb 1995)
     andretti(1) - Mario Andretti (Gottlieb 1995)
     barbwire(1) - Barb Wire (Gottlieb 1996)
     brooks(1) - Brooks & Dunn (rev. T1) (Gottlieb 1996)
     sam1_flashb_0310(1) - S.A.M. Boot Flash Update (V3.1) (Stern 2008)
     wpt_140a(1) - World Poker Tour (V14.0) (Stern 2008)
     scarn200(1) - Simpsons Kooky Carnival, The (Redemption) (V2.0) (Stern 2008)
     potc_600af(1) - Pirates of the Caribbean (V6.0 English, French) (Stern 2008)
     fg_1200ag(1) - Family Guy (V12.0 English, German) (Stern 2008)
     sman_261(1) - Spider-Man (V2.61) (Stern 2012)
     wof_500(1) - Wheel of Fortune (V5.0) (Stern 2007)
     shr_141(1) - Shrek (V1.41) (Stern 2008)
     ij4_210(1) - Indiana Jones (V2.1) (Stern 2009)
     bdk_294(1) - Batman: The Dark Knight (V2.94) (Stern 2010)
     csi_240(1) - CSI: Crime Scene Investigation (V2.4) (Stern 2009)
     twenty4_150(1) - 24 (V1.5) (Stern 2010)
     nba_802(1) - NBA (V8.02) (Stern 2009)
     bbh_170(1) - Big Buck Hunter Pro (V1.7) (Stern 2010)
     im_186ve(1) - Iron Man Vault Edition (V1.86) (Stern 2020)
     avr_120h(1) - Avatar Limited Edition (V1.2) (Stern 2011)
     rsn_110h(1) - Rolling Stones, The Limited Edition (V1.1) (Stern 2011)
     trn_174h(1) - TRON: Legacy Limited Edition (V1.74) (Stern 2013)
     tf_180h(1) - Transformers Limited Edition (V1.8) (Stern 2013)
     acd_170h(1) - AC/DC Limited Edition (V1.70.0) (Stern 2018)
     xmn_151h(1) - X-Men Limited Edition (V1.51) (Stern 2014)
     avs_170h(1) - Avengers, The Limited Edition (V1.7) (Stern 2016)
     mtl_180h(1) - Metallica Limited Edition (V1.80.0) (Stern 2018)
     st_162h(1) - Star Trek (Stern) Limited Edition (V1.62) (Stern 2018)
     mt_145h(1) - Mustang Limited Edition (V1.45) (Stern 2016)
     twd_160h(1) - Walking Dead, The Limited Edition (V1.60.0) (Stern 2017)
     smanve_101(1) - Spider-Man Vault Edition (V1.01) (Stern 2016)

Seg87F:
     thndrman(5) - Thunder Man (Apple Time 1987)
     skatebll(4) - Skateball (Bally 1980)
     frontier(4) - Frontier (Bally 1980)
     xenon(4) - Xenon (Bally 1980)
     flashgdn(4) - Flash Gordon (Bally 1981)
     eballdlx(4) - Eight Ball Deluxe (rev. 15) (Bally 1981)
     fball_ii(4) - Fireball II (Bally 1981)
     fathom(4) - Fathom (Bally 1981)
     medusa(4) - Medusa (Bally 1981)
     centaur(4) - Centaur (Bally 1981)
     elektra(4) - Elektra (Bally 1981)
     vector(4) - Vector (Bally 1982)
     rapidfir(2) - Rapid Fire (Bally 1982)
     m_mpac(4) - Mr. & Mrs. Pac-Man Pinball (Bally 1982)
     spectrum(4) - Spectrum (Bally 1982)
     speakesy(4) - Speakeasy (Bally 1982)
     bmx(4) - BMX (Bally 1983)
     xsandos(4) - X's & O's (Bally 1983)
     kosteel(4) - Kings of Steel (Bally 1984)
     blakpyra(4) - Black Pyramid (Bally 1984)
     spyhuntr(4) - Spy Hunter (Bally 1984)
     fbclass(4) - Fireball Classic (Bally 1984)
     cybrnaut(4) - Cybernaut (Bally 1985)
     scotest8(4) - Scott's Test ROM (version 8) (Scott Charles 2019)
     eballchp(4) - Eight Ball Champ (Bally 1985)
     beatclck(4) - Beat the Clock (Bally 1985)
     ladyluck(4) - Lady Luck (Bally 1986)
     suprbowl(4) - Super Bowl (Bell Games 1984)
     cosflash(4) - Cosmic Flash (Bell Games 1985)
     worlddef(4) - World Defender (Nuova Bell Games 1985)
     darkshad(4) - Dark Shadow (Nuova Bell Games 1986)
     skflight(4) - Skill Flight (Nuova Bell Games 1986)
     cobra(4) - Cobra (Nuova Bell Games 1987)
     futrquen(4) - Future Queen (Nuova Bell Games 1987)
     toppin(4) - Top Pin (Nuova Bell Games 1988)
     biggame(4) - Big Game (Stern 1980)
     seawitch(4) - Seawitch (Stern 1980)
     cheetah(4) - Cheetah (Black cabinet) (Stern 1980)
     quicksil(4) - Quicksilver (Stern 1980)
     stargzr(4) - Star Gazer (Stern 1980)
     flight2k(4) - Flight 2000 (Stern 1980)
     nineball(4) - Nine Ball (Stern 1980)
     freefall(4) - Free Fall (Stern 1981)
     lightnin(4) - Lightning (Stern 1981)
     splitsec(4) - Split Second (Stern 1981)
     catacomb(4) - Catacomb (Stern 1981)
     ironmaid(4) - Iron Maiden (Stern 1981)
     viper(4) - Viper (Stern 1981)
     dragfist(4) - Dragonfist (Stern 1982)
     orbitor1(4) - Orbitor 1 (Stern 1982)
     cue(1) - Cue (Prototype) (Stern 1982)
     lazrlord(4) - Lazer Lord (Prototype) (Stern 1984)
     scram_tp(5) - Scramble (Tecnoplay 1987)
     socrking(5) - Soccer Kings (Zaccaria 1982)
     pinchamp(5) - Pinball Champ (Zaccaria 1983)
     tmachzac(5) - Time Machine (Zaccaria) (Zaccaria 1983)
     farfalla(5) - Farfalla (Zaccaria 1983)
     dvlrider(5) - Devil Riders (Zaccaria 1984)
     mcastle(5) - Magic Castle (Zaccaria 1984)
     robot(5) - Robot (Zaccaria 1985)
     strsphnx(5) - Star's Phoenix (Italian Speech) (Zaccaria 1987)
     nstrphnx(5) - New Star's Phoenix (Italian Speech) (Zaccaria 1987)

Seg7:
     boomrang(6) - Boomerang (Engineering Prototype, patched patent code) (Bally 1975)
     bowarrow(6) - Bow & Arrow (Prototype, rev. 23) (Bally 1976)
     freedom(6) - Freedom (Bally 1976)
     evelknie(6) - Evel Knievel (Bally 1977)
     eightbll(6) - Eight Ball (Bally 1977)
     pwerplay(6) - Power Play (Bally 1978)
     matahari(6) - Mata Hari (Bally 1978)
     blackjck(6) - Black Jack (Bally 1978)
     stk_sprs(6) - Strikes and Spares (Bally 1978)
     lostwrld(6) - Lost World (Bally 1978)
     smman(8) - Six Million Dollar Man, The (Bally 1978)
     playboy(6) - Playboy (Bally 1978)
     voltan(6) - Voltan Escapes Cosmic Doom (Bally 1978)
     sst(6) - Supersonic (Bally 1979)
     startrek(6) - Star Trek (Bally 1979)
     kiss(6) - Kiss (Bally 1979)
     paragon(6) - Paragon (Bally 1979)
     hglbtrtr(6) - Harlem Globetrotters (Bally 1979)
     dollyptn(6) - Dolly Parton (Bally 1979)
     futurspa(6) - Future Spa (Bally 1979)
     ngndshkr(6) - Nitro Groundshaker (Bally 1980)
     slbmania(6) - Silverball Mania (Bally 1980)
     spaceinv(6) - Space Invaders (Bally 1980)
     rollston(6) - Rolling Stones (Bally 1980)
     mystic(6) - Mystic (Bally 1980)
     viking(6) - Viking (Bally 1980)
     hotdoggn(6) - Hot Doggin (Bally 1980)
     skatebll(2) - Skateball (Bally 1980)
     frontier(2) - Frontier (Bally 1980)
     xenon(2) - Xenon (Bally 1980)
     flashgdn(2) - Flash Gordon (Bally 1981)
     eballdlx(2) - Eight Ball Deluxe (rev. 15) (Bally 1981)
     fball_ii(2) - Fireball II (Bally 1981)
     embryon(6) - Embryon (Bally 1981)
     fathom(2) - Fathom (Bally 1981)
     medusa(5) - Medusa (Bally 1981)
     centaur(2) - Centaur (Bally 1981)
     elektra(3) - Elektra (Bally 1981)
     vector(4) - Vector (Bally 1982)
     rapidfir(1) - Rapid Fire (Bally 1982)
     m_mpac(5) - Mr. & Mrs. Pac-Man Pinball (Bally 1982)
     spectrum(2) - Spectrum (Bally 1982)
     speakesy(2) - Speakeasy (Bally 1982)
     bmx(2) - BMX (Bally 1983)
     granslam(9) - Grand Slam (Bally 1983)
     goldball(6) - Gold Ball (Bally 1983)
     xsandos(2) - X's & O's (Bally 1983)
     kosteel(2) - Kings of Steel (Bally 1984)
     mdntmrdr(6) - Midnight Marauders (Gun game) (Bally Midway 1984)
     blakpyra(2) - Black Pyramid (Bally 1984)
     spyhuntr(2) - Spy Hunter (Bally 1984)
     fbclass(2) - Fireball Classic (Bally 1984)
     cybrnaut(2) - Cybernaut (Bally 1985)
     bigbat(1) - Big Bat (Bally Midway 1984)
     scotest8(2) - Scott's Test ROM (version 8) (Scott Charles 2019)
     champion(8) - Champion (Barni 1985)
     redbaron(8) - Red Baron (Barni 1985)
     suprbowl(2) - Super Bowl (Bell Games 1984)
     cosflash(2) - Cosmic Flash (Bell Games 1985)
     worlddef(2) - World Defender (Nuova Bell Games 1985)
     darkshad(2) - Dark Shadow (Nuova Bell Games 1986)
     skflight(2) - Skill Flight (Nuova Bell Games 1986)
     cobra(2) - Cobra (Nuova Bell Games 1987)
     futrquen(2) - Future Queen (Nuova Bell Games 1987)
     toppin(2) - Top Pin (Nuova Bell Games 1988)
     lwar_a83(4) - Laser War (8.3) (Data East 1987)
     startrip(8) - Star Trip (Game Plan 1979)
     famlyfun(8) - Family Fun! (Game Plan 1979)
     sshooter(6) - Sharpshooter (Game Plan 1979)
     vegasgp(8) - Vegas (Game Plan) (Game Plan 1979)
     coneyis(6) - Coney Island! (Game Plan 1979)
     lizard(6) - (Pinball) Lizard (Game Plan 1980)
     gwarfare(4) - Global Warfare (Game Plan 1981)
     mbossy(6) - Mike Bossy (Game Plan 1982)
     suprnova(6) - Super Nova (Game Plan 1982)
     sshootr2(4) - Sharp Shooter II (Game Plan 1983)
     attila(4) - Attila The Hun (Game Plan 1984)
     agent777(4) - Agents 777 (Game Plan 1984)
     cpthook(4) - Captain Hook (Game Plan 1985)
     ladyshot(4) - Lady Sharpshooter (Game Plan 1985)
     andromed(4) - Andromeda (Game Plan 1985)
     cyclopes(4) - Cyclopes (12/85) (Game Plan 1985)
     silvslug(4) - Silver Slugger (Gottlieb 1990)
     deadweap(4) - Deadly Weapon (Gottlieb 1990)
     tfight(4) - Title Fight (Gottlieb 1990)
     hoops(4) - Hoops (Gottlieb 1991)
     shaqattq(4) - Shaq Attaq (rev. 5) (Gottlieb 1995)
     andretti(3) - Mario Andretti (Gottlieb 1995)
     bullseye(6) - 301/Bullseye (Grand Products Inc. 1986)
     brvteam(4) - Brave Team (Inder (Spain) 1985)
     canasta(4) - Canasta '86' (Inder (Spain) 1986)
     lapbylap(4) - Lap By Lap (Inder (Spain) 1986)
     moonlght(4) - Moon Light (Inder (Spain) 1987)
     pinclown(4) - Clown (Inder) (Inder (Spain) 1988)
     corsario(4) - Corsario (Inder (Spain) 1989)
     mundial(4) - Mundial 90 (Inder (Spain) 1990)
     atleta(4) - Atleta (Inder (Spain) 1991)
     ind250cc(4) - 250 c.c. (Inder (Spain) 1992)
     metalman(4) - Metal Man (Inder (Spain) 1992)
     icemania(6) - Ice Mania (Jac Van Ham (Royal) 1986)
     escape(10) - Escape (Jac Van Ham (Royal) 1987)
     movmastr(10) - Movie Masters (Jac Van Ham (Royal) 19??)
     formula1(2) - Formula 1 (Jac Van Ham (Royal) 1988)
     ridersrf(17) - Rider's Surf (JocMatic 1986)
     walkyria(1) - Walkyria (Joctronic 1986)
     petaco(4) - Petaco (Juegos Populares 1984)
     petacon(4) - Petaco (new hardware) (Juegos Populares 1985)
     arizona(6) - Arizona (LTD 19??)
     atla_ltd(8) - Atlantis (LTD) (LTD 19??)
     discodan(7) - Disco Dancing (LTD 19??)
     hustler(6) - Hustler (LTD 19??)
     kkongltd(7) - King Kong (LTD) (LTD 19??)
     marqueen(7) - Martian Queen (LTD 19??)
     vikngkng(6) - Viking King (LTD 19??)
     cowboy3p(5) - Cowboy Eight Ball (LTD 1981)
     zephy(5) - Zephy (LTD 1982)
     cowboy(6) - Cowboy Eight Ball 2 (LTD 198?)
     hhotel(10) - Haunted Hotel (LTD 198?)
     pecmen(10) - Mr. & Mrs. Pec-Men (LTD 198?)
     alcapone(6) - Al Capone (LTD 198?)
     alienwar(6) - Alien Warrior (LTD 198?)
     tmacltd4(6) - Time Machine (LTD) (4 Players) (LTD 198?)
     tricksht(6) - Trick Shooter (LTD 198?)
     pentacup(12) - Pentacup (rev. 1) (Micropin 1978)
     flicker(6) - Flicker (Prototype) (Nutting Associates 1974)
     rotation(5) - Rotation VIII (1.17) (Midway 1978)
     spirit76(6) - Spirit of 76 (Mirco 1975)
     lckydraw(6) - Lucky Draw (Mirco 1978)
     monrobwl(8) - Stars & Strikes (Bowler) (Monroe Bowling Co. 19??)
     odin(13) - Odin (Peyper (Spain) 1985)
     nemesis(17) - Nemesis (Peyper (Spain) 1986)
     wolfman(17) - Wolf Man (Peyper (Spain) 1987)
     odisea(17) - Odisea Paris-Dakar (Peyper (Spain) 1987)
     blroller(7) - Bloody Roller (Playbar 1987)
     spcgambl(11) - Space Gambler (Playmatic 1978)
     bigtown(11) - Big Town (Playmatic 1978)
     lastlap(11) - Last Lap (Playmatic 1978)
     chance(11) - Chance (Playmatic 1978)
     party(11) - Party (Playmatic 1979)
     antar(11) - Antar (Playmatic 1979)
     evlfight(11) - Evil Fight (Playmatic 1980)
     attack(11) - Attack (Playmatic 1980)
     blkfever(11) - Black Fever (Playmatic 1980)
     zira(11) - Zira (Playmatic 1981)
     cerberus(11) - Cerberus (Playmatic 1982)
     spain82(11) - Spain 82 (Playmatic 1982)
     madrace(11) - Mad Race (Playmatic 198?)
     nautilus(17) - Nautilus (Playmatic 1984)
     theraid(17) - Raid, The (Playmatic 1984)
     ufo_x(17) - UFO-X (Playmatic 1984)
     kz26(17) - KZ-26 (Playmatic 1985)
     rock2500(17) - Rock 2500 (Playmatic 1985)
     starfire(17) - Star Fire (Playmatic 1985)
     trailer(17) - Trailer (Playmatic 1985)
     fldragon(17) - Flash Dragon (Playmatic 1986)
     trebol(3) - Trebol (Regama (Spain) 1985)
     thrdwrld(11) - Third World (Sonic (Spain) 1978)
     ngtfever(11) - Night Fever (Sonic (Spain) 1979)
     storm(11) - Storm (Sonic (Spain) 1979)
     gamatros(13) - Gamatron (Sonic) (Sonic (Spain) 1986)
     solarwar(13) - Solar Wars (Sonic) (Sonic (Spain) 1986)
     sonstwar(13) - Star Wars (Sonic) (Sonic (Spain) 1987)
     poleposn(13) - Pole Position (Sonic) (Sonic (Spain) 1987)
     hangon(13) - Hang-On (Sonic (Spain) 1988)
     flashman(17) - Flashman (Sport Matic 1984)
     spcship(7) - Space Ship (Stargame 1986)
     whtforce(7) - White Force (Stargame 1987)
     ironball(17) - Iron Balls (Stargame 1987)
     stingray(6) - Stingray (Stern 1977)
     pinball(6) - Pinball (Stern 1977)
     stars(6) - Stars (Stern 1978)
     memlane(6) - Memory Lane (Stern 1978)
     lectrono(6) - Lectronamo (Stern 1978)
     wildfyre(6) - Wildfyre (Stern 1978)
     nugent(6) - Nugent (Stern 1978)
     dracula(6) - Dracula (Stern 1979)
     hothand(6) - Hot Hand (Stern 1979)
     magic(6) - Magic (Stern 1979)
     princess(6) - Cosmic Princess (Stern 1979)
     meteor(6) - Meteor (Stern 1979)
     meteora(6) - Meteor (Bonus Count Offical Fix) (Stern 1979)
     galaxy(6) - Galaxy (Stern 1980)
     ali(6) - Ali (Stern 1980)
     biggame(2) - Big Game (Stern 1980)
     seawitch(2) - Seawitch (Stern 1980)
     cheetah(2) - Cheetah (Black cabinet) (Stern 1980)
     quicksil(2) - Quicksilver (Stern 1980)
     stargzr(2) - Star Gazer (Stern 1980)
     flight2k(2) - Flight 2000 (Stern 1980)
     nineball(2) - Nine Ball (Stern 1980)
     freefall(2) - Free Fall (Stern 1981)
     lightnin(3) - Lightning (Stern 1981)
     splitsec(2) - Split Second (Stern 1981)
     catacomb(2) - Catacomb (Stern 1981)
     ironmaid(2) - Iron Maiden (Stern 1981)
     viper(2) - Viper (Stern 1981)
     dragfist(3) - Dragonfist (Stern 1982)
     orbitor1(3) - Orbitor 1 (Stern 1982)
     cue(4) - Cue (Prototype) (Stern 1982)
     blbeauty(8) - Black Beauty (Shuffle) (Stern 1984)
     lazrlord(2) - Lazer Lord (Prototype) (Stern 1984)
     football(8) - Football (Taito 1979)
     obaoba(8) - Oba-Oba (Taito 1980)
     drakor(6) - Drakor (Taito 1980)
     meteort(6) - Meteor (Taito) (Taito 1980)
     fireact(6) - Fire Action (Taito 1981)
     cavnegro(6) - Cavaleiro Negro (Taito 1981)
     sureshot(6) - Sure Shot (Taito 1981)
     ladylukt(6) - Lady Luck (Taito) (Taito 1981)
     cosmic(6) - Cosmic (Taito 1981)
     gemini(6) - Gemini 2000 (Taito 1982)
     vortex(6) - Vortex (Taito 1982)
     titan(6) - Titan (Taito 1982)
     zarza(6) - Zarza (Taito 1982)
     sharkt(6) - Shark (Taito) (Taito 1982)
     hawkman(6) - Hawkman (Taito 1982)
     stest(6) - Speed Test (Taito 1982)
     lunelle(6) - Lunelle (Taito 1982)
     rally(6) - Rally (Taito 1982)
     snake(6) - Snake Machine (Taito 1982)
     gork(6) - Gork (Taito 1982)
     mrblack(6) - Mr. Black (Taito 1984)
     fireactd(6) - Fire Action Deluxe (Taito 198?)
     sshuttle(6) - Space Shuttle (Taito) (Taito 1985)
     polar(6) - Polar Explorer (Taito 198?)
     taitest(6) - Taito Test Fixture (Taito 198?)
     bbbowlin(8) - Big Ball Bowling (Bowler) (United(?) 19??)
     ator(13) - Ator (Video Dens 1985)
     httip_l1(6) - Hot Tip (L-1) (Williams 1977)
     lucky_l1(6) - Lucky Seven (L-1) (Williams 1977)
     cntct_l1(6) - Contact (L-1) (Williams 1978)
     wldcp_l1(6) - World Cup (L-1) (Williams 1978)
     disco_l1(6) - Disco Fever (L-1) (Williams 1978)
     pkrno_l1(6) - Pokerino (L-1) (Williams 1978)
     phnix_l1(6) - Phoenix (L-1) (Williams 1978)
     flash_l1(6) - Flash (Sys.6 L-1) (Williams 1978)
     stlwr_l2(6) - Stellar Wars (L-2) (Williams 1979)
     pomp_l1(8) - Pompeii (Shuffle) (L-1) (Williams 1978)
     topaz_l1(8) - Topaz (Shuffle) (L-1) (Williams 1978)
     arist_l1(8) - Aristocrat (Shuffle) (L-1) (Williams 1979)
     taurs_l1(8) - Taurus (Shuffle) (L-1) (Williams 1979)
     kingt_l1(8) - King Tut (Shuffle) (L-1) (Williams 1979)
     trizn_l1(6) - Tri Zone (L-1) (Williams 1979)
     tmwrp_l3(6) - Time Warp (L-3) (Williams 1979)
     grgar_l1(6) - Gorgar (L-1) (Williams 1979)
     lzbal_l2(6) - Laser Ball (L-2) (Williams 1979)
     frpwr_l6(6) - Firepower (L-6) (Williams 1980)
     omni_l1(8) - Omni (Shuffle) (L-1) (Williams 1980)
     blkou_l1(6) - Blackout (L-1) (Williams 1980)
     scrpn_l1(6) - Scorpion (L-1) (Williams 1980)
     algar_l1(8) - Algar (L-1) (Williams 1980)
     alpok_l6(8) - Alien Poker (L-6) (Williams 1980)
     frpwr_a7(6) - Firepower (Sys.7/6-digit conversion rev. 31) (Williams / Oliver 2005)
     frpwr_d7(6) - Firepower (Sys.7/7-digit conversion rev. 31) (Williams / Oliver 2005)
     frpwr_e7(6) - Firepower (Sys.7/6-digit /10 Scoring rev. 31) (Williams / Oliver 2005)
     bstrk_l1(8) - Big Strike (Shuffle) (L-1) (Williams 1983)
     tstrk_l1(8) - Triple Strike (Shuffle) (L-1) (Williams 1983)
     pfevr_l2(9) - Pennant Fever Baseball (L-2) (Williams 1984)
     sshtl_l7(4) - Space Shuttle (L-7) (Williams 1984)
     szone_l5(9) - Strike Zone (Shuffle) (L-5) (Williams 1984)
     alcat_l7(12) - Alley Cats (Shuffle) (L-7) (Williams 1985)
     tts_l2(12) - Tic-Tac-Strike (Shuffle) (L-2) (Williams 1986)
     gmine_l2(12) - Gold Mine (Shuffle) (L-2) (Williams 1987)
     tdawg_l1(12) - Top Dawg (Shuffle) (L-1) (Williams 1987)
     shfin_l1(12) - Shuffle Inn (Shuffle) (L-1) (Williams 1987)
     wsports(7) - Winter Sports (Zaccaria 1978)
     hod(7) - House of Diamonds (Zaccaria 1978)
     futurwld(7) - Future World (Zaccaria 1978)
     sshtlzac(7) - Space Shuttle (Zaccaria) (Zaccaria 1980)
     ewf(7) - Earth, Wind & Fire (Zaccaria 1981)
     myststar(6) - Mystic Star (Zaccaria 1984)
     suprpick(5) - Super Picker (Allied Leisure 1977)
     foxylady(8) - Foxy Lady (Game Plan 1978)

Video:
     granny(1) - Granny and the Gators (Video/Pinball Combo) (Bally 1984)
     dakar(1) - Dakar (Mr. Game (Italy) 1988)
     motrshow(1) - Motor Show (Mr. Game (Italy) 1988)
     wcup90(1) - World Cup '90 (Mr. Game (Italy) 1990)
     cavemana(1) - Caveman (Pinball/Video Combo) (set 2) (Gottlieb 1981)

Seg87:
     eballchp(2) - Eight Ball Champ (Bally 1985)
     beatclck(2) - Beat the Clock (Bally 1985)
     ladyluck(2) - Lady Luck (Bally 1986)
     faeton(4) - Faeton (Juegos Populares 1985)
     halley(4) -   (Juegos Populares 1986)
     aqualand(4) - Aqualand (Juegos Populares 1986)
     america(4) - America 1492 (Juegos Populares 1986)
     olympus(4) - Olympus (Juegos Populares 1986)
     pimbal(4) - Pimbal (Pinball 3000) (Juegos Populares 19??)
     papillon(4) - Papillon (Video Dens 1986)
     break(4) - Break (Video Dens 1986)
     bk_l4(4) - Black Knight (L-4) (Williams 1980)
     jngld_l2(4) - Jungle Lord (L-2) (Williams 1981)
     pharo_l2(4) - Pharaoh (L-2) (Williams 1981)
     solar_l2(4) - Solar Fire (L-2) (Williams 1981)
     barra_l1(4) - Barracora (L-1) (Williams 1981)
     hypbl_l4(6) - HyperBall (L-4) (Williams 1981)
     csmic_l1(4) - Cosmic Gunfight (L-1) (Williams 1980)
     thund_p1(4) - Thunderball (P-1 Prototype) (Williams 1982)
     vrkon_l1(4) - Varkon (L-1) (Williams 1982)
     splbn_l0(6) - Spellbinder (L-0 BETA) (Williams / Jess M. Askey 1982)
     wrlok_l3(4) - Warlok (L-3) (Williams 1982)
     dfndr_l4(4) - Defender (L-4) (Williams 1982)
     ratrc_l1(4) - Rat Race (L-1) (Williams 1983)
     tmfnt_l5(4) - Time Fantasy (L-5) (Williams 1982)
     jst_l2(4) - Joust (L-2) (Williams 1983)
     fpwr2_l2(4) - Firepower II (L-2) (Williams 1983)
     lsrcu_l2(4) - Laser Cue (L-2) (Williams 1983)
     strlt_l1(4) - Star Light (L-1) (Williams 1984)
     scrzy_l1(1) - Still Crazy (L-1) (Williams 1984)
     sshtl_l7(4) - Space Shuttle (L-7) (Williams 1984)
     sorcr_l2(4) - Sorcerer (L-2) (Williams 1985)
     comet_l5(4) - Comet (L-5) (Williams 1985)

Seg98:
     motrdome(4) - MotorDome (Bally 1986)
     blackblt(4) - Black Belt (Bally 1986)
     specforc(4) - Special Force (Bally 1986)
     strngscc(4) - Strange Science (rev. C) (Bally 1986)
     cityslck(4) - City Slicker (Bally 1987)
     hardbody(4) - Hardbody (Bally 1987)
     prtyanim(4) - Party Animal (Bally 1987)
     hvymetal(4) - Heavy Metal Meltdown (Bally 1987)
     dungdrag(4) - Dungeons & Dragons (Bally 1987)
     esclwrld(4) - Escape from the Lost World (Bally 1987)
     black100(4) - Blackwater 100 (Bally 1988)
     trucksp3(4) - Truck Stop (P-3 Prototype) (Bally 1988)
     atlantis(4) - Atlantis (rev. 3) (Bally 1989)

Seg10:
     motrdome(1) - MotorDome (Bally 1986)
     blackblt(1) - Black Belt (Bally 1986)
     specforc(1) - Special Force (Bally 1986)
     strngscc(1) - Strange Science (rev. C) (Bally 1986)
     cityslck(1) - City Slicker (Bally 1987)
     hardbody(1) - Hardbody (Bally 1987)
     prtyanim(1) - Party Animal (Bally 1987)
     hvymetal(1) - Heavy Metal Meltdown (Bally 1987)
     dungdrag(1) - Dungeons & Dragons (Bally 1987)
     esclwrld(1) - Escape from the Lost World (Bally 1987)
     black100(1) - Blackwater 100 (Bally 1988)
     trucksp3(1) - Truck Stop (P-3 Prototype) (Bally 1988)
     atlantis(1) - Atlantis (rev. 3) (Bally 1989)
     glxplay(8) - Galaxy Play (CICPlay 1985)
     kidnap(8) - Kidnap (CICPlay 1986)
     glxplay2(8) - Galaxy Play 2 (CICPlay 1987)

Seg7S:
     champion(3) - Champion (Barni 1985)
     redbaron(3) -  (Barni 1985)
     glxplay(3) - Galaxy Play (CICPlay 1985)
     kidnap(3) - Kidnap (CICPlay 1986)
     glxplay2(3) - Galaxy Play 2 (CICPlay 1987)
     gwarfare(2) - Global Warfare (Game Plan 1981)
     sshootr2(2) - Sharp Shooter II (Game Plan 1983)
     attila(2) - Attila The Hun (Game Plan 1984)
     agent777(2) - Agents 777 (Game Plan 1984)
     cpthook(2) - Captain Hook (Game Plan 1985)
     andromed(2) - Andromeda (Game Plan 1985)
     cyclopes(2) - Cyclopes (12/85) (Game Plan 1985)
     topazi(2) - Topaz (Inder) (Inder (Spain) 1979)
     skatebrd(2) - Skate Board (Inder (Spain) 1980)
     brvteam(2) - Brave Team (Inder (Spain) 1985)
     canasta(2) - Canasta '86' (Inder (Spain) 1986)
     lapbylap(4) - Lap By Lap (Inder (Spain) 1986)
     moonlght(4) - Moon Light (Inder (Spain) 1987)
     pinclown(2) - Clown (Inder) (Inder (Spain) 1988)
     corsario(3) - Corsario (Inder (Spain) 1989)
     mundial(3) - Mundial 90 (Inder (Spain) 1990)
     atleta(3) - Atleta (Inder (Spain) 1991)
     ind250cc(3) - 250 c.c. (Inder (Spain) 1992)
     metalman(3) - Metal Man (Inder (Spain) 1992)
     walkyria(7) - Walkyria (Joctronic 1986)
     petaco(3) - Petaco (Juegos Populares 1984)
     petacon(3) - Petaco (new hardware) (Juegos Populares 1985)
     faeton(3) - Faeton (Juegos Populares 1985)
     halley(3) - Halley Comet (Juegos Populares 1986)
     aqualand(3) - Aqualand (Juegos Populares 1986)
     america(3) - America 1492 (Juegos Populares 1986)
     olympus(3) - Olympus (Juegos Populares 1986)
     pimbal(3) - Pimbal (Pinball 3000) (Juegos Populares 19??)
     odin(4) - Odin (Peyper (Spain) 1985)
     nemesis(23) - Nemesis (Peyper (Spain) 1986)
     wolfman(23) - Wolf Man (Peyper (Spain) 1987)
     odisea(23) - Odisea Paris-Dakar (Peyper (Spain) 1987)
     spcgambl(2) - Space Gambler (Playmatic 1978)
     bigtown(2) - Big Town (Playmatic 1978)
     lastlap(2) - Last Lap (Playmatic 1978)
     chance(2) - Chance (Playmatic 1978)
     party(2) - Party (Playmatic 1979)
     thrdwrld(2) - Third World (Sonic (Spain) 1978)
     ngtfever(2) - Night Fever (Sonic (Spain) 1979)
     gamatros(4) - Gamatron (Sonic) (Sonic (Spain) 1986)
     solarwar(4) - Solar Wars (Sonic) (Sonic (Spain) 1986)
     sonstwar(4) - Star Wars (Sonic) (Sonic (Spain) 1987)
     poleposn(4) - Pole Position (Sonic) (Sonic (Spain) 1987)
     hangon(4) - Hang-On (Sonic (Spain) 1988)
     ator(4) - Ator (Video Dens 1985)
     papillon(3) - Papillon (Video Dens 1986)
     break(5) - Break (Video Dens 1986)
     aftor(2) - Af-Tor (Wico 1984)
     bk_l4(4) - Black Knight (L-4) (Williams 1980)
     jngld_l2(4) - Jungle Lord (L-2) (Williams 1981)
     pharo_l2(4) - Pharaoh (L-2) (Williams 1981)
     solar_l2(4) - Solar Fire (L-2) (Williams 1981)
     barra_l1(4) - Barracora (L-1) (Williams 1981)
     csmic_l1(4) - Cosmic Gunfight (L-1) (Williams 1980)
     thund_p1(4) - Thunderball (P-1 Prototype) (Williams 1982)
     vrkon_l1(4) - Varkon (L-1) (Williams 1982)
     wrlok_l3(4) - Warlok (L-3) (Williams 1982)
     dfndr_l4(4) - Defender (L-4) (Williams 1982)
     ratrc_l1(4) - Rat Race (L-1) (Williams 1983)
     tmfnt_l5(4) - Time Fantasy (L-5) (Williams 1982)
     jst_l2(4) - Joust (L-2) (Williams 1983)
     fpwr2_l2(4) - Firepower II (L-2) (Williams 1983)
     lsrcu_l2(4) - Laser Cue (L-2) (Williams 1983)
     strlt_l1(4) - Star Light (L-1) (Williams 1984)
     sorcr_l2(4) - Sorcerer (L-2) (Williams 1985)
     comet_l5(4) - Comet (L-5) (Williams 1985)
     hs_l4(4) - High Speed (L-4) (Williams 1986)
     grand_l4(4) - Grand Lizard (L-4) (Williams 1986)
     rdkng_l4(4) - Road Kings (L-4) (Williams 1986)
     pb_l5(4) - Pin-Bot (L-5) (Williams 1986)
     milln_l3(4) - Millionaire (L-3) (Williams 1987)
     spidermn(4) - Amazing Spider-Man, The (Gottlieb 1980)
     spiderm7(4) - Amazing Spider-Man, The (7-digit conversion) (Oliver 2008)
     panther7(4) - Panthera (7-digit conversion) (Oliver 2008)
     circus7(4) - Circus (7-digit conversion) (Oliver 2008)
     cntforc7(4) - Counterforce (7-digit conversion) (Oliver 2008)
     starrac7(4) - Star Race (7-digit conversion) (Oliver 2008)
     jamesb7(4) - James Bond (Timed Play, 7-digit conversion) (Oliver 2008)
     timelin7(4) - Time Line (7-digit conversion) (Oliver 2008)
     forceii7(4) - Force II (7-digit conversion) (Oliver 2008)
     pnkpntr7(4) - Pink Panther (7-digit conversion) (Oliver 2008)
     mars(4) - Mars - God of War (Gottlieb 1981)
     vlcno_a7(4) - Volcano (7-digit conversion) (Oliver 2008)
     vlcno_b7(4) - Volcano (Sound Only, 7-digit conversion) (Oliver 2008)
     blkhole7(4) - Black Hole (7-digit conversion) (Oliver 2008)
     blkhol7s(4) - Black Hole (Sound Only, 7-digit conversion) (Oliver 2008)
     hh7(4) - Haunted House (rev. 2, 7-digit conversion) (Oliver 2008)
     eclipse7(4) - Eclipse (7-digit conversion) (Oliver 2008)
     dvlsdre(4) - Devil's Dare (Gottlieb 1981)
     dvlsdre2(4) - Devil's Dare (Sound Only) (Gottlieb 1981)
     rockyf(4) - Rocky (French Speech) (Gottlieb 1982)
     amazonha(4) - Amazon Hunt (alternate set) (Gottlieb 1983)

Seg16S:
     f1gp(2) - F1 Grand Prix (Nuova Bell Games 1987)

Dmd, DmdNoAA, NoDisp:
     pmv112(1) - Pinball Magic (1.0.12) (Capcom 1995)
     abv106(1) - Airborne (1.6) (Capcom 1996)
     bsv103(1) - Breakshot (1.3) (Capcom 1996)
     ffv104(1) - Flipper Football (1.04) (Capcom 1996)
     bbb109(1) - Big Bang Bar (Beta 1.9 US) (Capcom 1996)
     kpb105(1) - Kingpin (Beta 1.05) (Capcom 1996)
     monopoly(1) - Monopoly (3.20) (Stern 2001)
     rctycn(1) - RollerCoaster Tycoon (7.02) (Stern 2002)
     simpprty(1) - Simpsons Pinball Party, The (5.00) (Stern 2003)
     wpt_140a(14) - World Poker Tour (V14.0) (Stern 2008)
     wof_500(1) - Wheel of Fortune (V5.0) (Stern 2007)

Seg9:
     glxplay(12) - Galaxy Play (CICPlay 1985)
     kidnap(12) - Kidnap (CICPlay 1986)
     glxplay2(12) - Galaxy Play 2 (CICPlay 1987)
     fjholden(6) - FJ Holden (Hankin 1978)
     orbit1(6) - Orbit 1 (Hankin 1978)
     howzat(6) - Howzat (Hankin 1980)
     shark(6) - Shark (Hankin 1980)
     empsback(6) - Empire Strikes Back, The (Hankin 1981)
     topazi(4) - Topaz (Inder) (Inder (Spain) 1979)
     skatebrd(4) - Skate Board (Inder (Spain) 1980)
     aftor(4) - Af-Tor (Wico 1984)
     spidermn(4) - Amazing Spider-Man, The (Gottlieb 1980)
     jamesb7(1) - James Bond (Timed Play, 7-digit conversion) (Oliver 2008)
     timelin7(1) - Time Line (7-digit conversion) (Oliver 2008)
     pnkpntr7(2) - Pink Panther (7-digit conversion) (Oliver 2008)
     mars(4) - Mars - God of War (Gottlieb 1981)
     blkhole7(1) - Black Hole (7-digit conversion) (Oliver 2008)
     blkhol7s(1) - Black Hole (Sound Only, 7-digit conversion) (Oliver 2008)
     hh7(1) - Haunted House (rev. 2, 7-digit conversion) (Oliver 2008)
     eclipse7(1) - Eclipse (7-digit conversion) (Oliver 2008)
     dvlsdre(2) - Devil's Dare (Gottlieb 1981)
     dvlsdre2(2) - Devil's Dare (Sound Only) (Gottlieb 1981)
     cavemana(4) - Caveman (Pinball/Video Combo) (set 2) (Gottlieb 1981)
     rockyf(2) - Rocky (French Speech) (Gottlieb 1982)

Seg8:
     lwar_a83(2) - Laser War (8.3) (Data East 1987)
     ssvc_a26(2) - Secret Service (2.6) (Data East 1988)
     torp_e21(2) - Torpedo Alley (2.1 Europe) (Data East 1988)
     tmac_a24(2) - Time Machine (2.4) (Data East 1988)
     play_a24(2) - Playboy 35th Anniversary (2.4) (Data East 1989)
     faeton(1) - Faeton (Juegos Populares 1985)
     halley(1) - Halley Comet (Juegos Populares 1986)
     aqualand(1) - Aqualand (Juegos Populares 1986)
     america(1) - America 1492 (Juegos Populares 1986)
     olympus(1) - Olympus (Juegos Populares 1986)
     pimbal(1) - Pimbal (Pinball 3000) (Juegos Populares 19??)
     macgalxy(13) - MAC's Galaxy (MAC S.A. 1986)
     macjungl(13) - MAC Jungle (MAC S.A. 1986)
     spctrain(13) - Space Train (MAC S.A. 1987)
     spcpnthr(13) - Space Panther (MAC S.A. 1988)
     mac_1808(13) - Unknown Game (MAC #1808) (MAC S.A. 19??)
     macjungn(13) - MAC Jungle (New version) (MAC S.A. 1995)
     nbamac(13) - NBA MAC (MAC S.A. 1996)
     hs_l4(2) - High Speed (L-4) (Williams 1986)
     grand_l4(2) - Grand Lizard (L-4) (Williams 1986)
     rdkng_l4(2) - Road Kings (L-4) (Williams 1986)
     pb_l5(2) - Pin-Bot (L-5) (Williams 1986)
     milln_l3(2) - Millionaire (L-3) (Williams 1987)
     f14_l1(2) - F-14 Tomcat (L-1) (Williams 1987)
     fire_l3(2) - Fire! (L-3) (Williams 1987)
     bguns_l8(2) - Big Guns (L-8) (Williams 1987)
     spstn_l5(2) - Space Station (L-5) (Williams 1988)
     cycln_l5(2) - Cyclone (L-5) (Williams 1988)
     bnzai_l3(2) - Banzai Run (L-3) (Williams 1988)
     swrds_l2(2) - Swords of Fury (L-2) (Williams 1988)
     taxi_l4(1) - Taxi (Lola) (L-4) (Williams 1988)
     polic_l4(1) - Police Force (LA-4) (Williams 1989)
     rvrbt_l3(1) - Riverboat Gambler (L-3) (Williams 1990)

Seg8D:
     gamesnsm(6) - Games, The (NSM) (NSM (Germany) 1985)
     cosflnsm(6) - Cosmic Flash (NSM) (NSM (Germany) 1985)
     firebird(6) - Hot Fire Birds (NSM (Germany) 1985)
     odin(8) - Odin (Peyper (Spain) 1985)
     nemesis(8) - Nemesis (Peyper (Spain) 1986)
     wolfman(8) - Wolf Man (Peyper (Spain) 1987)
     odisea(8) - Odisea Paris-Dakar (Peyper (Spain) 1987)
     spcgambl(4) - Space Gambler (Playmatic 1978)
     bigtown(4) - Big Town (Playmatic 1978)
     lastlap(4) - Last Lap (Playmatic 1978)
     chance(4) - Chance (Playmatic 1978)
     party(4) - Party (Playmatic 1979)
     thrdwrld(4) - Third World (Sonic (Spain) 1978)
     ngtfever(4) - Night Fever (Sonic (Spain) 1979)
     gamatros(8) - Gamatron (Sonic) (Sonic (Spain) 1986)
     solarwar(8) - Solar Wars (Sonic) (Sonic (Spain) 1986)
     sonstwar(8) - Star Wars (Sonic) (Sonic (Spain) 1987)
     poleposn(8) - Pole Position (Sonic) (Sonic (Spain) 1987)
     hangon(8) - Hang-On (Sonic (Spain) 1988)
     slalom03(7) - Slalom Code 0.3 (Stargame 1988)
     spectra(5) - Spectra IV (Valley 1979)
     ator(8) - Ator (Video Dens 1985)

Seg7, NoDisp:
     apollo13(1) - Apollo 13 (5.01, Display 5.00) (Sega 1995)
     nbaf_31(1) - NBA Fastbreak (3.1, Sound S3.0) (Bally 1997)

Dmd, NoDisp:
     hirolcas(1) - High Roller Casino (3.00) (Stern 2001)
     ripleys(3) - Ripley's Believe It or Not! (3.20) (Stern 2004)

Seg7SCH:
     taxi_l4(1) - 

Seg8H:
     polic_l4(1) - Police Force (LA-4) (Williams 1989)

Seg87H:
     rvrbt_l3(1) - Riverboat Gambler (L-3) (Williams 1990)

Seg7H:
     rvrbt_l3(1) - Riverboat Gambler (L-3) (Williams 1990)

Seg16R:
     fh_l9(2) - Funhouse (L-9, SL-3) (Williams 1992)
     bop_l7(2) - Machine: Bride of Pinbot, The (L-7) (Williams 1992)
     hd_l3(2) - Harley-Davidson (L-3) (Bally 1991)

Seg16D:
     fh_l9(2) - Funhouse (L-9, SL-3) (Williams 1992)
     bop_l7(2) - Machine: Bride of Pinbot, The (L-7) (Williams 1992)

Seg16N:
     fh_l9(2) - Funhouse (L-9, SL-3) (Williams 1992)
     bop_l7(2) - Machine: Bride of Pinbot, The (L-7) (Williams 1992)

Seg98F:
     spiderm7(4) - Amazing Spider-Man, The (7-digit conversion) (Oliver 2008)
     panther7(4) - Panthera (7-digit conversion) (Oliver 2008)
     circus7(4) - Circus (7-digit conversion) (Oliver 2008)
     cntforc7(4) - Counterforce (7-digit conversion) (Oliver 2008)
     starrac7(4) - Star Race (7-digit conversion) (Oliver 2008)
     jamesb7(4) - James Bond (Timed Play, 7-digit conversion) (Oliver 2008)
     timelin7(4) - Time Line (7-digit conversion) (Oliver 2008)
     forceii7(4) - Force II (7-digit conversion) (Oliver 2008)
     pnkpntr7(4) - Pink Panther (7-digit conversion) (Oliver 2008)
     vlcno_a7(4) - Volcano (7-digit conversion) (Oliver 2008)
     vlcno_b7(4) - Volcano (Sound Only, 7-digit conversion) (Oliver 2008)
     blkhole7(4) - Black Hole (7-digit conversion) (Oliver 2008)
     blkhol7s(4) - Black Hole (Sound Only, 7-digit conversion) (Oliver 2008)
     hh7(4) - Haunted House (rev. 2, 7-digit conversion) (Oliver 2008)
     eclipse7(4) - Eclipse (7-digit conversion) (Oliver 2008)
     dvlsdre(4) - Devil's Dare (Gottlieb 1981)
     dvlsdre2(4) - Devil's Dare (Sound Only) (Gottlieb 1981)
     cavemana(4) - Caveman (Pinball/Video Combo) (set 2) (Gottlieb 1981)
     rockyf(4) - Rocky (French Speech) (Gottlieb 1982)
     amazonha(4) - Amazon Hunt (alternate set) (Gottlieb 1983)
```
</details>

So I would get the manual of one those games for each display type, look up the part numbers of the display and look for replacement units in order to get a good shot. The problem is just that the replacement parts aren't the sames as the originals. For exampe, where Bally's `PS-8363-P` would have a comma only ever three characters, the [replacement part](https://www.marcospecialties.com/pinball-parts/PS-8363-P) has commas after every character.

So finally I ended up pre-populating the comma type on best guess, and the author can always change it. This resulted in a few more options in the segment display's inspector:

![image](https://user-images.githubusercontent.com/70426/117726710-42ba4f00-b1e7-11eb-9f97-045cf8d19b89.png)

Then there were a few refactorings done, mainly in the shader code, which now properly relies on number of segments instead of "segment type". Also, the materials seem to work fine now without having to re-create them on each parameter change. Additionally, *Undo* was fixed.

Lastly, there's now only one frame format for segment displays, which is a 2-byte short, and it's independent from number of segments.

One cool thing is that mixing displays seems to work well. Here the DMD and the shot clock of NBA Fastbreak.

https://user-images.githubusercontent.com/70426/117727396-400c2980-b1e8-11eb-94e1-25f39afa9a76.mp4

## TODO

- [x] Use `sharedMaterial` in DMD shader as well
- [x] Re-test games