### PR TITLE
Share the same switch status object among multiple switch sources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Built with Unity 2021.2.
 - Put game-, mesh-, collision- animation data into separate components ([#227](https://github.com/freezy/VisualPinball.Engine/pull/227), [Documentation](https://docs.visualpinball.org/creators-guide/editor/unity-components.html)). 
 
 ### Fixed
+- Fixed switch status when multiple mappings point to the same ID ([#347](https://github.com/freezy/VisualPinball.Engine/pull/347)).
 - Lighting setup. It's now usable ([#330](https://github.com/freezy/VisualPinball.Engine/pull/330)).
 - Ball passing through collider plane and disappearing.
 - Alpha channel of color values is now correctly written ([#291](https://github.com/freezy/VisualPinball.Engine/pull/291)).

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/DeviceSwitch.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/DeviceSwitch.cs
@@ -59,8 +59,8 @@ namespace VisualPinball.Unity
 			_switchHandler = new SwitchHandler(name, player);
 		}
 
-		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig) =>
-			_switchHandler.AddSwitchDest(switchConfig.WithPulse(_isPulseSwitch).WithDefault(_switchDefault));
+		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig, IApiSwitchStatus switchStatus) =>
+			_switchHandler.AddSwitchDest(switchConfig.WithPulse(_isPulseSwitch).WithDefault(_switchDefault), switchStatus);
 		public void AddWireDest(WireDestConfig wireConfig) => _switchHandler.AddWireDest(wireConfig);
 		void IApiSwitch.RemoveWireDest(string destId) => _switchHandler.RemoveWireDest(destId);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/SwitchHandler.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/SwitchHandler.cs
@@ -36,7 +36,7 @@ namespace VisualPinball.Unity
 		/// </summary>
 		private List<WireDestConfig> _wires;
 
-		private readonly Dictionary<string, ItemSwitchStatus> _switchStatuses = new Dictionary<string, ItemSwitchStatus>();
+		private readonly Dictionary<string, IApiSwitchStatus> _switchStatuses = new Dictionary<string, IApiSwitchStatus>();
 
 		private static VisualPinballSimulationSystemGroup SimulationSystemGroup => World.DefaultGameObjectInjectionWorld.GetOrCreateSystem<VisualPinballSimulationSystemGroup>();
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
@@ -52,12 +52,14 @@ namespace VisualPinball.Unity
 		/// Set up this switch to send its status to the gamelogic engine with the given ID.
 		/// </summary>
 		/// <param name="switchConfig">Config containing gamelogic engine's switch ID and pulse settings</param>
-		internal IApiSwitchStatus AddSwitchDest(SwitchConfig switchConfig)
+		/// <param name="switchStatus">Since multiple switch destinations can map to a switch, we might already have a status object.</param>
+		internal IApiSwitchStatus AddSwitchDest(SwitchConfig switchConfig, IApiSwitchStatus switchStatus)
 		{
 			if (_switches == null) {
 				_switches = new List<SwitchConfig>();
 			}
-			var swStatus = new ItemSwitchStatus(switchConfig.IsNormallyClosed) { IsSwitchEnabled = IsEnabled };
+
+			var swStatus = switchStatus ?? new ItemSwitchStatus(switchConfig.IsNormallyClosed) { IsSwitchEnabled = IsEnabled };
 			_switches.Add(switchConfig);
 			_switchStatuses[switchConfig.SwitchId] = swStatus;
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/SwitchPlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/SwitchPlayer.cs
@@ -85,7 +85,8 @@ namespace VisualPinball.Unity
 							var device = _switchDevices[switchMapping.Device];
 							var deviceSwitch = device.Switch(switchMapping.DeviceItem);
 							if (deviceSwitch != null) {
-								var switchStatus = deviceSwitch.AddSwitchDest(new SwitchConfig(switchMapping));
+								var existingSwitchStatus = SwitchStatuses.ContainsKey(switchMapping.Id) ? SwitchStatuses[switchMapping.Id] : null;
+								var switchStatus = deviceSwitch.AddSwitchDest(new SwitchConfig(switchMapping), existingSwitchStatus);
 								SwitchStatuses[switchMapping.Id] = switchStatus;
 
 							} else {

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperApi.cs
@@ -48,7 +48,7 @@ namespace VisualPinball.Unity
 		#region Wiring
 
 		public bool IsSwitchEnabled => SwitchHandler.IsEnabled;
-		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig) => AddSwitchDest(switchConfig.WithPulse(true));
+		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig, IApiSwitchStatus switchStatus) => AddSwitchDest(switchConfig.WithPulse(true), switchStatus);
 		IApiSwitch IApiSwitchDevice.Switch(string deviceItem) => this;
 
 		IApiCoil IApiCoilDevice.Coil(string deviceItem) => this;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/CollisionSwitch/CollisionSwitchApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/CollisionSwitch/CollisionSwitchApi.cs
@@ -1,8 +1,23 @@
+// Visual Pinball Engine
+// Copyright (C) 2021 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 using System;
-using Logger = NLog.Logger;
 using NLog;
 using UnityEngine;
-using Unity.Entities;
+using Logger = NLog.Logger;
 
 namespace VisualPinball.Unity
 {
@@ -11,20 +26,20 @@ namespace VisualPinball.Unity
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
 		private readonly CollisionSwitchComponent _collisionSwitchComponent;
-		private Player _player;
+		private readonly Player _player;
 		private IApiHittable _hittable;
 
-		private protected readonly SwitchHandler SwitchHandler;
+		private readonly SwitchHandler _switchHandler;
 
 		public event EventHandler Init;
 		public event EventHandler<SwitchEventArgs> Switch;
 
-		public bool IsSwitchEnabled => SwitchHandler.IsEnabled;
-		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig) => SwitchHandler.AddSwitchDest(switchConfig.WithPulse(true));
-		void IApiSwitch.AddWireDest(WireDestConfig wireConfig) => SwitchHandler.AddWireDest(wireConfig.WithPulse(true));
-		void IApiSwitch.RemoveWireDest(string destId) => SwitchHandler.RemoveWireDest(destId);
+		public bool IsSwitchEnabled => _switchHandler.IsEnabled;
+		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig, IApiSwitchStatus switchStatus) => _switchHandler.AddSwitchDest(switchConfig.WithPulse(true), switchStatus);
+		void IApiSwitch.AddWireDest(WireDestConfig wireConfig) => _switchHandler.AddWireDest(wireConfig.WithPulse(true));
+		void IApiSwitch.RemoveWireDest(string destId) => _switchHandler.RemoveWireDest(destId);
 		IApiSwitch IApiSwitchDevice.Switch(string deviceItem) => this;
-		public void OnSwitch(bool closed) => SwitchHandler.OnSwitch(closed);
+		public void OnSwitch(bool closed) => _switchHandler.OnSwitch(closed);
 
 		public bool IsHittable => _hittable != null;
 
@@ -33,7 +48,7 @@ namespace VisualPinball.Unity
 			_collisionSwitchComponent = go.GetComponentInChildren<CollisionSwitchComponent>();
 			_player = player;
 
-			SwitchHandler = new SwitchHandler(go.name, player);
+			_switchHandler = new SwitchHandler(go.name, player);
 		}
 
 		void IApi.OnInit(BallManager ballManager)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperApi.cs
@@ -181,7 +181,7 @@ namespace VisualPinball.Unity
 		#region Wiring
 
 		public bool IsSwitchEnabled => SwitchHandler.IsEnabled;
-		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig) => AddSwitchDest(switchConfig);
+		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig, IApiSwitchStatus switchStatus) => AddSwitchDest(switchConfig, switchStatus);
 		void IApiSwitch.AddWireDest(WireDestConfig wireConfig) => AddWireDest(wireConfig);
 		void IApiSwitch.RemoveWireDest(string destId) => RemoveWireDest(destId);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateApi.cs
@@ -81,7 +81,7 @@ namespace VisualPinball.Unity
 		#region Wiring
 
 		public bool IsSwitchEnabled => SwitchHandler.IsEnabled;
-		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig) => AddSwitchDest(switchConfig.WithPulse(true));
+		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig, IApiSwitchStatus switchStatus) => AddSwitchDest(switchConfig.WithPulse(true), switchStatus);
 		void IApiSwitch.AddWireDest(WireDestConfig wireConfig) => AddWireDest(wireConfig.WithPulse(true));
 		void IApiSwitch.RemoveWireDest(string destId) => RemoveWireDest(destId);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/DropTargetApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/DropTargetApi.cs
@@ -93,7 +93,7 @@ namespace VisualPinball.Unity
 		#region Wiring
 
 		public bool IsSwitchEnabled => SwitchHandler.IsEnabled;
-		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig) => AddSwitchDest(switchConfig);
+		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig, IApiSwitchStatus switchStatus) => AddSwitchDest(switchConfig, switchStatus);
 		IApiSwitch IApiSwitchDevice.Switch(string deviceItem) => this;
 
 		void IApiSwitch.AddWireDest(WireDestConfig wireConfig) => AddWireDest(wireConfig);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetApi.cs
@@ -48,7 +48,7 @@ namespace VisualPinball.Unity
 		#region Wiring
 
 		public bool IsSwitchEnabled => SwitchHandler.IsEnabled;
-		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig) => AddSwitchDest(switchConfig.WithPulse(true));
+		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig, IApiSwitchStatus switchStatus) => AddSwitchDest(switchConfig.WithPulse(true), switchStatus);
 		void IApiSwitch.AddWireDest(WireDestConfig wireConfig) => AddWireDest(wireConfig.WithPulse(true));
 		void IApiSwitch.RemoveWireDest(string destId) => RemoveWireDest(destId);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/IApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/IApi.cs
@@ -142,7 +142,8 @@ namespace VisualPinball.Unity
 		/// Set up this switch to send its status to the gamelogic engine with the given ID.
 		/// </summary>
 		/// <param name="switchConfig">Config containing gamelogic engine's switch ID and pulse settings</param>
-		IApiSwitchStatus AddSwitchDest(SwitchConfig switchConfig);
+		/// <param name="switchStatus">Since multiple switch destinations can map to a switch, we might already have a status object.</param>
+		IApiSwitchStatus AddSwitchDest(SwitchConfig switchConfig, IApiSwitchStatus switchStatus);
 
 		/// <summary>
 		/// Set up this switch to directly trigger another game item (coil or lamp), or

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemApi.cs
@@ -66,7 +66,7 @@ namespace VisualPinball.Unity
 
 		private protected DeviceSwitch CreateSwitch(string name, bool isPulseSwitch, SwitchDefault switchDefault = SwitchDefault.Configurable) => new DeviceSwitch(name, isPulseSwitch, switchDefault, _player);
 
-		private protected IApiSwitchStatus AddSwitchDest(SwitchConfig switchConfig) => SwitchHandler.AddSwitchDest(switchConfig);
+		private protected IApiSwitchStatus AddSwitchDest(SwitchConfig switchConfig,IApiSwitchStatus switchStatus) => SwitchHandler.AddSwitchDest(switchConfig, switchStatus);
 
 		internal void AddWireDest(WireDestConfig wireConfig) => SwitchHandler.AddWireDest(wireConfig);
 		internal void RemoveWireDest(string destId) => SwitchHandler.RemoveWireDest(destId);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerApi.cs
@@ -235,7 +235,7 @@ namespace VisualPinball.Unity
 			}
 		}
 
-		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig) => AddSwitchDest(switchConfig.WithPulse(false));
+		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig, IApiSwitchStatus switchStatus) => AddSwitchDest(switchConfig.WithPulse(false), switchStatus);
 		void IApiSwitch.AddWireDest(WireDestConfig wireConfig) => AddWireDest(wireConfig.WithPulse(false));
 		void IApiSwitch.RemoveWireDest(string destId) => RemoveWireDest(destId);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerApi.cs
@@ -73,7 +73,7 @@ namespace VisualPinball.Unity
 		#region IApiSwitch
 
 		public bool IsSwitchEnabled => SwitchHandler.IsEnabled;
-		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig) => AddSwitchDest(switchConfig.WithPulse(true));
+		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig, IApiSwitchStatus switchStatus) => AddSwitchDest(switchConfig.WithPulse(true), switchStatus);
 		void IApiSwitch.AddWireDest(WireDestConfig wireConfig) => AddWireDest(wireConfig.WithPulse(true));
 		void IApiSwitch.RemoveWireDest(string destId) => RemoveWireDest(destId);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SlingshotApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SlingshotApi.cs
@@ -36,7 +36,7 @@ namespace VisualPinball.Unity
 		public event EventHandler<SwitchEventArgs> Switch;
 
 		public bool IsSwitchEnabled => _switchHandler.IsEnabled;
-		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig) => _switchHandler.AddSwitchDest(switchConfig.WithPulse(true));
+		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig, IApiSwitchStatus switchStatus) => _switchHandler.AddSwitchDest(switchConfig.WithPulse(true), switchStatus);
 		void IApiSwitch.AddWireDest(WireDestConfig wireConfig) => _switchHandler.AddWireDest(wireConfig.WithPulse(true));
 		void IApiSwitch.RemoveWireDest(string destId) => _switchHandler.RemoveWireDest(destId);
 		IApiSwitch IApiSwitchDevice.Switch(string deviceItem) => this;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerApi.cs
@@ -53,7 +53,7 @@ namespace VisualPinball.Unity
 		#region Wiring
 
 		public bool IsSwitchEnabled => SwitchHandler.IsEnabled;
-		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig) => AddSwitchDest(switchConfig);
+		IApiSwitchStatus IApiSwitch.AddSwitchDest(SwitchConfig switchConfig, IApiSwitchStatus switchStatus) => AddSwitchDest(switchConfig, switchStatus);
 		void IApiSwitch.AddWireDest(WireDestConfig wireConfig) => AddWireDest(wireConfig);
 		void IApiSwitch.RemoveWireDest(string destId) => RemoveWireDest(destId);
 


### PR DESCRIPTION
Since we can have multiple switch mappings pointing to the same switch but a dictionary by switch ID storing the statuses, each switch for the same ID would overwrite the status of the previous one. This PR fixes that by re-using the same status object for all switches of the same ID.