### PR TITLE
plugins: add meta for System.Buffers. Remove trailing newlines from metas

### DIFF
--- a/VisualPinball.Engine/VisualPinball.Engine.csproj
+++ b/VisualPinball.Engine/VisualPinball.Engine.csproj
@@ -66,6 +66,8 @@
 
       <Plugins Include="$(OutDir)NetVips.dll" />
       <Plugins Include="$(NuGetPackageRoot)\netvips.native.$(RuntimeIdentifier)\8.11.0\runtimes\$(RuntimeIdentifier)\native\*" />
+
+      <Plugins Include="$(OutDir)System.Buffers.dll" />
     </ItemGroup>
     <Message Text="PluginsDeploy: @(Plugins)" />
     <Copy SourceFiles="@(Plugins)" DestinationFolder="..\VisualPinball.Unity\Plugins\$(RuntimeIdentifier)\" SkipUnchangedFiles="true" />

--- a/VisualPinball.Unity/Plugins/linux-x64/System.Buffers.dll.meta
+++ b/VisualPinball.Unity/Plugins/linux-x64/System.Buffers.dll.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b5836c2589934c088183e61d68d838bd
+guid: 288f8387623e436191fb14aa9c1abf80
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -18,8 +18,8 @@ PluginImporter:
       settings:
         Exclude Editor: 0
         Exclude Android: 1
-        Exclude Linux64: 1
-        Exclude OSXUniversal: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 1
         Exclude Win: 1
         Exclude Win64: 1
         Exclude iOS: 1
@@ -31,9 +31,9 @@ PluginImporter:
       settings:
         CPU: x86_64
         DefaultValueInitialized: true
-        OS: OSX
+        OS: Linux
   - first:
-      Standalone: OSXUniversal
+      Standalone: Linux64
     second:
       enabled: 1
       settings:

--- a/VisualPinball.Unity/Plugins/osx-x64/FluentAssertions.dll.meta
+++ b/VisualPinball.Unity/Plugins/osx-x64/FluentAssertions.dll.meta
@@ -41,4 +41,3 @@ PluginImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
- 

--- a/VisualPinball.Unity/Plugins/osx-x64/JeremyAnsel.Media.WavefrontObj.dll.meta
+++ b/VisualPinball.Unity/Plugins/osx-x64/JeremyAnsel.Media.WavefrontObj.dll.meta
@@ -41,4 +41,3 @@ PluginImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
- 

--- a/VisualPinball.Unity/Plugins/osx-x64/NetMiniZ.dll.meta
+++ b/VisualPinball.Unity/Plugins/osx-x64/NetMiniZ.dll.meta
@@ -41,4 +41,3 @@ PluginImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
- 

--- a/VisualPinball.Unity/Plugins/osx-x64/OpenMcdf.dll.meta
+++ b/VisualPinball.Unity/Plugins/osx-x64/OpenMcdf.dll.meta
@@ -41,4 +41,3 @@ PluginImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
- 

--- a/VisualPinball.Unity/Plugins/osx-x64/System.Buffers.dll.meta
+++ b/VisualPinball.Unity/Plugins/osx-x64/System.Buffers.dll.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b5836c2589934c088183e61d68d838bd
+guid: 790bd16b83804608b169d768f9eab5c6
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/VisualPinball.Unity/Plugins/osx-x64/VisualPinball.Resources.dll.meta
+++ b/VisualPinball.Unity/Plugins/osx-x64/VisualPinball.Resources.dll.meta
@@ -41,4 +41,3 @@ PluginImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
- 

--- a/VisualPinball.Unity/Plugins/win-x64/NetVips.dll.meta
+++ b/VisualPinball.Unity/Plugins/win-x64/NetVips.dll.meta
@@ -41,4 +41,3 @@ PluginImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
- 

--- a/VisualPinball.Unity/Plugins/win-x64/System.Buffers.dll.meta
+++ b/VisualPinball.Unity/Plugins/win-x64/System.Buffers.dll.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b5836c2589934c088183e61d68d838bd
+guid: 836b3fea9e594073abbd6c6b59cd51f5
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -19,9 +19,9 @@ PluginImporter:
         Exclude Editor: 0
         Exclude Android: 1
         Exclude Linux64: 1
-        Exclude OSXUniversal: 0
+        Exclude OSXUniversal: 1
         Exclude Win: 1
-        Exclude Win64: 1
+        Exclude Win64: 0
         Exclude iOS: 1
         Exclude tvOS: 1
   - first:
@@ -31,9 +31,9 @@ PluginImporter:
       settings:
         CPU: x86_64
         DefaultValueInitialized: true
-        OS: OSX
+        OS: Windows
   - first:
-      Standalone: OSXUniversal
+      Standalone: Win64
     second:
       enabled: 1
       settings:

--- a/VisualPinball.Unity/Plugins/win-x64/libvips-42.dll.meta
+++ b/VisualPinball.Unity/Plugins/win-x64/libvips-42.dll.meta
@@ -41,4 +41,3 @@ PluginImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-  

--- a/VisualPinball.Unity/Plugins/win-x86/FluentAssertions.dll.meta
+++ b/VisualPinball.Unity/Plugins/win-x86/FluentAssertions.dll.meta
@@ -41,4 +41,3 @@ PluginImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-  

--- a/VisualPinball.Unity/Plugins/win-x86/JeremyAnsel.Media.WavefrontObj.dll.meta
+++ b/VisualPinball.Unity/Plugins/win-x86/JeremyAnsel.Media.WavefrontObj.dll.meta
@@ -41,4 +41,3 @@ PluginImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-  

--- a/VisualPinball.Unity/Plugins/win-x86/NLog.dll.meta
+++ b/VisualPinball.Unity/Plugins/win-x86/NLog.dll.meta
@@ -41,4 +41,3 @@ PluginImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-  

--- a/VisualPinball.Unity/Plugins/win-x86/NetMiniZ.dll.meta
+++ b/VisualPinball.Unity/Plugins/win-x86/NetMiniZ.dll.meta
@@ -41,4 +41,3 @@ PluginImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-  

--- a/VisualPinball.Unity/Plugins/win-x86/OpenMcdf.dll.meta
+++ b/VisualPinball.Unity/Plugins/win-x86/OpenMcdf.dll.meta
@@ -41,4 +41,3 @@ PluginImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-  

--- a/VisualPinball.Unity/Plugins/win-x86/System.Buffers.dll.meta
+++ b/VisualPinball.Unity/Plugins/win-x86/System.Buffers.dll.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b5836c2589934c088183e61d68d838bd
+guid: 676eda95fc15421797a8709b43d4fd4e
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -19,8 +19,8 @@ PluginImporter:
         Exclude Editor: 0
         Exclude Android: 1
         Exclude Linux64: 1
-        Exclude OSXUniversal: 0
-        Exclude Win: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 0
         Exclude Win64: 1
         Exclude iOS: 1
         Exclude tvOS: 1
@@ -29,15 +29,15 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        CPU: x86_64
+        CPU: x86
         DefaultValueInitialized: true
-        OS: OSX
+        OS: Windows
   - first:
-      Standalone: OSXUniversal
+      Standalone: Win
     second:
       enabled: 1
       settings:
-        CPU: x86_64
+        CPU: x86
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/VisualPinball.Unity/Plugins/win-x86/VisualPinball.Resources.dll.meta
+++ b/VisualPinball.Unity/Plugins/win-x86/VisualPinball.Resources.dll.meta
@@ -41,4 +41,3 @@ PluginImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-  

--- a/VisualPinball.Unity/Plugins/win-x86/libglib-2.0-0.dll.meta
+++ b/VisualPinball.Unity/Plugins/win-x86/libglib-2.0-0.dll.meta
@@ -41,4 +41,3 @@ PluginImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-  

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1-preview.53",
   "displayName": "Visual Pinball Engine",
   "description": "Main project of the Visual Pinball Engine.",
-  "unity": "2020.2",
-  "unityRelease": "1f1",
+  "unity": "2020.3",
+  "unityRelease": "12f1",
   "dependencies": {
     "com.unity.burst": "1.4.4",
     "com.unity.collections": "0.15.0-preview.21",


### PR DESCRIPTION
This PR addresses the following issues:

When pulling down VPE from the registry, Unity was failing to find the `System.Buffers.dll` dependency for `NetVips`. (Unity does not error if you are using VPE locally.)

Unity was throwing errors finding blank new lines at the end of the meta files for several of the plugins. 