### PR TITLE
Add emissive color to renderer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
             rid: osx-x64
           - os: macos-latest
             rid: osx-arm64
+          - os: macos-latest
+            rid: ios-arm64
           - os: ubuntu-latest
             rid: linux-x64
     steps:

--- a/VisualPinball.Engine/VisualPinball.Engine.csproj
+++ b/VisualPinball.Engine/VisualPinball.Engine.csproj
@@ -54,14 +54,13 @@
     <ItemGroup>
       <Plugins Include="$(OutDir)NLog.dll" />
       <Plugins Include="$(OutDir)OpenMcdf.dll" />
-
       <Plugins Include="$(OutDir)NetMiniZ.dll" />
-      <Plugins Include="$(NuGetPackageRoot)\netminiz.native.$(RuntimeIdentifier)\1.3.0\runtimes\$(RuntimeIdentifier)\native\*" />
-
       <Plugins Include="$(OutDir)NetVips.dll" />
-      <Plugins Include="$(NuGetPackageRoot)\netvips.native.$(RuntimeIdentifier)\8.12.1\runtimes\$(RuntimeIdentifier)\native\*" />
-
       <Plugins Include="$(OutDir)System.Buffers.dll" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(RuntimeIdentifier)' != 'ios-arm64'">
+      <Plugins Include="$(NuGetPackageRoot)\netminiz.native.$(RuntimeIdentifier)\1.3.0\runtimes\$(RuntimeIdentifier)\native\*" />
+      <Plugins Include="$(NuGetPackageRoot)\netvips.native.$(RuntimeIdentifier)\8.12.1\runtimes\$(RuntimeIdentifier)\native\*" />
     </ItemGroup>
     <Message Text="PluginsDeploy: @(Plugins)" />
     <Copy SourceFiles="@(Plugins)" DestinationFolder="..\VisualPinball.Unity\Plugins\$(RuntimeIdentifier)\" SkipUnchangedFiles="true" />

--- a/VisualPinball.Unity/Plugins/ios-arm64/FluentAssertions.dll.meta
+++ b/VisualPinball.Unity/Plugins/ios-arm64/FluentAssertions.dll.meta
@@ -1,0 +1,76 @@
+fileFormatVersion: 2
+guid: 7642ea36b9fa4ce88f332b2e344be707
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 0
+        Exclude tvOS: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/Plugins/ios-arm64/JeremyAnsel.Media.WavefrontObj.dll.meta
+++ b/VisualPinball.Unity/Plugins/ios-arm64/JeremyAnsel.Media.WavefrontObj.dll.meta
@@ -1,0 +1,76 @@
+fileFormatVersion: 2
+guid: 36a14415f90b49ce96cc7fac73992047
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 0
+        Exclude tvOS: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/Plugins/ios-arm64/NLog.dll.meta
+++ b/VisualPinball.Unity/Plugins/ios-arm64/NLog.dll.meta
@@ -1,0 +1,76 @@
+fileFormatVersion: 2
+guid: fad246ae587e4b53a088f42bdf9918df
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 0
+        Exclude tvOS: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/Plugins/ios-arm64/NetMiniZ.dll.meta
+++ b/VisualPinball.Unity/Plugins/ios-arm64/NetMiniZ.dll.meta
@@ -1,0 +1,76 @@
+fileFormatVersion: 2
+guid: ff4e1635e7894fca9fd09079f6448c1a
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 0
+        Exclude tvOS: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/Plugins/ios-arm64/NetVips.dll.meta
+++ b/VisualPinball.Unity/Plugins/ios-arm64/NetVips.dll.meta
@@ -1,0 +1,76 @@
+fileFormatVersion: 2
+guid: 19f231fb760641e9b316260436e907be
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 0
+        Exclude tvOS: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/Plugins/ios-arm64/OpenMcdf.dll.meta
+++ b/VisualPinball.Unity/Plugins/ios-arm64/OpenMcdf.dll.meta
@@ -1,0 +1,76 @@
+fileFormatVersion: 2
+guid: 24a8a8f1a93d4711bd3791ead9d975b0
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 0
+        Exclude tvOS: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/Plugins/ios-arm64/System.Buffers.dll.meta
+++ b/VisualPinball.Unity/Plugins/ios-arm64/System.Buffers.dll.meta
@@ -1,0 +1,76 @@
+fileFormatVersion: 2
+guid: 5c794ec1350a4f2a9bac1f58700452e9
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 0
+        Exclude tvOS: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/Plugins/ios-arm64/VisualPinball.Resources.dll.meta
+++ b/VisualPinball.Unity/Plugins/ios-arm64/VisualPinball.Resources.dll.meta
@@ -1,0 +1,76 @@
+fileFormatVersion: 2
+guid: 2497db4ebbed44c98eea94548327ca11
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 0
+        Exclude tvOS: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/Rendering/IMaterialConverter.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Rendering/IMaterialConverter.cs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System.Text;
+using UnityEngine;
 using VisualPinball.Engine.VPT;
 using Material = UnityEngine.Material;
 
@@ -64,5 +65,9 @@ namespace VisualPinball.Unity
 		void SetSmoothness(Material material, float smoothness);
 
 		int NormalMapProperty { get; }
+
+		void SetEmissiveColor(MaterialPropertyBlock propBlock, Color color);
+
+		Color? GetEmissiveColor(Material material);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/Rendering/Standard/StandardMaterialConverter.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Rendering/Standard/StandardMaterialConverter.cs
@@ -152,5 +152,17 @@ namespace VisualPinball.Unity
 		public void SetMaterialType(Material material, MaterialType materialType)
 		{
 		}
+
+		public void SetEmissiveColor(MaterialPropertyBlock propBlock, Color color)
+		{
+			// standard has no emissive color
+		}
+
+		public Color? GetEmissiveColor(Material material)
+		{
+			// standard has no emissive color
+
+			return null;
+		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Light/LightComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Light/LightComponent.cs
@@ -84,8 +84,6 @@ namespace VisualPinball.Unity
 		private const string BulbMeshName = "Light (Bulb)";
 		private const string SocketMeshName = "Light (Socket)";
 
-		private static readonly int EmissiveColorProperty = Shader.PropertyToID("_EmissiveColor");
-
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
 		#endregion
@@ -206,9 +204,9 @@ namespace VisualPinball.Unity
 			// emissive materials
 			_propBlock = new MaterialPropertyBlock();
 			foreach (var mr in GetComponentsInChildren<MeshRenderer>()) {
-				var emissiveColor = mr.sharedMaterial.GetColor(EmissiveColorProperty);
-				if (emissiveColor.a > 10f) {
-					_fullEmissions.Add((mr, emissiveColor, 0));
+				var emissiveColor = RenderPipeline.Current.MaterialConverter.GetEmissiveColor(mr.sharedMaterial);
+				if (emissiveColor?.a > 10f) {
+					_fullEmissions.Add((mr, (Color)emissiveColor, 0));
 				}
 			}
 		}
@@ -305,7 +303,7 @@ namespace VisualPinball.Unity
 				var (mr, color, lastValue) = _fullEmissions[i];
 				mr.GetPropertyBlock(_propBlock);
 				var emission = Mathf.Lerp(lastValue, value, position);
-				_propBlock.SetColor(EmissiveColorProperty, emission * color * 0.05f);
+				RenderPipeline.Current.MaterialConverter.SetEmissiveColor(_propBlock, emission * color * 0.05f);
 				_fullEmissions[i] = (mr, color, emission);
 				mr.SetPropertyBlock(_propBlock);
 			}
@@ -316,7 +314,7 @@ namespace VisualPinball.Unity
 		{
 			foreach (var (mr, color, lastValue) in _fullEmissions) {
 				mr.GetPropertyBlock(_propBlock);
-				_propBlock.SetColor(EmissiveColorProperty, value * color * 0.05f);
+				RenderPipeline.Current.MaterialConverter.SetEmissiveColor(_propBlock, value * color * 0.05f);
 				mr.SetPropertyBlock(_propBlock);
 			}
 		}


### PR DESCRIPTION
This PR adds two new methods to the `IMaterialConverter` interface:

```
public void SetEmissiveColor(MaterialPropertyBlock propBlock, Color color);
public Color? GetEmissiveColor(Material material)
```

Currently, only HDRP supports emissive color. 

When creating a new project that uses URP, when the player is activated, the lamp api will crash.


In addition to the render pipeline updates, this PR also adds support for ios-arm64. 