### PR TITLE
misc: fix trough optos to be normally open

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughApi.cs
@@ -197,7 +197,7 @@ namespace VisualPinball.Unity
 				_stackSwitches = new DeviceSwitch[Data.SwitchCount];
 				foreach (var sw in Item.AvailableSwitches) {
 					if (sw.InternalId > 0) {
-						_stackSwitches[sw.InternalId - 1] = CreateSwitch(sw.Id, false, Data.Type == TroughType.ModernOpto ? SwitchDefault.NormallyClosed : SwitchDefault.NormallyOpen);
+						_stackSwitches[sw.InternalId - 1] = CreateSwitch(sw.Id, false, SwitchDefault.NormallyOpen);
 						_switchLookup[sw.Id] = _stackSwitches[sw.InternalId - 1];
 					}
 				}
@@ -209,7 +209,7 @@ namespace VisualPinball.Unity
 			}
 
 			if (Data.JamSwitch) {
-				JamSwitch = CreateSwitch(Trough.JamSwitchId, false, Data.Type == TroughType.ModernOpto ? SwitchDefault.NormallyClosed : SwitchDefault.NormallyOpen);
+				JamSwitch = CreateSwitch(Trough.JamSwitchId, false, SwitchDefault.NormallyOpen);
 				_switchLookup[Trough.JamSwitchId] = JamSwitch;
 			}
 


### PR DESCRIPTION
- When a ball is sitting between an opto, it breaks the light beam, ie "opening" the switch (0 - false)
- When a ball is not between the light beam, the light beam is passing through, ie "closing" the switch (1 - true)

That said, PinMAME treats open Opto switches as Active (true). This is the reverse of the above.

![Screen Shot 2021-06-14 at 4 36 41 PM](https://user-images.githubusercontent.com/1197137/121956115-ba235700-cd2e-11eb-9867-cdae1d651e2f.png)

A better explanation can be found [here](https://pinside.com/pinball/forum/topic/lets-discuss-williams-opto-theory#post-2424066):

> Part 2 - Why optos are ACTIVE when they're blocked..
> 
> The IR reciever (Phototransistor) allows the row circuit to be closed (i.e. switch closed, current flowing from collector to emitter) when it detects IR light. When there is no IR light detected, the phototransistor is open, stopping current from flowing.
> 
> Since the ball blocking the IR beam is activating the switch, this is why in switch test that -
> 
> An ACTIVE switch is one that is not in its normal state. For regular switches, this is when the switch is closed, current flowing. For optos, this is when the switch is open (the IR beam is broken, switch is open).
> 
> This is also why, when running switch tests, and looking for help on here, you need to pay attention to whether the switch is Active - has an "(A)" after the name/status) or simply 'On'. 'On' is a misnomer, since optos are supposed to be on, other switches aren't.

This PR reverses the defaults for Opto switches.