### PR TITLE
Remove parent-child relationship.

### DIFF
--- a/VisualPinball.Unity/Assets/Resources/Materials/Dot Matrix Display (SRP).mat
+++ b/VisualPinball.Unity/Assets/Resources/Materials/Dot Matrix Display (SRP).mat
@@ -24,7 +24,8 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Dot Matrix Display (SRP)
-  m_Shader: {fileID: -6465566751694194690, guid: 3dfbd2115636a284d89d71fdefd9b4d2, type: 3}
+  m_Shader: {fileID: -6465566751694194690, guid: 3dfbd2115636a284d89d71fdefd9b4d2,
+    type: 3}
   m_ShaderKeywords: _DISABLE_SSR_TRANSPARENT
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -281,7 +282,8 @@ Material:
     - __SkewAngle: 0
     m_Colors:
     - Color_754dade2513142578632eb55adb8f59b: {r: 1, g: 0.36865607, b: 0, a: 0}
-    - Color_a1cf9b5e0df34a8c907984367d220f54: {r: 0.25471696, g: 0.25471696, b: 0.25471696, a: 0}
+    - Color_a1cf9b5e0df34a8c907984367d220f54: {r: 0.25471696, g: 0.25471696, b: 0.25471696,
+        a: 0}
     - Vector2_59fda9737b9e42259b122fbd66ccd94d: {r: 0.7, g: 0.28, b: 0, a: 0}
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _BaseColorMap_MipInfo: {r: 0, g: 0, b: 0, a: 0}
@@ -304,3 +306,16 @@ Material:
     - __Padding: {r: 0.3, g: 0.5, b: 0, a: 0}
     - __UnlitColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
   m_BuildTextureStacks: []
+--- !u!114 &3792289215621747627
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 5

--- a/VisualPinball.Unity/Assets/Resources/Materials/Segment Display (SRP).mat
+++ b/VisualPinball.Unity/Assets/Resources/Materials/Segment Display (SRP).mat
@@ -24,7 +24,8 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Segment Display (SRP)
-  m_Shader: {fileID: -6465566751694194690, guid: d54eb986991300e419411008eb1f597d, type: 3}
+  m_Shader: {fileID: -6465566751694194690, guid: d54eb986991300e419411008eb1f597d,
+    type: 3}
   m_ShaderKeywords: _DISABLE_SSR_TRANSPARENT
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -279,7 +280,8 @@ Material:
     - __SkewAngle: 0
     m_Colors:
     - Color_754dade2513142578632eb55adb8f59b: {r: 1, g: 0.36865607, b: 0, a: 0}
-    - Color_a1cf9b5e0df34a8c907984367d220f54: {r: 0.25471696, g: 0.25471696, b: 0.25471696, a: 0}
+    - Color_a1cf9b5e0df34a8c907984367d220f54: {r: 0.25471696, g: 0.25471696, b: 0.25471696,
+        a: 0}
     - Vector2_59fda9737b9e42259b122fbd66ccd94d: {r: 0.7, g: 0.28, b: 0, a: 0}
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _BaseColorMap_MipInfo: {r: 0, g: 0, b: 0, a: 0}
@@ -302,3 +304,16 @@ Material:
     - __SeparatorPos: {r: 1.4, g: 0, b: 0, a: 0}
     - __UnlitColor: {r: 0.25471696, g: 0.25471696, b: 0.25471696, a: 0}
   m_BuildTextureStacks: []
+--- !u!114 &6529312484818753363
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 5

--- a/VisualPinball.Unity/Documentation~/creators-guide/editor/unity-components.md
+++ b/VisualPinball.Unity/Documentation~/creators-guide/editor/unity-components.md
@@ -19,7 +19,7 @@ In *VPE*, we have separate components for each of these sections. There are four
 
 1. The **Main Component** represents the actual game item.
 2. A **Collider Component** adds physical behavior to the game item. It defines how the item interacts with other objects, for example what bounciness, friction and randomness is applied to a pinball hitting the item.
-3. **Mesh Components** generate meshes, i.e. the geometry used to render the object on the playfield. The results are the procedurally generated 3d objects rendered in the scene.
+3. **Mesh Components** generate meshes, i.e. the geometry used to render the object on the playfield. The results are the procedurally generated 3D objects rendered in the scene.
 4. **Animation components** apply movement to the game item. If the entire object is moving (for example a flipper), that is handled by the collision component, but for items where only parts move (e.g. the plate of a gate, or the ring of a bumper) these components apply the movement to the GameObject.
 
 Let's look at a flipper:
@@ -27,57 +27,3 @@ Let's look at a flipper:
 ![VPE vs VP](properties-vpe-vs-vp.png)
 
 Here, we see the main component (*Flipper*), the collider component (*Flipper Collider*), and two mesh components (*Flipper Base Mesh* and *Flipper Rubber Mesh*) inside VPE compared to Visual Pinball. While the main and collider component sit on the base GameObject, each mesh component is on its own child GameObject. This is how Unity works - a GameObject only contains one component of each type.
-
-> [!note]
-> Internally, VPE still keeps a single set of data. That's why you see the collapsed *Base Mesh*, *Rubber Mesh* and *Physics* sections in the main component. When you change values there, the corresponding values in the other components will update at the same time. In general, you don't have to manually manage all this. When creating game items via the toolbox, the new GameObject will already have all the necessary components, as will the items created when importing a `.vpx` file.
-
-This separation of logic has a few advantages. First, it's more obvious how a game item behaves. No collider component? That means the game item is not collidable. No mesh component? It's (permanently) invisible. But there are other advantages, as you will see in the next section.
-
-## Combining Components
-
-VPE allows you to mix and match components onto game items. For example, for a given game item, you could assign a collider or mesh from another type. The most common use case is replacing built-in meshes with primitives, removing the original mesh component and replacing it with a generated version. But there are other usages, like using a primitive collider on a rubber. You can also add *multiple* children with colliders (or meshes) for a game item. 
-
-We call this **parenting**. The game item that overrides a given behavior is still created, but serves as a *parent* container to other game items.
-
-The advantage compared to Visual Pinball, where you would create individual game items, is that VPE treats them as one single logical entity. For example, VPE will automatically rotate a primitive flipper item when it's parented under a flipper, and events from multiple colliders will be emitted from the same parent object.
-
-### Supported Combinations
-
-Not every game item can be parented to any other game item. It doesn't make much sense to use a flipper collider for a bumper. In fact, most of the combinations are unsupported. Here's what VPE does support so far:
-
-|                  | Supported Meshes                                              | Supported Colliders        | Supported Animators       |
-|------------------|---------------------------------------------------------------|----------------------------|---------------------------|
-| **Bumper**       | Bumper Base, Bumper Cap, Bumper Ring, Bumper Skirt, Primitive | Bumper                     | Bumper Ring, Bumper Skirt |
-| **Flipper**      | Flipper Base, Flipper Rubber, Primitive                       | Flipper                    |                           |
-| **Gate**         | Gate Bracket, Gate Wire, Primitive                            | Gate                       | Gate Wire                 |
-| **Hit Target**   | Hit Target, Primitive                                         | Hit Target                 | Hit Target, Drop Target   |
-| **Kicker**       | Kicker, Primitive                                             | Kicker                     |                           |
-| **Light** | Light, Primitive                                              |                            |                           |
-| **Plunger**      | Flat Plunger, Plunger Rod, Plunger Spring                     | Plunger                    | Plunger                   |
-| **Primitive**    | Primitive                                                     | Primitive, Ramp, Wall      |                           |
-| **Ramp**         | Ramp, Primitive                                               | Ramp                       |                           |
-| **Rubber**       | Rubber, Primitive                                             | Rubber, Surface, Primitive |                           |
-| **Spinner**      | Spinner Bracket, Spinner Plate, Primitive                     | Spinner                    | Spinner Plate             |
-| **Surface**      | Surface, Primitive                                            | Surface, Primitive         |                           |
-| **Trigger**      | Trigger, Primitive                                            | Trigger                    | Trigger                   |
-
-
-## Naming Conventions
-
-In order to maintain backward compatibility with Visual Pinball, VPE relies on naming conventions to parent one game item to another.
-
-There are two suffixes that have special meaning for VPE:
-
-- `_Mesh` applies the game item's mesh to its parent
-- `_Collider` applies the game item's collider to its parent
-
-For example, if in Visual Pinball you name a primitive `LeftFlipper_Mesh`, VPE will look for a `LeftFlipper` game item and replace its mesh with the mesh of that primitive. In other words, it will *parent* `LeftFlipper_Mesh` to `LeftFlipper` and disable `LeftFlipper`'s original mesh.
-
-Another example: If in Visual Pinball you name a rubber `LeftSlingshot` and two primitives `LeftSlingshot_Collider_Soft` and  `LeftSlingshot_Collider_Hard`, VPE will disable the collider of `LeftSlingshot` and use both the other colliders instead. During gameplay when the ball hits either `LeftSlingshot_Collider_Soft` or `LeftSlingshot_Collider_Hard`, the `Hit` event will be emitted on `LeftSlingshot`.
-
-> [!warning]
-> When you *export* to `.vpx` and you have parented items that don't follow the naming convention, the parenting will get lost when re-importing the table into VPE. In the future, VPE may offer to (or even automatically) rename the parented children on export, but that's still on our TODO list.
-
-## Visibility
-
-In order to determine whether a game item is visible, VPE looks at the hierarchy and the mesh components of its GameObject. If a game item has no mesh component, its automatically set to *invisible*. It's also invisible if the GameObject is set to inactive (the checkbox at the top left in the Inspector).

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/ColliderInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/ColliderInspector.cs
@@ -115,34 +115,17 @@ namespace VisualPinball.Unity.Editor
 
 		protected bool HasErrors()
 		{
-			if (!HasMainComponent) {
-				NoDataError();
-				return true;
+			if (HasMainComponent) {
+				return false;
 			}
 
-			if (!ColliderComponent.IsCorrectlyParented) {
-				InvalidParentError();
-				return true;
-			}
-
-			return false;
+			NoDataError();
+			return true;
 		}
 
 		private static void NoDataError()
 		{
 			EditorGUILayout.HelpBox($"Cannot find main component!\n\nYou must have a {typeof(TMainComponent).Name} component on this GameObject.", MessageType.Error);
-		}
-
-		private void InvalidParentError()
-		{
-			var validParentTypes = ColliderComponent.ValidParents.ToArray();
-			var typeMessage = validParentTypes.Length > 0
-				? $"Supported parents are: [ {string.Join(", ", validParentTypes.Select(t => t.Name))} ]."
-				: $"In this case, colliders for {ColliderComponent.ItemName} don't support any parenting at all.";
-			EditorGUILayout.HelpBox($"Invalid parent. This {ColliderComponent.ItemName} is parented to a {ColliderComponent.ParentComponent.ItemName}, which VPE doesn't support.\n{typeMessage}", MessageType.Error);
-			if (GUILayout.Button("Open Documentation", EditorStyles.linkLabel)) {
-				Application.OpenURL("https://docs.visualpinball.org/creators-guide/editor/unity-components.html");
-			}
 		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/MainInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/MainInspector.cs
@@ -16,8 +16,6 @@
 
 // ReSharper disable AssignmentInConditionalExpression
 
-using System.Linq;
-using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 
@@ -37,27 +35,7 @@ namespace VisualPinball.Unity.Editor
 			base.OnEnable();
 		}
 
-		protected bool HasErrors()
-		{
-			if (!MainComponent.IsCorrectlyParented) {
-				InvalidParentError();
-				return true;
-			}
-
-			return false;
-		}
-
-		protected void InvalidParentError()
-		{
-			var validParentTypes = MainComponent.ValidParents.ToArray();
-			var typeMessage = validParentTypes.Length > 0
-				? $"Supported parents are: [ {string.Join(", ", validParentTypes.Select(t => t.Name))} ]."
-				: $"In this case, {MainComponent.ItemName} doesn't support any parenting at all.";
-			EditorGUILayout.HelpBox($"Invalid parent. This {MainComponent.ItemName} is parented to a {MainComponent.ParentComponent.ItemName}, which VPE doesn't support.\n{typeMessage}", MessageType.Error);
-			if (GUILayout.Button("Open Documentation", EditorStyles.linkLabel)) {
-				Application.OpenURL("https://docs.visualpinball.org/creators-guide/editor/unity-components.html");
-			}
-		}
+		protected bool HasErrors() => false;
 
 		protected void UpdateSurfaceReferences(Transform obj)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/MeshInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/MeshInspector.cs
@@ -53,34 +53,17 @@ namespace VisualPinball.Unity.Editor
 
 		protected bool HasErrors()
 		{
-			if (!HasMainComponent) {
-				NoDataError();
-				return true;
+			if (HasMainComponent) {
+				return false;
 			}
 
-			if (!MeshComponent.IsCorrectlyParented) {
-				InvalidParentError();
-				return true;
-			}
-
-			return false;
+			NoDataError();
+			return true;
 		}
 
 		private static void NoDataError()
 		{
 			EditorGUILayout.HelpBox($"Cannot find main component!\n\nYou must have a {typeof(TMainComponent).Name} component on either this GameObject, its parent or grand parent.", MessageType.Error);
-		}
-
-		private void InvalidParentError()
-		{
-			var validParentTypes = MeshComponent.ValidParents.ToArray();
-			var typeMessage = validParentTypes.Length > 0
-				? $"Supported parents are: [ {string.Join(", ", validParentTypes.Select(t => t.Name))} ]."
-				: $"In this case, meshes for {MeshComponent.ItemName} don't support any parenting at all.";
-			EditorGUILayout.HelpBox($"Invalid parent. This {MeshComponent.ItemName} is parented to a {MeshComponent.ParentComponent.ItemName}, which VPE doesn't support.\n{typeMessage}", MessageType.Error);
-			if (GUILayout.Button("Open Documentation", EditorStyles.linkLabel)) {
-				Application.OpenURL("https://docs.visualpinball.org/creators-guide/editor/unity-components.html");
-			}
 		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
@@ -195,16 +195,16 @@ namespace VisualPinball.Unity
 
 		#region Registrations
 
-		public void RegisterBumper(BumperComponent component, Entity entity, Entity parentEntity)
+		public void RegisterBumper(BumperComponent component, Entity entity)
 		{
-			Register(new BumperApi(component.gameObject, entity, parentEntity, this), component, entity);
+			Register(new BumperApi(component.gameObject, entity, this), component, entity);
 			RegisterTransform<BumperRingAnimationComponent>(BumperRingTransforms, component, entity);
 			RegisterTransform<BumperSkirtAnimationComponent>(BumperSkirtTransforms, component, entity);
 		}
 
-		public void RegisterFlipper(FlipperComponent component, Entity entity, Entity parentEntity)
+		public void RegisterFlipper(FlipperComponent component, Entity entity)
 		{
-			Register(new FlipperApi(component.gameObject, entity, parentEntity, this), component, entity);
+			Register(new FlipperApi(component.gameObject, entity, this), component, entity);
 			FlipperTransforms[entity] = component.gameObject.transform;
 
 			if (EngineProvider<IDebugUI>.Exists) {
@@ -212,27 +212,27 @@ namespace VisualPinball.Unity
 			}
 		}
 
-		public void RegisterDropTarget(DropTargetComponent component, Entity entity, Entity parentEntity)
+		public void RegisterDropTarget(DropTargetComponent component, Entity entity)
 		{
-			Register(new DropTargetApi(component.gameObject, entity, parentEntity, this), component, entity);
+			Register(new DropTargetApi(component.gameObject, entity, this), component, entity);
 			RegisterTransform<DropTargetAnimationComponent>(DropTargetTransforms, component, entity);
 		}
 
-		public void RegisterGate(GateComponent component, Entity entity, Entity parentEntity)
+		public void RegisterGate(GateComponent component, Entity entity)
 		{
-			Register(new GateApi(component.gameObject, entity, parentEntity, this), component, entity);
+			Register(new GateApi(component.gameObject, entity, this), component, entity);
 			RegisterTransform<GateWireAnimationComponent>(GateWireTransforms, component, entity);
 		}
 
-		public void RegisterHitTarget(HitTargetComponent component, Entity entity, Entity parentEntity)
+		public void RegisterHitTarget(HitTargetComponent component, Entity entity)
 		{
-			Register(new HitTargetApi(component.gameObject, entity, parentEntity, this), component, entity);
+			Register(new HitTargetApi(component.gameObject, entity, this), component, entity);
 			RegisterTransform<HitTargetAnimationComponent>(HitTargetTransforms, component, entity);
 		}
 
-		public void RegisterKicker(KickerComponent component, Entity entity, Entity parentEntity)
+		public void RegisterKicker(KickerComponent component, Entity entity)
 		{
-			Register(new KickerApi(component.gameObject, entity, parentEntity, this), component, entity);
+			Register(new KickerApi(component.gameObject, entity, this), component, entity);
 		}
 
 		public void RegisterLamp(LightComponent component)
@@ -265,9 +265,9 @@ namespace VisualPinball.Unity
 			Register(new SlingshotApi(component.gameObject, this), component);
 		}
 
-		public void RegisterPlunger(PlungerComponent component, Entity entity, Entity parentEntity, InputActionReference actionRef)
+		public void RegisterPlunger(PlungerComponent component, Entity entity, InputActionReference actionRef)
 		{
-			var plungerApi = new PlungerApi(component.gameObject, entity, parentEntity, this);
+			var plungerApi = new PlungerApi(component.gameObject, entity, this);
 			Register(plungerApi, component, entity);
 
 			if (actionRef != null) {
@@ -284,30 +284,30 @@ namespace VisualPinball.Unity
 			_colliderGenerators.Add(PlayfieldApi);
 		}
 
-		public void RegisterPrimitive(PrimitiveComponent component, Entity entity, Entity parentEntity)
+		public void RegisterPrimitive(PrimitiveComponent component, Entity entity)
 		{
-			Register(new PrimitiveApi(component.gameObject, entity, parentEntity, this), component, entity);
+			Register(new PrimitiveApi(component.gameObject, entity, this), component, entity);
 		}
 
-		public void RegisterRamp(RampComponent component, Entity entity, Entity parentEntity)
+		public void RegisterRamp(RampComponent component, Entity entity)
 		{
-			Register(new RampApi(component.gameObject, entity, parentEntity, this), component, entity);
+			Register(new RampApi(component.gameObject, entity, this), component, entity);
 		}
 
-		public void RegisterRubber(RubberComponent component, Entity entity, Entity parentEntity)
+		public void RegisterRubber(RubberComponent component, Entity entity)
 		{
-			Register(new RubberApi(component.gameObject, entity, parentEntity, this), component, entity);
+			Register(new RubberApi(component.gameObject, entity, this), component, entity);
 		}
 
-		public void RegisterSpinner(SpinnerComponent component, Entity entity, Entity parentEntity)
+		public void RegisterSpinner(SpinnerComponent component, Entity entity)
 		{
-			Register(new SpinnerApi(component.gameObject, entity, parentEntity, this), component, entity);
+			Register(new SpinnerApi(component.gameObject, entity, this), component, entity);
 			RegisterTransform<SpinnerPlateAnimationComponent>(SpinnerPlateTransforms, component, entity);
 		}
 
-		public void RegisterSurface(SurfaceComponent component, Entity entity, Entity parentEntity)
+		public void RegisterSurface(SurfaceComponent component, Entity entity)
 		{
-			Register(new SurfaceApi(component.gameObject, entity, parentEntity, this), component, entity);
+			Register(new SurfaceApi(component.gameObject, entity, this), component, entity);
 		}
 
 		public void RegisterTeleporter(TeleporterComponent component)
@@ -315,9 +315,9 @@ namespace VisualPinball.Unity
 			Register(new TeleporterApi(component.gameObject, this), component);
 		}
 
-		public void RegisterTrigger(TriggerComponent component, Entity entity, Entity parentEntity)
+		public void RegisterTrigger(TriggerComponent component, Entity entity)
 		{
-			Register(new TriggerApi(component.gameObject, entity, parentEntity, this), component, entity);
+			Register(new TriggerApi(component.gameObject, entity, this), component, entity);
 			TriggerTransforms[entity] = component.gameObject.transform;
 		}
 
@@ -325,7 +325,7 @@ namespace VisualPinball.Unity
 		{
 			var component = go.AddComponent<TriggerComponent>();
 			component.SetData(data);
-			Register(new TriggerApi(go, entity, Entity.Null, this), component, entity);
+			Register(new TriggerApi(go, entity, this), component, entity);
 		}
 
 		public void RegisterTrough(TroughComponent component)

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
@@ -34,7 +34,6 @@ namespace VisualPinball.Unity
 
 		public int Id => Header.Id;
 		public Entity Entity => Header.Entity;
-		public Entity ParentEntity => Header.ParentEntity;
 		public ColliderType Type => Header.Type;
 		public PhysicsMaterialData Material => Header.Material;
 		public float Threshold => Header.Threshold;
@@ -181,7 +180,7 @@ namespace VisualPinball.Unity
 
 				// must be a new place if only by a little
 				if (distLs > normalDist) {
-					events.Enqueue(new EventData(EventId.HitEventsHit, collHeader.ParentEntity, ballEntity, true));
+					events.Enqueue(new EventData(EventId.HitEventsHit, collHeader.Entity, ballEntity, true));
 				}
 			}
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/ColliderInfo.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/ColliderInfo.cs
@@ -31,7 +31,6 @@ namespace VisualPinball.Unity
 		public int Id;
 		public ItemType ItemType;
 		public Entity Entity;
-		public Entity ParentEntity;
 		public PhysicsMaterialData Material;
 		public float HitThreshold;
 		public bool FireEvents;

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/LineSlingshotCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/LineSlingshotCollider.cs
@@ -143,7 +143,7 @@ namespace VisualPinball.Unity
 
 				// !! magic distance, must be a new place if only by a little
 				if (distLs > 0.25f) {
-					events.Enqueue(new EventData(EventId.SurfaceEventsSlingshot, _header.ParentEntity, ballEntity, true));
+					events.Enqueue(new EventData(EventId.SurfaceEventsSlingshot, _header.Entity, ballEntity, true));
 
 					// todo slingshot animation
 					// m_slingshotanim.m_TimeReset = g_pplayer->m_time_msec + 100;

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/ColliderHeader.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/ColliderHeader.cs
@@ -31,7 +31,6 @@ namespace VisualPinball.Unity
 		public ItemType ItemType;
 		public int Id;
 		public Entity Entity;
-		public Entity ParentEntity;
 		public PhysicsMaterialData Material;
 
 		public float Threshold;
@@ -62,9 +61,6 @@ namespace VisualPinball.Unity
 			ItemType = info.ItemType;
 			Id = info.Id;
 			Entity = info.Entity;
-			ParentEntity = info.ParentEntity != Entity.Null
-				? info.ParentEntity
-				: Entity;
 			Material = info.Material;
 			Threshold = info.HitThreshold;
 			FireEvents = info.FireEvents;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperApi.cs
@@ -40,8 +40,8 @@ namespace VisualPinball.Unity
 		/// </summary>
 		public event EventHandler<SwitchEventArgs> Switch;
 
-		public BumperApi(GameObject go, Entity entity, Entity parentEntity, Player player)
-			: base(go, entity, parentEntity, player)
+		public BumperApi(GameObject go, Entity entity, Player player)
+			: base(go, entity, player)
 		{
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperCollider.cs
@@ -42,7 +42,7 @@ namespace VisualPinball.Unity
 				skirtData.HitEvent = true;
 				skirtData.BallPosition = ball.Position;
 
-				events.Enqueue(new EventData(EventId.HitEventsHit, collider.ParentEntity, ballEntity, true));
+				events.Enqueue(new EventData(EventId.HitEventsHit, collider.Entity, ballEntity, true));
 			}
 		}
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperColliderComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Bumper;
@@ -48,9 +47,8 @@ namespace VisualPinball.Unity
 
 		#endregion
 
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
-		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity, Entity parentEntity)
-			=> new BumperApi(gameObject, entity, parentEntity, player);
+		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
+			=> new BumperApi(gameObject, entity, player);
 
 		public override PhysicsMaterialData PhysicsMaterialData => GetPhysicsMaterialData(scatterAngleDeg: Scatter);
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperComponent.cs
@@ -68,7 +68,6 @@ namespace VisualPinball.Unity
 
 		public override ItemType ItemType => ItemType.Bumper;
 		public override string ItemName => "Bumper";
-		public override IEnumerable<Type> ValidParents => BumperColliderComponent.ValidParentTypes;
 
 		public override BumperData InstantiateData() => new BumperData();
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<BumperData, BumperComponent>);
@@ -179,7 +178,7 @@ namespace VisualPinball.Unity
 			}
 
 			// register at player
-			GetComponentInParent<Player>().RegisterBumper(this, entity, ParentEntity);
+			GetComponentInParent<Player>().RegisterBumper(this, entity);
 		}
 
 		public override IEnumerable<MonoBehaviour> SetData(BumperData data)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationComponent.cs
@@ -16,8 +16,6 @@
 
 // ReSharper disable InconsistentNaming
 
-using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Bumper;
 
@@ -26,8 +24,6 @@ namespace VisualPinball.Unity
 	[AddComponentMenu("Visual Pinball/Animation/Bumper Ring Animation")]
 	public class BumperRingAnimationComponent : AnimationComponent<BumperData, BumperComponent>
 	{
-		public override IEnumerable<Type> ValidParents => Type.EmptyTypes; // animation components only apply to their own
-
 		#region Data
 
 		[Tooltip("How quick the ring moves down when the ball is hit.")]

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationComponent.cs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Bumper;
 
@@ -24,6 +22,5 @@ namespace VisualPinball.Unity
 	[AddComponentMenu("Visual Pinball/Animation/Bumper Skirt Animation")]
 	public class BumperSkirtAnimationComponent : AnimationComponent<BumperData, BumperComponent>
 	{
-		public override IEnumerable<Type> ValidParents => Type.EmptyTypes; // animation components only apply to their own
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/CollidableApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/CollidableApi.cs
@@ -31,13 +31,11 @@ namespace VisualPinball.Unity
 		protected readonly TCollidableComponent ColliderComponent;
 
 		private protected EntityManager EntityManager;
-		private readonly Entity _parentEntity;
 
-		protected CollidableApi(GameObject go, Entity entity, Entity parentEntity, Player player) : base(go, player)
+		protected CollidableApi(GameObject go, Entity entity, Player player) : base(go, player)
 		{
 			EntityManager = World.DefaultGameObjectInjectionWorld != null ? World.DefaultGameObjectInjectionWorld.EntityManager : default;
 			Entity = entity;
-			_parentEntity = parentEntity;
 
 			ColliderComponent = go.GetComponent<TCollidableComponent>();
 		}
@@ -71,7 +69,6 @@ namespace VisualPinball.Unity
 				Id = -1,
 				ItemType = itemType,
 				Entity = Entity,
-				ParentEntity = _parentEntity,
 				FireEvents = FireHitEvents,
 				IsEnabled = ColliderComponent && ColliderComponent.isActiveAndEnabled,
 				Material = ColliderComponent.PhysicsMaterialData,

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/ColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/ColliderComponent.cs
@@ -58,7 +58,7 @@ namespace VisualPinball.Unity
 		[NonSerialized] private readonly List<ICollider> _nonMeshColliders = new List<ICollider>();
 		[NonSerialized] private bool _collidersDirty;
 
-		protected abstract IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity, Entity parentEntity);
+		protected abstract IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity);
 
 		public abstract PhysicsMaterialData PhysicsMaterialData { get; }
 
@@ -114,7 +114,7 @@ namespace VisualPinball.Unity
 
 			var generateColliders = ShowAabbs || showColliders && !HasCachedColliders;
 			if (generateColliders) {
-				var api = InstantiateColliderApi(player, _colliderEntity, Entity.Null);
+				var api = InstantiateColliderApi(player, _colliderEntity);
 				var colliders = new List<ICollider>();
 				api.CreateColliders(colliders, 0.1f);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperApi.cs
@@ -71,8 +71,8 @@ namespace VisualPinball.Unity
 
 		private bool _isEos;
 
-		internal FlipperApi(GameObject go, Entity entity, Entity parentEntity, Player player)
-			: base(go, entity, parentEntity, player)
+		internal FlipperApi(GameObject go, Entity entity, Player player)
+			: base(go, entity, player)
 		{
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperBaseMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperBaseMeshComponent.cs
@@ -15,7 +15,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Flipper;
@@ -29,8 +28,6 @@ namespace VisualPinball.Unity
 	public class FlipperBaseMeshComponent : MeshComponent<FlipperData, FlipperComponent>
 	{
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
-
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 
 		protected override Mesh GetMesh(FlipperData _)
 			=> new FlipperMeshGenerator(MainComponent).GetMesh(FlipperMeshGenerator.Base, 0);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
@@ -856,11 +856,11 @@ namespace VisualPinball.Unity
 				var flipperHit = hitData.HitMomentBit ? -1.0f : -bnv; // move event processing to end of collision handler...
 				if (flipperHit < 0f) {
 					// simple hit event
-					events.Enqueue(new EventData(EventId.HitEventsHit, _header.ParentEntity, ballEntity, true));
+					events.Enqueue(new EventData(EventId.HitEventsHit, _header.Entity, ballEntity, true));
 
 				} else {
 					// collision velocity (normal to face)
-					events.Enqueue(new EventData(EventId.FlipperEventsCollide, _header.ParentEntity, ballEntity, flipperHit));
+					events.Enqueue(new EventData(EventId.FlipperEventsCollide, _header.Entity, ballEntity, flipperHit));
 				}
 			}
 			movementData.LastHitTime = timeMsec; // keep resetting until idle for 250 milliseconds

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperColliderComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Flipper;
@@ -79,11 +78,10 @@ namespace VisualPinball.Unity
 		#endregion
 
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 		public override PhysicsMaterialData PhysicsMaterialData => GetPhysicsMaterialData(Elasticity, ElasticityFalloff, Friction, Scatter);
 
-		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity, Entity parentEntity)
-			=> new FlipperApi(gameObject, entity, parentEntity, player);
+		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
+			=> new FlipperApi(gameObject, entity, player);
 
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperComponent.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
@@ -118,11 +117,6 @@ namespace VisualPinball.Unity
 
 		public override ItemType ItemType => ItemType.Flipper;
 		public override string ItemName => "Flipper";
-
-		public override IEnumerable<Type> ValidParents => FlipperColliderComponent.ValidParentTypes
-			.Concat(FlipperBaseMeshComponent.ValidParentTypes)
-			.Concat(FlipperRubberMeshComponent.ValidParentTypes)
-			.Distinct();
 
 		public override FlipperData InstantiateData() => new FlipperData();
 
@@ -227,7 +221,7 @@ namespace VisualPinball.Unity
 			}
 
 			// register
-			player.RegisterFlipper(this, entity, ParentEntity);
+			player.RegisterFlipper(this, entity);
 		}
 
 		public override IEnumerable<MonoBehaviour> SetData(FlipperData data)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperRubberMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperRubberMeshComponent.cs
@@ -15,7 +15,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Flipper;
@@ -29,8 +28,6 @@ namespace VisualPinball.Unity
 	public class FlipperRubberMeshComponent : MeshComponent<FlipperData, FlipperComponent>
 	{
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
-
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 
 		protected override PbrMaterial GetMaterial(FlipperData data, Table table)
 			=> FlipperMeshGenerator.GetMaterial(FlipperMeshGenerator.Rubber, table, data);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateApi.cs
@@ -73,8 +73,8 @@ namespace VisualPinball.Unity
 		// todo
 		public event EventHandler Timer;
 
-		public GateApi(GameObject go, Entity entity, Entity parentEntity, Player player)
-			: base(go, entity, parentEntity, player)
+		public GateApi(GameObject go, Entity entity, Player player)
+			: base(go, entity, player)
 		{
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateColliderComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using Unity.Entities;
 using UnityEngine;
@@ -69,11 +68,9 @@ namespace VisualPinball.Unity
 
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
 
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
-
 		public override PhysicsMaterialData PhysicsMaterialData => GetPhysicsMaterialData(Elasticity, friction: Friction);
 
-		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity, Entity parentEntity)
-			=> new GateApi(gameObject, entity, parentEntity, player);
+		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
+			=> new GateApi(gameObject, entity, player);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateComponent.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Unity.Entities;
 using Unity.Mathematics;
 using UnityEngine;
@@ -88,9 +87,6 @@ namespace VisualPinball.Unity
 
 		public override ItemType ItemType => ItemType.Gate;
 		public override string ItemName => "Gate";
-
-		public override IEnumerable<Type> ValidParents => GateColliderComponent.ValidParentTypes
-			.Distinct();
 
 		public override GateData InstantiateData() => new GateData();
 
@@ -173,7 +169,7 @@ namespace VisualPinball.Unity
 			}
 
 			// register
-			transform.GetComponentInParent<Player>().RegisterGate(this, entity, ParentEntity);
+			transform.GetComponentInParent<Player>().RegisterGate(this, entity);
 		}
 
 		public override IEnumerable<MonoBehaviour> SetData(GateData data)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateWireAnimationComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateWireAnimationComponent.cs
@@ -14,14 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-using System;
-using System.Collections.Generic;
 using VisualPinball.Engine.VPT.Gate;
 
 namespace VisualPinball.Unity
 {
 	public class GateWireAnimationComponent : AnimationComponent<GateData, GateComponent>
 	{
-		public override IEnumerable<Type> ValidParents => Type.EmptyTypes; // animation components only apply to their own
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/DropTargetAnimationComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/DropTargetAnimationComponent.cs
@@ -16,8 +16,6 @@
 
 // ReSharper disable InconsistentNaming
 
-using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT.HitTarget;
 
@@ -27,8 +25,6 @@ namespace VisualPinball.Unity
 	[RequireComponent(typeof(DropTargetColliderComponent))]
 	public class DropTargetAnimationComponent : AnimationComponent<HitTargetData, DropTargetComponent>
 	{
-		public override IEnumerable<Type> ValidParents => Type.EmptyTypes;
-
 		#region Data
 
 		[Tooltip("How fast the drop target moves down.")]

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/DropTargetApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/DropTargetApi.cs
@@ -55,8 +55,8 @@ namespace VisualPinball.Unity
 			set => SetIsDropped(value);
 		}
 
-		internal DropTargetApi(GameObject go, Entity entity, Entity parentEntity, Player player)
-			: base(go, entity, parentEntity, player)
+		internal DropTargetApi(GameObject go, Entity entity, Player player)
+			: base(go, entity, player)
 		{
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/DropTargetColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/DropTargetColliderComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.HitTarget;
@@ -63,11 +62,9 @@ namespace VisualPinball.Unity
 
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
 
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
-
 		public override PhysicsMaterialData PhysicsMaterialData => GetPhysicsMaterialData(Elasticity, ElasticityFalloff, Friction, Scatter, OverwritePhysics);
 
-		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity, Entity parentEntity)
-			=> new DropTargetApi(gameObject, entity, parentEntity, player);
+		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
+			=> new DropTargetApi(gameObject, entity, player);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/DropTargetComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/DropTargetComponent.cs
@@ -67,7 +67,7 @@ namespace VisualPinball.Unity
 			}
 
 			// register
-			transform.GetComponentInParent<Player>().RegisterDropTarget(this, entity, ParentEntity);
+			transform.GetComponentInParent<Player>().RegisterDropTarget(this, entity);
 		}
 
 		public override IEnumerable<MonoBehaviour> SetData(HitTargetData data)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetAnimationComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetAnimationComponent.cs
@@ -16,8 +16,6 @@
 
 // ReSharper disable InconsistentNaming
 
-using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT.HitTarget;
 
@@ -27,8 +25,6 @@ namespace VisualPinball.Unity
 	[RequireComponent(typeof(HitTargetColliderComponent))]
 	public class HitTargetAnimationComponent : AnimationComponent<HitTargetData, HitTargetComponent>
 	{
-		public override IEnumerable<Type> ValidParents => Type.EmptyTypes;
-
 		#region Data
 
 		[Min(0)]

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetApi.cs
@@ -40,8 +40,8 @@ namespace VisualPinball.Unity
 		/// </summary>
 		public event EventHandler<SwitchEventArgs> Switch;
 
-		internal HitTargetApi(GameObject go, Entity entity, Entity parentEntity, Player player)
-			: base(go, entity, parentEntity, player)
+		internal HitTargetApi(GameObject go, Entity entity, Player player)
+			: base(go, entity, player)
 		{
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetColliderComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.HitTarget;
@@ -57,11 +56,9 @@ namespace VisualPinball.Unity
 
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
 
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
-
 		public override PhysicsMaterialData PhysicsMaterialData => GetPhysicsMaterialData(Elasticity, ElasticityFalloff, Friction, Scatter, OverwritePhysics);
 
-		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity, Entity parentEntity)
-			=> new HitTargetApi(gameObject, entity, parentEntity, player);
+		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
+			=> new HitTargetApi(gameObject, entity, player);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetComponent.cs
@@ -50,7 +50,7 @@ namespace VisualPinball.Unity
 			}
 
 			// register
-			transform.GetComponentInParent<Player>().RegisterHitTarget(this, entity, ParentEntity);
+			transform.GetComponentInParent<Player>().RegisterHitTarget(this, entity);
 		}
 
 		public override IEnumerable<MonoBehaviour> SetData(HitTargetData data)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/TargetComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/TargetComponent.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.Game.Engines;
@@ -87,9 +86,6 @@ namespace VisualPinball.Unity
 
 		public override ItemType ItemType => ItemType.HitTarget;
 		public override string ItemName => "Target";
-
-		public override IEnumerable<Type> ValidParents => HitTargetColliderComponent.ValidParentTypes
-			.Distinct();
 
 		public override HitTargetData InstantiateData() => new HitTargetData();
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<HitTargetData, TargetComponent>);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerApi.cs
@@ -54,8 +54,8 @@ namespace VisualPinball.Unity
 
 		private readonly Dictionary<string, KickerDeviceCoil> _coils = new Dictionary<string, KickerDeviceCoil>();
 
-		public KickerApi(GameObject go, Entity entity, Entity parentEntity, Player player)
-			: base(go, entity, parentEntity, player)
+		public KickerApi(GameObject go, Entity entity, Player player)
+			: base(go, entity, player)
 		{
 			foreach (var coil in MainComponent.Coils) {
 				_coils[coil.Id] = new KickerDeviceCoil(player, coil, this);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerColliderComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Kicker;
@@ -53,9 +52,8 @@ namespace VisualPinball.Unity
 
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
 
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 		public override PhysicsMaterialData PhysicsMaterialData => GetPhysicsMaterialData(scatterAngleDeg: Scatter);
-		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity, Entity parentEntity)
-			=> new KickerApi(gameObject, entity, parentEntity, player);
+		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
+			=> new KickerApi(gameObject, entity, player);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerComponent.cs
@@ -72,9 +72,6 @@ namespace VisualPinball.Unity
 		public override ItemType ItemType => ItemType.Kicker;
 		public override string ItemName => "Kicker";
 
-		public override IEnumerable<Type> ValidParents => KickerColliderComponent.ValidParentTypes
-			.Distinct();
-
 		public override KickerData InstantiateData() => new KickerData();
 
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<KickerData, KickerComponent>);
@@ -197,7 +194,7 @@ namespace VisualPinball.Unity
 			}
 
 			// register
-			transform.GetComponentInParent<Player>().RegisterKicker(this, entity, ParentEntity);
+			transform.GetComponentInParent<Player>().RegisterKicker(this, entity);
 		}
 
 		public override IEnumerable<MonoBehaviour> SetData(KickerData data)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Light/LightComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Light/LightComponent.cs
@@ -73,8 +73,6 @@ namespace VisualPinball.Unity
 		public override ItemType ItemType => ItemType.Light;
 		public override string ItemName => "Light";
 
-		public override IEnumerable<Type> ValidParents => Type.EmptyTypes;
-
 		public override LightData InstantiateData() => new LightData();
 
 		public override bool OverrideTransform => false;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Light/LightInsertMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Light/LightInsertMeshComponent.cs
@@ -16,8 +16,6 @@
 
 // ReSharper disable InconsistentNaming
 
-using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.Math;
 using VisualPinball.Engine.VPT;
@@ -41,8 +39,6 @@ namespace VisualPinball.Unity
 		public DragPointData[] DragPoints { get => _dragPoints; set => _dragPoints = value; }
 
 		#endregion
-
-		public override IEnumerable<Type> ValidParents => Type.EmptyTypes;
 
 		protected override Mesh GetMesh(LightData data)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MainComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MainComponent.cs
@@ -16,10 +16,7 @@
 
 // ReSharper disable InconsistentNaming
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Table;
@@ -70,67 +67,6 @@ namespace VisualPinball.Unity
 		/// </summary>
 		/// <returns></returns>
 		public abstract TData InstantiateData();
-
-		#endregion
-
-		#region Parenting
-
-		/// <summary>
-		/// List of types for parenting. Empty list if only to own parent.
-		/// </summary>
-		public abstract IEnumerable<Type> ValidParents { get; }
-
-		protected Entity ParentEntity {
-			get {
-				var parentComponent = ParentComponent;
-				if (parentComponent != null && !(parentComponent is TableComponent)) {
-					return parentComponent.Entity;
-				}
-				return Entity.Null;
-			}
-			set => throw new NotImplementedException();
-		}
-
-		public IMainRenderableComponent ParentComponent => FindParentComponent();
-
-		public bool IsCorrectlyParented {
-			get {
-				if (!ValidParents.Any()) {
-					return true;
-				}
-				var parentComponent = ParentComponent;
-				return parentComponent == null || ValidParents.Any(validParent => parentComponent.GetType() == validParent);
-			}
-		}
-		private IMainRenderableComponent FindParentComponent()
-		{
-			IMainRenderableComponent ma = null;
-			var go = gameObject;
-
-			// search on parent
-			if (go.transform.parent != null) {
-				ma = go.transform.parent.GetComponent<IMainRenderableComponent>();
-			}
-
-			if (ma is MonoBehaviour mb && (mb.GetComponent<TableComponent>() != null || mb.GetComponent<PlayfieldComponent>() != null)) {
-				return null;
-			}
-
-			if (ma != null) {
-				return ma;
-			}
-
-			// search on grand parent
-			if (go.transform.parent != null && go.transform.parent.transform.parent != null) {
-				ma = go.transform.parent.transform.parent.GetComponent<IMainRenderableComponent>();
-			}
-
-			if (ma is MonoBehaviour mb2 && (mb2.GetComponent<TableComponent>() != null || mb2.GetComponent<PlayfieldComponent>() != null)) {
-				return null;
-			}
-
-			return ma;
-		}
 
 		#endregion
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MainRenderableComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MainRenderableComponent.cs
@@ -91,11 +91,6 @@ namespace VisualPinball.Unity
 		protected void Convert(Entity entity, EntityManager dstManager)
 		{
 			Entity = entity;
-			var parentComponent = ParentComponent;
-			// todo remove the parenting stuff
-			// if (parentComponent != null && !(parentComponent is TableComponent)) {
-			// 	ParentEntity = parentComponent.Entity;
-			// }
 		}
 
 		protected float SurfaceHeight(ISurfaceComponent surface, Vector2 position)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Playfield/PlayfieldApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Playfield/PlayfieldApi.cs
@@ -26,7 +26,7 @@ namespace VisualPinball.Unity
 {
 	public class PlayfieldApi : CollidableApi<PlayfieldComponent, PlayfieldColliderComponent, TableData>
 	{
-		internal PlayfieldApi(GameObject go, Player player) : base(go, Player.PlayfieldEntity, Entity.Null, player)
+		internal PlayfieldApi(GameObject go, Player player) : base(go, Player.PlayfieldEntity, player)
 		{
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Playfield/PlayfieldColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Playfield/PlayfieldColliderComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Table;
@@ -56,9 +55,8 @@ namespace VisualPinball.Unity
 
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
 
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 		public override PhysicsMaterialData PhysicsMaterialData => GetPhysicsMaterialData(0, 0);
-		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity, Entity parentEntity)
+		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
 			=> new PlayfieldApi(gameObject, player);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Playfield/PlayfieldComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Playfield/PlayfieldComponent.cs
@@ -18,7 +18,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Unity.Entities;
 using Unity.Mathematics;
 using UnityEngine;
@@ -83,10 +82,6 @@ namespace VisualPinball.Unity
 
 		protected override Type MeshComponentType => typeof(PlayfieldMeshComponent);
 		protected override Type ColliderComponentType => typeof(PlayfieldColliderComponent);
-
-		public override IEnumerable<Type> ValidParents => PlayfieldColliderComponent.ValidParentTypes
-			.Concat(PlayfieldMeshComponent.ValidParentTypes)
-			.Distinct();
 
 		public Rect3D BoundingBox => new Rect3D(Left, Right, Top, Bottom, TableHeight, GlassHeight);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Playfield/PlayfieldMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Playfield/PlayfieldMeshComponent.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Table;
@@ -18,8 +17,6 @@ namespace VisualPinball.Unity.Playfield
 		#endregion
 
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
-
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 
 		protected override Mesh GetMesh(TableData data)
 			=> new TableMeshGenerator(data).GetMesh();

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerApi.cs
@@ -61,8 +61,8 @@ namespace VisualPinball.Unity
 
 		public bool DoRetract { get; set; } = true;
 
-		internal PlungerApi(GameObject go, Entity entity, Entity parentEntity, Player player)
-			: base(go, entity, parentEntity, player)
+		internal PlungerApi(GameObject go, Entity entity, Player player)
+			: base(go, entity, player)
 		{
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerColliderComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Plunger;
@@ -59,9 +58,8 @@ namespace VisualPinball.Unity
 
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
 
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 		public override PhysicsMaterialData PhysicsMaterialData => GetPhysicsMaterialData();
-		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity, Entity parentEntity)
-			=> new PlungerApi(gameObject, entity, parentEntity, player);
+		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
+			=> new PlungerApi(gameObject, entity, player);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerComponent.cs
@@ -20,7 +20,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Unity.Entities;
 using Unity.Mathematics;
 using UnityEngine;
@@ -63,12 +62,6 @@ namespace VisualPinball.Unity
 		public override string ItemName => "Plunger";
 
 		public override PlungerData InstantiateData() => new PlungerData();
-
-		public override IEnumerable<Type> ValidParents => PlungerColliderComponent.ValidParentTypes
-			.Concat(PlungerFlatMeshComponent.ValidParentTypes)
-			.Concat(PlungerRodMeshComponent.ValidParentTypes)
-			.Concat(PlungerSpringMeshComponent.ValidParentTypes)
-			.Distinct();
 
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<PlungerData, PlungerComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<PlungerData, PlungerComponent>);
@@ -130,7 +123,6 @@ namespace VisualPinball.Unity
 				FireEvents = true,
 				IsEnabled = true,
 				ItemType = ItemType.Plunger,
-				ParentEntity = entity
 			};
 
 			dstManager.AddComponentData(entity, new PlungerStaticData {
@@ -182,7 +174,7 @@ namespace VisualPinball.Unity
 			});
 
 			// register at player
-			GetComponentInParent<Player>().RegisterPlunger(this, entity, ParentEntity, analogPlungerAction);
+			GetComponentInParent<Player>().RegisterPlunger(this, entity, analogPlungerAction);
 		}
 
 		public override IEnumerable<MonoBehaviour> SetData(PlungerData data)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerFlatMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerFlatMeshComponent.cs
@@ -15,7 +15,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Plunger;
@@ -29,8 +28,6 @@ namespace VisualPinball.Unity
 	public class PlungerFlatMeshComponent : PlungerMeshComponent
 	{
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
-
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 
 		protected override Mesh GetMesh(PlungerData data)
 			=> new PlungerMeshGenerator(data).GetMesh(MainComponent.PositionZ, PlungerMeshGenerator.Flat);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerRodMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerRodMeshComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Plunger;
@@ -45,8 +44,6 @@ namespace VisualPinball.Unity
 		#endregion
 
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
-
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 
 		protected override Mesh GetMesh(PlungerData data)
 			=> new PlungerMeshGenerator(data).GetMesh(MainComponent.PositionZ, PlungerMeshGenerator.Rod);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerSpringMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerSpringMeshComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Plunger;
@@ -43,8 +42,6 @@ namespace VisualPinball.Unity
 		#endregion
 
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
-
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 
 		protected override Mesh GetMesh(PlungerData data)
 			=> new PlungerMeshGenerator(data).GetMesh(MainComponent.PositionZ, PlungerMeshGenerator.Spring);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveApi.cs
@@ -35,7 +35,7 @@ namespace VisualPinball.Unity
 		/// </summary>
 		public event EventHandler<HitEventArgs> Hit;
 
-		internal PrimitiveApi(GameObject go, Entity entity, Entity parentEntity, Player player) : base(go, entity, parentEntity, player)
+		internal PrimitiveApi(GameObject go, Entity entity, Player player) : base(go, entity, player)
 		{
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveColliderComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Primitive;
@@ -68,9 +67,8 @@ namespace VisualPinball.Unity
 			typeof(SurfaceComponent),
 		};
 
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 		public override PhysicsMaterialData PhysicsMaterialData => GetPhysicsMaterialData(Elasticity, ElasticityFalloff, Friction, Scatter, OverwritePhysics);
-		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity, Entity parentEntity)
-			=> new PrimitiveApi(gameObject, entity, parentEntity, player);
+		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
+			=> new PrimitiveApi(gameObject, entity, player);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveComponent.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Unity.Entities;
 using Unity.Mathematics;
 using UnityEngine;
@@ -66,10 +65,6 @@ namespace VisualPinball.Unity
 
 		public override PrimitiveData InstantiateData() => new PrimitiveData();
 
-		public override IEnumerable<Type> ValidParents => PrimitiveColliderComponent.ValidParentTypes
-			.Concat(PrimitiveMeshComponent.ValidParentTypes)
-			.Distinct();
-
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<PrimitiveData, PrimitiveComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<PrimitiveData, PrimitiveComponent>);
 
@@ -108,7 +103,7 @@ namespace VisualPinball.Unity
 			Convert(entity, dstManager);
 
 			// register
-			transform.GetComponentInParent<Player>().RegisterPrimitive(this, entity, ParentEntity);
+			transform.GetComponentInParent<Player>().RegisterPrimitive(this, entity);
 		}
 
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveMeshComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.Game;
 using VisualPinball.Engine.VPT;
@@ -56,8 +55,6 @@ namespace VisualPinball.Unity
 			typeof(TriggerComponent),
 			typeof(SlingshotComponent),
 		};
-
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 
 		protected override Mesh GetMesh(PrimitiveData data)
 			=> new PrimitiveMeshGenerator(data).GetMesh(MainComponent.PlayfieldHeight, data.Mesh, Origin.Original, false);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampApi.cs
@@ -33,7 +33,7 @@ namespace VisualPinball.Unity
 		/// </summary>
 		public event EventHandler<HitEventArgs> Hit;
 
-		internal RampApi(GameObject go, Entity entity, Entity parentEntity, Player player) : base(go, entity, parentEntity, player)
+		internal RampApi(GameObject go, Entity entity, Player player) : base(go, entity, player)
 		{
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampColliderComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Ramp;
@@ -65,9 +64,8 @@ namespace VisualPinball.Unity
 			typeof(PrimitiveComponent)
 		};
 
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 		public override PhysicsMaterialData PhysicsMaterialData => GetPhysicsMaterialData(Elasticity, friction: Friction, scatterAngleDeg: Scatter, overwrite: OverwritePhysics);
-		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity, Entity parentEntity)
-			=> new RampApi(gameObject, entity, parentEntity, player);
+		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
+			=> new RampApi(gameObject, entity, player);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampComponent.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -111,11 +110,6 @@ namespace VisualPinball.Unity
 		public override string ItemName => "Ramp";
 
 		public override RampData InstantiateData() => new RampData();
-		public override IEnumerable<Type> ValidParents => RampColliderComponent.ValidParentTypes
-			.Concat(RampFloorMeshComponent.ValidParentTypes)
-			.Concat(RampWallMeshComponent.ValidParentTypes)
-			.Concat(RampWireMeshComponent.ValidParentTypes)
-			.Distinct();
 
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<RampData, RampComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<RampData, RampComponent>);
@@ -198,7 +192,7 @@ namespace VisualPinball.Unity
 			Convert(entity, dstManager);
 
 			// register
-			transform.GetComponentInParent<Player>().RegisterRamp(this, entity, ParentEntity);
+			transform.GetComponentInParent<Player>().RegisterRamp(this, entity);
 		}
 
 		public override IEnumerable<MonoBehaviour> SetData(RampData data)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampFloorMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampFloorMeshComponent.cs
@@ -15,7 +15,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Ramp;
@@ -29,8 +28,6 @@ namespace VisualPinball.Unity
 	public class RampFloorMeshComponent : MeshComponent<RampData, RampComponent>
 	{
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
-
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 
 		protected override Mesh GetMesh(RampData _)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampWallMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampWallMeshComponent.cs
@@ -15,7 +15,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Ramp;
@@ -29,8 +28,6 @@ namespace VisualPinball.Unity
 	public class RampWallMeshComponent : MeshComponent<RampData, RampComponent>
 	{
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
-
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 
 		protected override Mesh GetMesh(RampData data)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampWireMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampWireMeshComponent.cs
@@ -15,7 +15,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Ramp;
@@ -29,8 +28,6 @@ namespace VisualPinball.Unity
 	public class RampWireMeshComponent : MeshComponent<RampData, RampComponent>
 	{
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
-
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 
 		protected override Mesh GetMesh(RampData data)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberApi.cs
@@ -35,7 +35,7 @@ namespace VisualPinball.Unity
 		/// </summary>
 		public event EventHandler<HitEventArgs> Hit;
 
-		internal RubberApi(GameObject go, Entity entity, Entity parentEntity, Player player) : base(go, entity, parentEntity, player)
+		internal RubberApi(GameObject go, Entity entity, Player player) : base(go, entity, player)
 		{
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberColliderComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Rubber;
@@ -58,9 +57,8 @@ namespace VisualPinball.Unity
 
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
 
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 		public override PhysicsMaterialData PhysicsMaterialData => GetPhysicsMaterialData(Elasticity, ElasticityFalloff, Friction, Scatter, OverwritePhysics);
-		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity, Entity parentEntity)
-			=> new RubberApi(gameObject, entity, parentEntity, player);
+		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
+			=> new RubberApi(gameObject, entity, player);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberComponent.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -72,10 +71,6 @@ namespace VisualPinball.Unity
 
 		public override RubberData InstantiateData() => new RubberData();
 
-		public override IEnumerable<Type> ValidParents => RubberColliderComponent.ValidParentTypes
-			.Concat(RubberMeshComponent.ValidParentTypes)
-			.Distinct();
-
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<RubberData, RubberComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<RubberData, RubberComponent>);
 
@@ -94,7 +89,7 @@ namespace VisualPinball.Unity
 			Convert(entity, dstManager);
 
 			// register
-			transform.GetComponentInParent<Player>().RegisterRubber(this, entity, ParentEntity);
+			transform.GetComponentInParent<Player>().RegisterRubber(this, entity);
 		}
 
 		public override IEnumerable<MonoBehaviour> SetData(RubberData data)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberMeshComponent.cs
@@ -15,7 +15,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Rubber;
@@ -29,7 +28,6 @@ namespace VisualPinball.Unity
 	public class RubberMeshComponent : MeshComponent<RubberData, RubberComponent>
 	{
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 
 		protected override Mesh GetMesh(RubberData data)
 			=> new RubberMeshGenerator(MainComponent).GetTransformedMesh(MainComponent.PlayfieldHeight, MainComponent.Height, MainComponent.PlayfieldDetailLevel);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerApi.cs
@@ -65,8 +65,8 @@ namespace VisualPinball.Unity
 		/// </summary>
 		public event EventHandler<SwitchEventArgs> Switch;
 
-		public SpinnerApi(GameObject go, Entity entity, Entity parentEntity, Player player)
-			: base(go, entity, parentEntity, player)
+		public SpinnerApi(GameObject go, Entity entity, Player player)
+			: base(go, entity, player)
 		{
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerColliderComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Spinner;
@@ -37,9 +36,8 @@ namespace VisualPinball.Unity
 
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
 
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 		public override PhysicsMaterialData PhysicsMaterialData => GetPhysicsMaterialData(Elasticity);
-		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity, Entity parentEntity)
-			=> new SpinnerApi(gameObject, entity, parentEntity, player);
+		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
+			=> new SpinnerApi(gameObject, entity, player);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerComponent.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Unity.Entities;
 using Unity.Mathematics;
 using UnityEngine;
@@ -79,9 +78,6 @@ namespace VisualPinball.Unity
 
 		public override ItemType ItemType => ItemType.Spinner;
 		public override string ItemName => "Spinner";
-
-		public override IEnumerable<Type> ValidParents => SpinnerColliderComponent.ValidParentTypes
-			.Distinct();
 
 		public override SpinnerData InstantiateData() => new SpinnerData();
 
@@ -157,7 +153,7 @@ namespace VisualPinball.Unity
 			}
 
 			// register
-			transform.GetComponentInParent<Player>().RegisterSpinner(this, entity, ParentEntity);
+			transform.GetComponentInParent<Player>().RegisterSpinner(this, entity);
 		}
 
 		public override IEnumerable<MonoBehaviour> SetData(SpinnerData data)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerPlateAnimationComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerPlateAnimationComponent.cs
@@ -14,14 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-using System;
-using System.Collections.Generic;
 using VisualPinball.Engine.VPT.Spinner;
 
 namespace VisualPinball.Unity
 {
 	public class SpinnerPlateAnimationComponent : AnimationComponent<SpinnerData, SpinnerComponent>
 	{
-		public override IEnumerable<Type> ValidParents => Type.EmptyTypes; // animation components only apply to their own
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/SubComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/SubComponent.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 
@@ -32,20 +30,6 @@ namespace VisualPinball.Unity
 		public bool HasMainComponent => FindMainComponent() == null;
 
 		public override string ItemName => MainComponent.ItemName;
-
-		public IMainRenderableComponent ParentComponent => MainComponent.ParentComponent;
-
-		public abstract IEnumerable<Type> ValidParents { get; }
-
-		public bool IsCorrectlyParented {
-			get {
-				if (!ValidParents.Any()) {
-					return true;
-				}
-				var parentComponent = ParentComponent;
-				return parentComponent == null || ValidParents.Any(validParent => parentComponent.GetType() == validParent);
-			}
-		}
 
 		private TMainComponent FindMainComponent()
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceApi.cs
@@ -39,7 +39,7 @@ namespace VisualPinball.Unity
 		/// </summary>
 		public event EventHandler Slingshot;
 
-		internal SurfaceApi(GameObject go, Entity entity, Entity parentEntity, Player player) : base(go, entity, parentEntity, player)
+		internal SurfaceApi(GameObject go, Entity entity, Player player) : base(go, entity, player)
 		{
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceColliderComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Surface;
@@ -74,9 +73,8 @@ namespace VisualPinball.Unity
 			typeof(SlingshotComponent),
 		};
 
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 		public override PhysicsMaterialData PhysicsMaterialData => GetPhysicsMaterialData(Elasticity, ElasticityFalloff, Friction, Scatter, OverwritePhysics);
-		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity, Entity parentEntity)
-			=> new SurfaceApi(gameObject, entity, parentEntity, player);
+		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
+			=> new SurfaceApi(gameObject, entity, player);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceComponent.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -59,11 +58,6 @@ namespace VisualPinball.Unity
 		public override SurfaceData InstantiateData() => new SurfaceData();
 
 
-		public override IEnumerable<Type> ValidParents => SurfaceColliderComponent.ValidParentTypes
-			.Concat(SurfaceSideMeshComponent.ValidParentTypes)
-			.Concat(SurfaceTopMeshComponent.ValidParentTypes)
-			.Distinct();
-
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<SurfaceData, SurfaceComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<SurfaceData, SurfaceComponent>);
 
@@ -92,7 +86,7 @@ namespace VisualPinball.Unity
 				});
 			}
 
-			transform.GetComponentInParent<Player>().RegisterSurface(this, entity, ParentEntity);
+			transform.GetComponentInParent<Player>().RegisterSurface(this, entity);
 		}
 
 		public override IEnumerable<MonoBehaviour> SetData(SurfaceData data)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceSideMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceSideMeshComponent.cs
@@ -15,7 +15,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Surface;
@@ -29,8 +28,6 @@ namespace VisualPinball.Unity
 	public class SurfaceSideMeshComponent : MeshComponent<SurfaceData, SurfaceComponent>
 	{
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
-
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 
 		protected override Mesh GetMesh(SurfaceData data)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceTopMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceTopMeshComponent.cs
@@ -15,7 +15,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Surface;
@@ -29,8 +28,6 @@ namespace VisualPinball.Unity
 	public class SurfaceTopMeshComponent : MeshComponent<SurfaceData, SurfaceComponent>
 	{
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
-
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 
 		protected override Mesh GetMesh(SurfaceData data)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableComponent.cs
@@ -54,8 +54,6 @@ namespace VisualPinball.Unity
 
 		public override TableData InstantiateData() => new TableData();
 
-		public override IEnumerable<Type> ValidParents => Type.EmptyTypes;
-
 		protected override Type MeshComponentType => null;
 		protected override Type ColliderComponentType => null;
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerAnimationComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerAnimationComponent.cs
@@ -16,8 +16,6 @@
 
 // ReSharper disable InconsistentNaming
 
-using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Trigger;
 
@@ -26,8 +24,6 @@ namespace VisualPinball.Unity
 	[AddComponentMenu("Visual Pinball/Animation/Trigger Animation")]
 	public class TriggerAnimationComponent : AnimationComponent<TriggerData, TriggerComponent>
 	{
-		public override IEnumerable<Type> ValidParents => Type.EmptyTypes; // animation components only apply to their own
-
 		#region Data
 
 		[Min(0)]

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerApi.cs
@@ -45,8 +45,8 @@ namespace VisualPinball.Unity
 		/// </summary>
 		public event EventHandler<SwitchEventArgs> Switch;
 
-		internal TriggerApi(GameObject go, Entity entity, Entity parentEntity, Player player)
-			: base(go, entity, parentEntity, player)
+		internal TriggerApi(GameObject go, Entity entity, Player player)
+			: base(go, entity, player)
 		{
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerCollider.cs
@@ -34,13 +34,13 @@ namespace VisualPinball.Unity
 					BallData.SetInsideOf(ref insideOfs, coll.Entity);
 					animationData.HitEvent = true;
 
-					events.Enqueue(new EventData(EventId.HitEventsHit, coll.ParentEntity,  ballEntity, true));
+					events.Enqueue(new EventData(EventId.HitEventsHit, coll.Entity,  ballEntity, true));
 
 				} else {
 					BallData.SetOutsideOf(ref insideOfs, coll.Entity);
 					animationData.UnHitEvent = true;
 
-					events.Enqueue(new EventData(EventId.HitEventsUnhit, coll.ParentEntity, ballEntity, true));
+					events.Enqueue(new EventData(EventId.HitEventsUnhit, coll.Entity, ballEntity, true));
 				}
 			}
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerColliderComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Trigger;
@@ -41,9 +40,8 @@ namespace VisualPinball.Unity
 
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
 
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 		public override PhysicsMaterialData PhysicsMaterialData => GetPhysicsMaterialData();
-		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity, Entity parentEntity)
-			=> new TriggerApi(gameObject, entity, parentEntity, player);
+		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
+			=> new TriggerApi(gameObject, entity, player);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerComponent.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Unity.Entities;
 using Unity.Mathematics;
 using UnityEngine;
@@ -64,10 +63,6 @@ namespace VisualPinball.Unity
 
 		public override ItemType ItemType => ItemType.Trigger;
 		public override string ItemName => "Trigger";
-
-		public override IEnumerable<Type> ValidParents => TriggerColliderComponent.ValidParentTypes
-			.Concat(TriggerMeshComponent.ValidParentTypes)
-			.Distinct();
 
 		public override TriggerData InstantiateData() => new TriggerData();
 
@@ -132,7 +127,7 @@ namespace VisualPinball.Unity
 			}
 
 			// register
-			transform.GetComponentInParent<Player>().RegisterTrigger(this, entity, ParentEntity);
+			transform.GetComponentInParent<Player>().RegisterTrigger(this, entity);
 		}
 
 		public override IEnumerable<MonoBehaviour> SetData(TriggerData data)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerMeshComponent.cs
@@ -17,7 +17,6 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Table;
@@ -43,8 +42,6 @@ namespace VisualPinball.Unity
 		public bool IsCircle => Shape == TriggerShape.TriggerStar || Shape == TriggerShape.TriggerButton;
 
 		public static readonly Type[] ValidParentTypes = Type.EmptyTypes;
-
-		public override IEnumerable<Type> ValidParents => ValidParentTypes;
 
 		protected override Mesh GetMesh(TriggerData data)
 			=> new TriggerMeshGenerator(data).GetMesh(MainComponent.PlayfieldHeight);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughComponent.cs
@@ -91,8 +91,6 @@ namespace VisualPinball.Unity
 		public override ItemType ItemType => ItemType.Trough;
 		public override string ItemName => "Trough";
 
-		public override IEnumerable<Type> ValidParents => System.Type.EmptyTypes;
-
 		public override TroughData InstantiateData() => new TroughData();
 
 		#endregion


### PR DESCRIPTION
The initial idea of parenting items to others was that you could use let's say a primitive collider for a rubber mesh and the collision events would get emitted on the rubber instead of the primitive.

However this introduces problems like not being able to simply group objects when we don't need event bubbling. Also, the way we'll handle those events is more likely via separate components. We already have such components, like `CollisionSwitchComponent`, which emits switch events on collision. This approach is more flexible and more explicit, thus more understandable.

So this PR removes the parent-child relationship, meaning auto-parenting of items with the `_Collider` suffix are removed as well.