### PR TITLE
Fix editor performance 

### DIFF
--- a/VisualPinball.Engine.Test/VisualPinball.Engine.Test.csproj
+++ b/VisualPinball.Engine.Test/VisualPinball.Engine.Test.csproj
@@ -30,7 +30,7 @@
     </PackageReference>
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211109-03" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211130-02" />
     <PackageReference Include="FluentAssertions" Version="6.2.0" ExcludeAssets="Compile" />
     <PackageReference Include="JeremyAnsel.Media.WavefrontObj" Version="2.0.19" />
   </ItemGroup>

--- a/VisualPinball.Engine/Game/Engines/GamelogicEngineLamp.cs
+++ b/VisualPinball.Engine/Game/Engines/GamelogicEngineLamp.cs
@@ -106,6 +106,5 @@ namespace VisualPinball.Engine.Game.Engines
 		SingleFading = 1,
 		RgbMulti = 2,
 		Rgb = 3,
-		SingleOffOn = 4,
 	}
 }

--- a/VisualPinball.Engine/VisualPinball.Engine.csproj
+++ b/VisualPinball.Engine/VisualPinball.Engine.csproj
@@ -28,12 +28,12 @@
     <None Remove="obj\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.7.12" />
+    <PackageReference Include="NLog" Version="4.7.13" />
     <PackageReference Include="OpenMcdf" Version="2.2.1.9" />
     <PackageReference Include="NetMiniZ" Version="1.3.0-preview.1" />
     <PackageReference Include="NetMiniZ.Native" Version="1.3.0" />
-    <PackageReference Include="NetVips" Version="2.0.1" />
-    <PackageReference Include="NetVips.Native" Version="8.12.0-rc1" />
+    <PackageReference Include="NetVips" Version="2.1.0" />
+    <PackageReference Include="NetVips.Native" Version="8.12.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VisualPinball.Resources\VisualPinball.Resources.csproj" />
@@ -59,7 +59,7 @@
       <Plugins Include="$(NuGetPackageRoot)\netminiz.native.$(RuntimeIdentifier)\1.3.0\runtimes\$(RuntimeIdentifier)\native\*" />
 
       <Plugins Include="$(OutDir)NetVips.dll" />
-      <Plugins Include="$(NuGetPackageRoot)\netvips.native.$(RuntimeIdentifier)\8.12.0-rc1\runtimes\$(RuntimeIdentifier)\native\*" />
+      <Plugins Include="$(NuGetPackageRoot)\netvips.native.$(RuntimeIdentifier)\8.12.1\runtimes\$(RuntimeIdentifier)\native\*" />
 
       <Plugins Include="$(OutDir)System.Buffers.dll" />
     </ItemGroup>

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/PlayerInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Inspectors/PlayerInspector.cs
@@ -16,6 +16,7 @@
 
 using System.Linq;
 using UnityEditor;
+using UnityEngine;
 using VisualPinball.Engine.Common;
 
 namespace VisualPinball.Unity.Editor
@@ -32,6 +33,17 @@ namespace VisualPinball.Unity.Editor
 		private string[] _debugUINames;
 		private int _debugUIIndex;
 
+		private bool _toggleDebug = true;
+
+		private SerializedProperty _updateDuringGameplayProperty;
+
+		private void OnEnable()
+		{
+			var player = (Player)target;
+
+			_updateDuringGameplayProperty = serializedObject.FindProperty(nameof(player.UpdateDuringGamplay));
+		}
+		
 		public override void OnInspectorGUI()
 		{
 			var player = (Player) target;
@@ -40,6 +52,24 @@ namespace VisualPinball.Unity.Editor
 			}
 			DrawEngineSelector("Physics Engine", ref player.physicsEngineId, ref _physicsEngines, ref _physicsEngineNames, ref _physicsEngineIndex);
 			DrawEngineSelector("Debug UI", ref player.debugUiId, ref _debugUIs, ref _debugUINames, ref _debugUIIndex);
+
+			if (_toggleDebug = EditorGUILayout.BeginFoldoutHeaderGroup(_toggleDebug, "Debug"))
+			{
+				EditorGUI.indentLevel++;
+
+				EditorGUI.BeginChangeCheck();
+
+				EditorGUILayout.PropertyField(_updateDuringGameplayProperty, new GUIContent("Update During Gameplay"));
+
+				if (EditorGUI.EndChangeCheck())
+				{
+					serializedObject.ApplyModifiedProperties();
+				}
+
+				EditorGUI.indentLevel--;
+			}
+
+			EditorGUILayout.EndFoldoutHeaderGroup();
 		}
 
 		private void DrawEngineSelector<T>(string engineName, ref string engineId, ref T[] instances, ref string[] names, ref int index) where T : IEngine

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Lamp/LampListViewItemRenderer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Lamp/LampListViewItemRenderer.cs
@@ -102,12 +102,7 @@ namespace VisualPinball.Unity.Editor
 			lamp?.OnChange(pressedDown);
 			if (player.LampStatuses.ContainsKey(data.Id)) {
 
-				if (data.Type != LampType.SingleOffOn) {
-					player.LampStatuses[data.Id] = pressedDown ? 1 : 0;
-				}
-				else {
-					player.LampStatuses[data.Id] = pressedDown ? 0 : 1;
-				}
+				player.LampStatuses[data.Id] = pressedDown ? 1 : 0;
 			}
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/Rock.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Patcher/Patcher/Tables/Rock.cs
@@ -82,22 +82,20 @@ namespace VisualPinball.Unity.Patcher
 
 			var lampGroups = CreateEmptyGameObject(playfieldGo, "Lamp Groups");
 
-			var lampGroup1 = CreateEmptyGameObject(lampGroups, "LampGroup1");
+			AddLightGroup(tableGo, CreateEmptyGameObject(lampGroups, "LampGroupUpperLeft1"),
+				"gi26", "gi28", "gi25", "gi23");
 
-			AddLightGroup(tableGo, lampGroup1,
-				"gi2", "gi4", "gi6", "gi7", "gi9",
-				"gi10", "gi11", "gi12", "gi13", "gi14", "gi15", "gi16", "gi17", "gi18", "gi19",
-				"gi20", "gi21", "gi23", "gi25", "gi26", "gi28", "gi29",
-				"gi30", "gi31");
+			AddLightGroup(tableGo, CreateEmptyGameObject(lampGroups, "LampGroupUpperLeft2"),
+				"gi27", "gi24", "gi22");
 
-			var lampGroup12 = CreateEmptyGameObject(lampGroups, "LampGroup12");
+			AddLightGroup(tableGo, CreateEmptyGameObject(lampGroups, "LampGroupUpperRight"),
+				 "gi30", "gi31", "gi14", "gi29", "gi4", "gi2", "gi7", "gi9", "gi21",
+				 "gi20", "gi19", "gi18", "gi17", "gi16", "gi15", "gi13", "gi12", "gi11");
 
-			AddLightGroup(tableGo, lampGroup12,
-				"gi22", "gi24", "gi27");
+			AddLightGroup(tableGo, CreateEmptyGameObject(lampGroups, "LampGroupLower"),
+				 "gi6", "gi10");
 
-			var lampGroup13 = CreateEmptyGameObject(lampGroups, "LampGroup13");
-
-			AddLightGroup(tableGo, lampGroup13,
+			AddLightGroup(tableGo, CreateEmptyGameObject(lampGroups, "LampGroupAux"),
 				"AL1a", "AL1b", "AL2a", "AL2b", "AL3a", "AL3b", "AL4a", "AL4b",
 				"AL5a", "AL5b", "AL6a", "AL6b", "AL7a", "AL7b", "AL8a", "AL8b",
 				"AL9a", "AL10a");

--- a/VisualPinball.Unity/VisualPinball.Unity.Test/VisualPinball.Unity.Test.csproj
+++ b/VisualPinball.Unity/VisualPinball.Unity.Test/VisualPinball.Unity.Test.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211109-03" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211130-02" />
     <PackageReference Include="FluentAssertions" Version="6.2.0" ExcludeAssets="Compile" />
   </ItemGroup>
   <ItemGroup>

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/CoilPlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/CoilPlayer.cs
@@ -44,6 +44,7 @@ namespace VisualPinball.Unity
 		private IGamelogicEngine _gamelogicEngine;
 		private LampPlayer _lampPlayer;
 		private WirePlayer _wirePlayer;
+		private Player _player;
 
 		private bool _updateDuringGameplay = false;
 
@@ -62,7 +63,7 @@ namespace VisualPinball.Unity
 			_lampPlayer = lampPlayer;
 			_wirePlayer = wirePlayer;
 
-			_updateDuringGameplay = UnityEngine.Object.FindObjectOfType<Player>().UpdateDuringGamplay;
+			_player = UnityEngine.Object.FindObjectOfType<Player>();
 		}
 
 		public void OnStart()
@@ -164,9 +165,7 @@ namespace VisualPinball.Unity
 				}
 
 #if UNITY_EDITOR
-				if (_updateDuringGameplay) {
-					RepaintManagers();
-				}
+				RefreshUI();
 #endif
 
 			} else {
@@ -182,8 +181,12 @@ namespace VisualPinball.Unity
 		}
 
 #if UNITY_EDITOR
-		private void RepaintManagers()
+		private void RefreshUI()
 		{
+			if (!_player.UpdateDuringGamplay) {
+				return;
+			}
+
 			foreach (var manager in (EditorWindow[])Resources.FindObjectsOfTypeAll(Type.GetType("VisualPinball.Unity.Editor.CoilManager, VisualPinball.Unity.Editor"))) {
 				manager.Repaint();
 			}

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/CoilPlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/CoilPlayer.cs
@@ -39,11 +39,11 @@ namespace VisualPinball.Unity
 		/// </summary>
 		private readonly Dictionary<string, List<CoilDestConfig>> _coilAssignments = new Dictionary<string, List<CoilDestConfig>>();
 
+		private Player _player;
 		private TableComponent _tableComponent;
 		private IGamelogicEngine _gamelogicEngine;
 		private LampPlayer _lampPlayer;
 		private WirePlayer _wirePlayer;
-		private Player _player;
 
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
@@ -53,14 +53,13 @@ namespace VisualPinball.Unity
 		internal IApiCoil Coil(ICoilDeviceComponent component, string coilItem)
 			=> _coilDevices.ContainsKey(component) ? _coilDevices[component].Coil(coilItem) : null;
 
-		public void Awake(TableComponent tableComponent, IGamelogicEngine gamelogicEngine, LampPlayer lampPlayer, WirePlayer wirePlayer)
+		public void Awake(Player player, TableComponent tableComponent, IGamelogicEngine gamelogicEngine, LampPlayer lampPlayer, WirePlayer wirePlayer)
 		{
+			_player = player;
 			_tableComponent = tableComponent;
 			_gamelogicEngine = gamelogicEngine;
 			_lampPlayer = lampPlayer;
 			_wirePlayer = wirePlayer;
-
-			_player = UnityEngine.Object.FindObjectOfType<Player>();
 		}
 
 		public void OnStart()

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/CoilPlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/CoilPlayer.cs
@@ -23,7 +23,6 @@ using Logger = NLog.Logger;
 
 #if UNITY_EDITOR
 using UnityEditor;
-
 #endif
 
 namespace VisualPinball.Unity
@@ -45,8 +44,6 @@ namespace VisualPinball.Unity
 		private LampPlayer _lampPlayer;
 		private WirePlayer _wirePlayer;
 		private Player _player;
-
-		private bool _updateDuringGameplay = false;
 
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/DeviceCoil.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/DeviceCoil.cs
@@ -26,10 +26,11 @@ namespace VisualPinball.Unity
 		protected Action OnEnable;
 		protected Action OnDisable;
 
-		private Player _player;
+		private readonly Player _player;
 
-		public DeviceCoil(Action onEnable = null, Action onDisable = null)
+		public DeviceCoil(Player player, Action onEnable = null, Action onDisable = null)
 		{
+			_player = player;
 			OnEnable = onEnable;
 			OnDisable = onDisable;
 		}
@@ -52,10 +53,6 @@ namespace VisualPinball.Unity
 #if UNITY_EDITOR
 		private void RefreshUI()
 		{
-			if (_player == null) {
-				_player = UnityEngine.Object.FindObjectOfType<Player>();
-			}
-
 			if (!_player.UpdateDuringGamplay) {
 				return;
 			}

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/DeviceCoil.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/DeviceCoil.cs
@@ -21,12 +21,12 @@ namespace VisualPinball.Unity
 {
 	public class DeviceCoil : IApiCoil
 	{
-		private Player _player;
-
 		public bool IsEnabled;
 
 		protected Action OnEnable;
 		protected Action OnDisable;
+
+		private Player _player;
 
 		public DeviceCoil(Action onEnable = null, Action onDisable = null)
 		{
@@ -37,12 +37,9 @@ namespace VisualPinball.Unity
 		public void OnCoil(bool enabled)
 		{
 			IsEnabled = enabled;
-			if (enabled)
-			{
+			if (enabled) {
 				OnEnable?.Invoke();
-			}
-			else
-			{
+			} else {
 				OnDisable?.Invoke();
 			}
 #if UNITY_EDITOR

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/DeviceCoil.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/DeviceCoil.cs
@@ -15,10 +15,11 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using UnityEngine;
 
 namespace VisualPinball.Unity
 {
-	public class DeviceCoil: IApiCoil
+	public class DeviceCoil : IApiCoil
 	{
 		public bool IsEnabled;
 
@@ -34,16 +35,29 @@ namespace VisualPinball.Unity
 		public void OnCoil(bool enabled)
 		{
 			IsEnabled = enabled;
-			if (enabled) {
+			if (enabled)
+			{
 				OnEnable?.Invoke();
-			} else {
+			}
+			else
+			{
 				OnDisable?.Invoke();
 			}
 #if UNITY_EDITOR
-			UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+			RefreshEditor();
 #endif
 		}
 
 		public void OnChange(bool enabled) => OnCoil(enabled);
+
+#if UNITY_EDITOR
+		private static void RefreshEditor()
+		{
+			foreach (var editor in (UnityEditor.Editor[])Resources.FindObjectsOfTypeAll(Type.GetType("VisualPinball.Unity.Editor.TroughInspector, VisualPinball.Unity.Editor")))
+			{
+				editor.Repaint();
+			}
+		}
+#endif
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/DeviceCoil.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/DeviceCoil.cs
@@ -21,6 +21,8 @@ namespace VisualPinball.Unity
 {
 	public class DeviceCoil : IApiCoil
 	{
+		private Player _player;
+
 		public bool IsEnabled;
 
 		protected Action OnEnable;
@@ -44,17 +46,24 @@ namespace VisualPinball.Unity
 				OnDisable?.Invoke();
 			}
 #if UNITY_EDITOR
-			RefreshEditor();
+			RefreshUI();
 #endif
 		}
 
 		public void OnChange(bool enabled) => OnCoil(enabled);
 
 #if UNITY_EDITOR
-		private static void RefreshEditor()
+		private void RefreshUI()
 		{
-			foreach (var editor in (UnityEditor.Editor[])Resources.FindObjectsOfTypeAll(Type.GetType("VisualPinball.Unity.Editor.TroughInspector, VisualPinball.Unity.Editor")))
-			{
+			if (_player == null) {
+				_player = UnityEngine.Object.FindObjectOfType<Player>();
+			}
+
+			if (!_player.UpdateDuringGamplay) {
+				return;
+			}
+
+			foreach (var editor in (UnityEditor.Editor[])Resources.FindObjectsOfTypeAll(Type.GetType("VisualPinball.Unity.Editor.TroughInspector, VisualPinball.Unity.Editor"))) {
 				editor.Repaint();
 			}
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/LampPlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/LampPlayer.cs
@@ -80,10 +80,10 @@ namespace VisualPinball.Unity
 
 					AssignLampMapping(lampMapping);
 
-					// turn all lamps off (or on if SingleOffOn)
+					// turn it off
 
 					if (_lamps.ContainsKey(lampMapping.Device)) {
-						_lamps[lampMapping.Device].OnLamp(lampMapping.Type != LampType.SingleOffOn ? 1f : 0f, ColorChannel.Alpha);
+						_lamps[lampMapping.Device].OnLamp(0f, ColorChannel.Alpha);
 					}
 				}
 
@@ -125,10 +125,6 @@ namespace VisualPinball.Unity
 
 							case LampType.SingleFading:
 								value = lampEvent.Value / (float)mapping.FadingSteps;
-								break;
-
-							case LampType.SingleOffOn:
-								value = lampEvent.Value > 0 ? 0f : 1f;
 								break;
 
 							default:

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/LampPlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/LampPlayer.cs
@@ -48,6 +48,7 @@ namespace VisualPinball.Unity
 
 		private TableComponent _tableComponent;
 		private IGamelogicEngine _gamelogicEngine;
+		private Player _player;
 
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
@@ -64,7 +65,7 @@ namespace VisualPinball.Unity
 			_tableComponent = tableComponent;
 			_gamelogicEngine = gamelogicEngine;
 
-			_updateDuringGameplay = UnityEngine.Object.FindObjectOfType<Player>().UpdateDuringGamplay;
+			_player = UnityEngine.Object.FindObjectOfType<Player>();
 		}
 
 		public void OnStart()
@@ -144,9 +145,7 @@ namespace VisualPinball.Unity
 				}
 
 #if UNITY_EDITOR
-				if (_updateDuringGameplay) {
-					RepaintManagers();
-				}
+				RefreshUI();
 #endif
 			}
 		}
@@ -222,8 +221,12 @@ namespace VisualPinball.Unity
 		}
 
 #if UNITY_EDITOR
-		private void RepaintManagers()
+		private void RefreshUI()
 		{
+			if (!_player.UpdateDuringGamplay) {
+				return;
+			}
+
 			foreach (var manager in (EditorWindow[])Resources.FindObjectsOfTypeAll(Type.GetType("VisualPinball.Unity.Editor.LampManager, VisualPinball.Unity.Editor"))) {
 				manager.Repaint();
 			}

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/LampPlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/LampPlayer.cs
@@ -46,9 +46,9 @@ namespace VisualPinball.Unity
 		/// </summary>
 		private readonly Dictionary<string, Dictionary<ILampDeviceComponent, LampMapping>> _lampMappings = new Dictionary<string, Dictionary<ILampDeviceComponent, LampMapping>>();
 
+		private Player _player;
 		private TableComponent _tableComponent;
 		private IGamelogicEngine _gamelogicEngine;
-		private Player _player;
 
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
@@ -57,15 +57,12 @@ namespace VisualPinball.Unity
 
 		internal Dictionary<string, float> LampStatuses { get; } = new Dictionary<string, float>();
 		internal void RegisterLamp(ILampDeviceComponent component, IApiLamp lampApi) => _lamps[component] = lampApi;
-
-		private bool _updateDuringGameplay = false;
 		
-		public void Awake(TableComponent tableComponent, IGamelogicEngine gamelogicEngine)
+		public void Awake(Player player, TableComponent tableComponent, IGamelogicEngine gamelogicEngine)
 		{
+			_player = player;
 			_tableComponent = tableComponent;
 			_gamelogicEngine = gamelogicEngine;
-
-			_player = UnityEngine.Object.FindObjectOfType<Player>();
 		}
 
 		public void OnStart()

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
@@ -51,7 +51,7 @@ namespace VisualPinball.Unity
 		[HideInInspector] [SerializeField] public string debugUiId;
 		[HideInInspector] [SerializeField] public string physicsEngineId;
 
-		[Tooltip("UpdateDuringGamplay")]
+		[Tooltip("When enabled, update the switch, coil, lamp and wire manager windows in the editor (slower performance)")]
 		public bool UpdateDuringGamplay = true;
 
 		// table related

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
@@ -134,8 +134,8 @@ namespace VisualPinball.Unity
 
 			if (engineComponent != null) {
 				GamelogicEngine = engineComponent;
-				_lampPlayer.Awake(_tableComponent, GamelogicEngine);
-				_coilPlayer.Awake(_tableComponent, GamelogicEngine, _lampPlayer, _wirePlayer);
+				_lampPlayer.Awake(this, _tableComponent, GamelogicEngine);
+				_coilPlayer.Awake(this, _tableComponent, GamelogicEngine, _lampPlayer, _wirePlayer);
 				_switchPlayer.Awake(_tableComponent, GamelogicEngine, _inputManager);
 				_wirePlayer.Awake(_tableComponent, _inputManager, _switchPlayer, this);
 				_displayPlayer.Awake(GamelogicEngine);

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
@@ -51,6 +51,9 @@ namespace VisualPinball.Unity
 		[HideInInspector] [SerializeField] public string debugUiId;
 		[HideInInspector] [SerializeField] public string physicsEngineId;
 
+		[Tooltip("UpdateDuringGamplay")]
+		public bool UpdateDuringGamplay = true;
+
 		// table related
 		private readonly List<IApi> _apis = new List<IApi>();
 		private readonly List<IApiColliderGenerator> _colliderGenerators = new List<IApiColliderGenerator>();

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/SwitchHandler.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/SwitchHandler.cs
@@ -119,9 +119,7 @@ namespace VisualPinball.Unity
 								IsEnabled = false;
 								_switchStatuses[switchConfig.SwitchId].IsSwitchEnabled = false;
 #if UNITY_EDITOR
-								if (_player.UpdateDuringGamplay) {
-									RepaintManagers();
-								}
+								RefreshUI();
 #endif
 							});
 					}
@@ -139,9 +137,7 @@ namespace VisualPinball.Unity
 			IsEnabled = enabled;
 
 #if UNITY_EDITOR
-			if (_player.UpdateDuringGamplay) {
-				RepaintManagers();
-			}
+			RefreshUI();
 #endif
 		}
 
@@ -179,18 +175,19 @@ namespace VisualPinball.Unity
 				onSwitched.Invoke(enabled);
 
 #if UNITY_EDITOR
-				if (_player.UpdateDuringGamplay) {
-					RepaintManagers();
-				}
+				RefreshUI();
 #endif
 			});
 		}
 
 #if UNITY_EDITOR
-		private void RepaintManagers()
+		private void RefreshUI()
 		{
-			foreach (var manager in (EditorWindow[])Resources.FindObjectsOfTypeAll(Type.GetType("VisualPinball.Unity.Editor.SwitchManager, VisualPinball.Unity.Editor")))
-			{
+			if (!_player.UpdateDuringGamplay) {
+				return;
+			}
+
+			foreach (var manager in (EditorWindow[])Resources.FindObjectsOfTypeAll(Type.GetType("VisualPinball.Unity.Editor.SwitchManager, VisualPinball.Unity.Editor"))) {
 				manager.Repaint();
 			}
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/SwitchHandler.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/SwitchHandler.cs
@@ -5,6 +5,10 @@ using Unity.Entities;
 using UnityEngine;
 using Logger = NLog.Logger;
 
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
 namespace VisualPinball.Unity
 {
 	/// <summary>
@@ -115,7 +119,9 @@ namespace VisualPinball.Unity
 								IsEnabled = false;
 								_switchStatuses[switchConfig.SwitchId].IsSwitchEnabled = false;
 #if UNITY_EDITOR
-								UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+								if (_player.UpdateDuringGamplay) {
+									RepaintManagers();
+								}
 #endif
 							});
 					}
@@ -133,7 +139,9 @@ namespace VisualPinball.Unity
 			IsEnabled = enabled;
 
 #if UNITY_EDITOR
-			UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+			if (_player.UpdateDuringGamplay) {
+				RepaintManagers();
+			}
 #endif
 		}
 
@@ -168,12 +176,25 @@ namespace VisualPinball.Unity
 				Debug.Log($"Setting scheduled switch {Name} to {enabled}.");
 				IsEnabled = enabled;
 
-#if UNITY_EDITOR
-				UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
-#endif
 				onSwitched.Invoke(enabled);
+
+#if UNITY_EDITOR
+				if (_player.UpdateDuringGamplay) {
+					RepaintManagers();
+				}
+#endif
 			});
 		}
+
+#if UNITY_EDITOR
+		private void RepaintManagers()
+		{
+			foreach (var manager in (EditorWindow[])Resources.FindObjectsOfTypeAll(Type.GetType("VisualPinball.Unity.Editor.SwitchManager, VisualPinball.Unity.Editor")))
+			{
+				manager.Repaint();
+			}
+		}
+#endif
 	}
 
 	internal class ItemSwitchStatus : IApiSwitchStatus

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/SwitchPlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/SwitchPlayer.cs
@@ -15,9 +15,9 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System.Collections.Generic;
-using System.Linq;
-using NLog;
 using UnityEngine.InputSystem;
+using NLog;
+using Logger = NLog.Logger;
 
 namespace VisualPinball.Unity
 {

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/WirePlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/WirePlayer.cs
@@ -285,10 +285,11 @@ namespace VisualPinball.Unity
 										WireStatuses[wireConfig.Id] = (WireStatuses[wireConfig.Id].Item1, -1);
 									}
 								}
-								#if UNITY_EDITOR
-									//UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
-								#endif
-							} else {
+#if UNITY_EDITOR
+								RefreshUI();
+#endif
+							}
+							else {
 								Logger.Warn($"Unknown wire \"{wireConfig.DeviceItem}\" in wire device \"{wireConfig.Device}\".");
 							}
 						}
@@ -313,9 +314,9 @@ namespace VisualPinball.Unity
 							SimulationSystemGroup.ScheduleAction(wireConfig.PulseDelay, () => {
 								wire.OnChange(false);
 								WireStatuses[wireConfig.Id] = (false, 0);
-								#if UNITY_EDITOR
-									//UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
-								#endif
+#if UNITY_EDITOR
+								RefreshUI();
+#endif
 							});
 						}
 
@@ -331,9 +332,9 @@ namespace VisualPinball.Unity
 								SimulationSystemGroup.ScheduleAction(wireConfig.PulseDelay, () => {
 									wire.OnChange(false);
 									WireStatuses[wireConfig.Id] = (false, -2);
-									#if UNITY_EDITOR
-										//UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
-									#endif
+#if UNITY_EDITOR
+									RefreshUI();
+#endif
 								});
 							}
 
@@ -341,9 +342,10 @@ namespace VisualPinball.Unity
 							WireStatuses[wireConfig.Id] = (WireStatuses[wireConfig.Id].Item1, -1);
 						}
 					}
-					#if UNITY_EDITOR
-						//UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
-					#endif
+
+#if UNITY_EDITOR
+					RefreshUI();
+#endif
 				}
 
 			} else {
@@ -393,9 +395,7 @@ namespace VisualPinball.Unity
 						}
 
 #if UNITY_EDITOR
-						if (_player.UpdateDuringGamplay) {
-							repaintManagers();
-						}
+						RefreshUI();
 #endif
 
 					} else {
@@ -431,8 +431,12 @@ namespace VisualPinball.Unity
 		#endregion
 
 #if UNITY_EDITOR
-		private void repaintManagers()
+		private void RefreshUI()
 		{
+			if (!_player.UpdateDuringGamplay) {
+				return;
+			}
+
 			foreach (var manager in (EditorWindow[])Resources.FindObjectsOfTypeAll(Type.GetType("VisualPinball.Unity.Editor.WireManager, VisualPinball.Unity.Editor")))
 			{
 				manager.Repaint();

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/WirePlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/WirePlayer.cs
@@ -17,11 +17,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NLog;
 using Unity.Entities;
 using UnityEngine;
 using UnityEngine.InputSystem;
+using NLog;
 using Logger = NLog.Logger;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace VisualPinball.Unity
 {
@@ -282,7 +286,7 @@ namespace VisualPinball.Unity
 									}
 								}
 								#if UNITY_EDITOR
-									UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+									//UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
 								#endif
 							} else {
 								Logger.Warn($"Unknown wire \"{wireConfig.DeviceItem}\" in wire device \"{wireConfig.Device}\".");
@@ -310,7 +314,7 @@ namespace VisualPinball.Unity
 								wire.OnChange(false);
 								WireStatuses[wireConfig.Id] = (false, 0);
 								#if UNITY_EDITOR
-									UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+									//UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
 								#endif
 							});
 						}
@@ -328,7 +332,7 @@ namespace VisualPinball.Unity
 									wire.OnChange(false);
 									WireStatuses[wireConfig.Id] = (false, -2);
 									#if UNITY_EDITOR
-										UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+										//UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
 									#endif
 								});
 							}
@@ -338,7 +342,7 @@ namespace VisualPinball.Unity
 						}
 					}
 					#if UNITY_EDITOR
-						UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+						//UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
 					#endif
 				}
 
@@ -388,9 +392,11 @@ namespace VisualPinball.Unity
 							WireStatuses[wireConfig.Id] = (isEnabled, lagSec);
 						}
 
-						#if UNITY_EDITOR
-							UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
-						#endif
+#if UNITY_EDITOR
+						if (_player.UpdateDuringGamplay) {
+							repaintManagers();
+						}
+#endif
 
 					} else {
 						// so we got a coil with no or too old switch in the queue. we assume this comes from the GLE
@@ -423,6 +429,16 @@ namespace VisualPinball.Unity
 		}
 
 		#endregion
+
+#if UNITY_EDITOR
+		private void repaintManagers()
+		{
+			foreach (var manager in (EditorWindow[])Resources.FindObjectsOfTypeAll(Type.GetType("VisualPinball.Unity.Editor.WireManager, VisualPinball.Unity.Editor")))
+			{
+				manager.Repaint();
+			}
+		}
+#endif
 	}
 
 	public class WireDestConfig

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/DropTargetBank/DropTargetBankApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/DropTargetBank/DropTargetBankApi.cs
@@ -11,9 +11,9 @@ namespace VisualPinball.Unity
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
 		private readonly DropTargetBankComponent _dropTargetBankComponent;
-		private Player _player;
+		private readonly Player _player;
 
-		private List<DropTargetApi> _dropTargetApis = new List<DropTargetApi>();
+		private readonly List<DropTargetApi> _dropTargetApis = new List<DropTargetApi>();
 		public DeviceCoil ResetCoil;
 
 		public event EventHandler Init;
@@ -37,8 +37,8 @@ namespace VisualPinball.Unity
 
 		void IApi.OnInit(BallManager ballManager)
 		{
-			ResetCoil = new DeviceCoil(OnResetCoilEnabled);
-			
+			ResetCoil = new DeviceCoil(_player, OnResetCoilEnabled);
+
 			for (var index = 0; index < _dropTargetBankComponent.BankSize; index++)
 			{
 				_dropTargetApis.Add(_player.TableApi.DropTarget(_dropTargetBankComponent.DropTargets[index]));

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperApi.cs
@@ -81,8 +81,8 @@ namespace VisualPinball.Unity
 			base.OnInit(ballManager);
 			Init?.Invoke(this, EventArgs.Empty);
 
-			_mainCoil = new DeviceCoil(OnMainCoilEnabled, OnMainCoilDisabled);
-			_holdCoil = new DeviceCoil(OnHoldCoilEnabled, OnHoldCoilDisabled);
+			_mainCoil = new DeviceCoil(Player, OnMainCoilEnabled, OnMainCoilDisabled);
+			_holdCoil = new DeviceCoil(Player, OnHoldCoilEnabled, OnHoldCoilDisabled);
 		}
 
 		void IApi.OnDestroy()

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemApi.cs
@@ -39,11 +39,11 @@ namespace VisualPinball.Unity
 
 		internal readonly GameObject GameObject;
 
-		private protected TableApi TableApi => _player.TableApi;
+		private protected TableApi TableApi => Player.TableApi;
 
 		internal VisualPinballSimulationSystemGroup SimulationSystemGroup => World.DefaultGameObjectInjectionWorld.GetOrCreateSystem<VisualPinballSimulationSystemGroup>();
 
-		private protected readonly Player _player;
+		private protected readonly Player Player;
 		private protected readonly SwitchHandler SwitchHandler;
 		private protected BallManager BallManager;
 		private protected TableComponent TableComponent;
@@ -52,7 +52,7 @@ namespace VisualPinball.Unity
 		{
 			GameObject = go;
 			MainComponent = go.GetComponent<TComponent>();
-			_player = player;
+			Player = player;
 			SwitchHandler = new SwitchHandler(Name, player);
 		}
 
@@ -64,7 +64,7 @@ namespace VisualPinball.Unity
 
 		#region IApiSwitchable
 
-		private protected DeviceSwitch CreateSwitch(string name, bool isPulseSwitch, SwitchDefault switchDefault = SwitchDefault.Configurable) => new DeviceSwitch(name, isPulseSwitch, switchDefault, _player);
+		private protected DeviceSwitch CreateSwitch(string name, bool isPulseSwitch, SwitchDefault switchDefault = SwitchDefault.Configurable) => new DeviceSwitch(name, isPulseSwitch, switchDefault, Player);
 
 		private protected IApiSwitchStatus AddSwitchDest(SwitchConfig switchConfig,IApiSwitchStatus switchStatus) => SwitchHandler.AddSwitchDest(switchConfig, switchStatus);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemApi.cs
@@ -43,7 +43,7 @@ namespace VisualPinball.Unity
 
 		internal VisualPinballSimulationSystemGroup SimulationSystemGroup => World.DefaultGameObjectInjectionWorld.GetOrCreateSystem<VisualPinballSimulationSystemGroup>();
 
-		private readonly Player _player;
+		private protected readonly Player _player;
 		private protected readonly SwitchHandler SwitchHandler;
 		private protected BallManager BallManager;
 		private protected TableComponent TableComponent;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerApi.cs
@@ -58,7 +58,7 @@ namespace VisualPinball.Unity
 			: base(go, entity, parentEntity, player)
 		{
 			foreach (var coil in MainComponent.Coils) {
-				_coils[coil.Id] = new KickerDeviceCoil(coil, this);
+				_coils[coil.Id] = new KickerDeviceCoil(player, coil, this);
 			}
 		}
 
@@ -278,7 +278,7 @@ namespace VisualPinball.Unity
 		public readonly KickerCoil Coil;
 		private readonly KickerApi _kickerApi;
 
-		public KickerDeviceCoil(KickerCoil coil, KickerApi api)
+		public KickerDeviceCoil(Player player, KickerCoil coil, KickerApi api) : base(player)
 		{
 			Coil = coil;
 			_kickerApi = api;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Mech/StepRotatorMechApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Mech/StepRotatorMechApi.cs
@@ -59,7 +59,7 @@ namespace VisualPinball.Unity
 			_currentStep = 0;
 			_direction = Direction.Forward;
 
-			_motorCoil = new DeviceCoil(OnMotorCoilEnabled, OnMotorCoilDisabled);
+			_motorCoil = new DeviceCoil(_player, OnMotorCoilEnabled, OnMotorCoilDisabled);
 
 			_marks = _component.Marks.ToDictionary(m => m.SwitchId, m => m);
 			_switches = _component.Marks.ToDictionary(m => m.SwitchId, m => new DeviceSwitch(m.SwitchId, false, SwitchDefault.NormallyOpen, _player));

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerApi.cs
@@ -79,8 +79,8 @@ namespace VisualPinball.Unity
 			base.OnInit(ballManager);
 			Init?.Invoke(this, EventArgs.Empty);
 
-			PullCoil = new DeviceCoil(PullBack, Fire);
-			FireCoil = new DeviceCoil(Fire);
+			PullCoil = new DeviceCoil(Player, PullBack, Fire);
+			FireCoil = new DeviceCoil(Player, Fire);
 		}
 
 		void IApi.OnDestroy()

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Teleporter/TeleporterApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Teleporter/TeleporterApi.cs
@@ -48,7 +48,7 @@ namespace VisualPinball.Unity
 
 		void IApi.OnInit(BallManager ballManager)
 		{
-			_teleporterCoil = new DeviceCoil(OnTeleport);
+			_teleporterCoil = new DeviceCoil(_player, OnTeleport);
 			_fromKicker = _player.TableApi.Kicker(_component.FromKicker);
 			_toKicker = _player.TableApi.Kicker(_component.ToKicker);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughApi.cs
@@ -16,11 +16,12 @@
 
 using System;
 using System.Collections.Generic;
-using NLog;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Trough;
+using NLog;
 using Logger = NLog.Logger;
+using UnityEditor;
 
 namespace VisualPinball.Unity
 {
@@ -316,8 +317,9 @@ namespace VisualPinball.Unity
 				default:
 					throw new ArgumentOutOfRangeException();
 			}
-
-			RefreshUI();
+#if UNITY_EDITOR
+			RefreshEditor();
+#endif
 		}
 
 		/// <summary>
@@ -357,7 +359,9 @@ namespace VisualPinball.Unity
 				default:
 					throw new ArgumentOutOfRangeException();
 			}
-			RefreshUI();
+#if UNITY_EDITOR
+			RefreshEditor();
+#endif
 		}
 
 		private void DrainNextUncountedBall()
@@ -487,7 +491,9 @@ namespace VisualPinball.Unity
 				TriggerJamSwitch();
 				RollOverStackBalls();
 				RollOverNextUncountedStackBall();
-				RefreshUI();
+#if UNITY_EDITOR
+				RefreshEditor();
+#endif
 				return true;
 			}
 
@@ -554,10 +560,14 @@ namespace VisualPinball.Unity
 		private void OnLastStackSwitch(object sender, SwitchEventArgs switchEventArgs)
 		{
 			if (!switchEventArgs.IsEnabled && UncountedStackBalls > 0) {
-				RefreshUI();
+#if UNITY_EDITOR
+				RefreshEditor();
+#endif
 				UncountedStackBalls--;
 				RollOverEntryBall(MainComponent.RollTime / 2);
-				RefreshUI();
+#if UNITY_EDITOR
+				RefreshEditor();
+#endif
 			}
 		}
 
@@ -587,12 +597,14 @@ namespace VisualPinball.Unity
 			UncountedStackBalls--;
 		}
 
-		private static void RefreshUI()
-		{
 #if UNITY_EDITOR
-			UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
-#endif
+		private static void RefreshEditor()
+		{
+			foreach (var editor in (UnityEditor.Editor[])Resources.FindObjectsOfTypeAll(Type.GetType("VisualPinball.Unity.Editor.TroughInspector, VisualPinball.Unity.Editor"))) {
+				editor.Repaint();
+			}
 		}
+#endif
 
 		#region Wiring
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughApi.cs
@@ -318,7 +318,7 @@ namespace VisualPinball.Unity
 					throw new ArgumentOutOfRangeException();
 			}
 #if UNITY_EDITOR
-			RefreshEditor();
+			RefreshUI();
 #endif
 		}
 
@@ -360,7 +360,7 @@ namespace VisualPinball.Unity
 					throw new ArgumentOutOfRangeException();
 			}
 #if UNITY_EDITOR
-			RefreshEditor();
+			RefreshUI();
 #endif
 		}
 
@@ -492,7 +492,7 @@ namespace VisualPinball.Unity
 				RollOverStackBalls();
 				RollOverNextUncountedStackBall();
 #if UNITY_EDITOR
-				RefreshEditor();
+				RefreshUI();
 #endif
 				return true;
 			}
@@ -561,12 +561,12 @@ namespace VisualPinball.Unity
 		{
 			if (!switchEventArgs.IsEnabled && UncountedStackBalls > 0) {
 #if UNITY_EDITOR
-				RefreshEditor();
+				RefreshUI();
 #endif
 				UncountedStackBalls--;
 				RollOverEntryBall(MainComponent.RollTime / 2);
 #if UNITY_EDITOR
-				RefreshEditor();
+				RefreshUI();
 #endif
 			}
 		}
@@ -598,8 +598,12 @@ namespace VisualPinball.Unity
 		}
 
 #if UNITY_EDITOR
-		private static void RefreshEditor()
+		private void RefreshUI()
 		{
+			if (!_player.UpdateDuringGamplay) {
+				return;
+			}
+			
 			foreach (var editor in (UnityEditor.Editor[])Resources.FindObjectsOfTypeAll(Type.GetType("VisualPinball.Unity.Editor.TroughInspector, VisualPinball.Unity.Editor"))) {
 				editor.Repaint();
 			}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughApi.cs
@@ -600,7 +600,7 @@ namespace VisualPinball.Unity
 #if UNITY_EDITOR
 		private void RefreshUI()
 		{
-			if (!_player.UpdateDuringGamplay) {
+			if (!Player.UpdateDuringGamplay) {
 				return;
 			}
 			

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughApi.cs
@@ -216,8 +216,8 @@ namespace VisualPinball.Unity
 			}
 
 			// setup coils
-			EntryCoil = new DeviceCoil(OnEntryCoilEnabled);
-			ExitCoil = new DeviceCoil(() => EjectBall());
+			EntryCoil = new DeviceCoil(Player, OnEntryCoilEnabled);
+			ExitCoil = new DeviceCoil(Player, () => EjectBall());
 
 			// fill up the ball stack
 			var ballCount = MainComponent.Type == TroughType.ClassicSingleBall ? 1 : MainComponent.BallCount;
@@ -603,7 +603,7 @@ namespace VisualPinball.Unity
 			if (!Player.UpdateDuringGamplay) {
 				return;
 			}
-			
+
 			foreach (var editor in (UnityEditor.Editor[])Resources.FindObjectsOfTypeAll(Type.GetType("VisualPinball.Unity.Editor.TroughInspector, VisualPinball.Unity.Editor"))) {
 				editor.Repaint();
 			}

--- a/VisualPinball.Unity/VisualPinball.Unity/VisualPinball.Unity.csproj
+++ b/VisualPinball.Unity/VisualPinball.Unity/VisualPinball.Unity.csproj
@@ -76,6 +76,6 @@
     <EmbeddedResource Remove="obj\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.7.12" />
+    <PackageReference Include="NLog" Version="4.7.13" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Currently, the Lamp/Switch/Coil/Wire managers are refreshed during gameplay using:

```cs
#if UNITY_EDITOR
   UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
#endif
```

@Pandelii noticed a huge performance hit and after debugging, this was the culprit.

This PR adds a new `Update During Gameplay`setting to the `Player` component that is defaulted true.
When this is enabled and a switch, coil, or lamp is updated, we will look for any open corresponding managers, and call the `repaint` method. (note, there can be multiple of the same manager windows open)

We also do the same for the `TroughInspector` and `CoilDevice`.

This PR also does the following:

- cleans up the lamp groups for Rock in preparation for Visual Scripting 
- updates `NetVips`, `NetVips Native`, and `NLog` dependencies to the latest. 
- reverts the hacked in Lamp Type of `Single Off On` in favor of upcoming Visual Scripting. 
