### PR TITLE
Rotate playfield to correct angle during gameplay.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Built with Unity 2021.2.
 - Native trough component ([#229](https://github.com/freezy/VisualPinball.Engine/pull/229), [#248](https://github.com/freezy/VisualPinball.Engine/pull/248), [#256](https://github.com/freezy/VisualPinball.Engine/pull/256), [Documentation](https://docs.visualpinball.org/creators-guide/manual/mechanisms/troughs.html)).
 
 ### Changed
+- Playfield is now rotated to the correct angle during gameplay ([#370](https://github.com/freezy/VisualPinball.Engine/pull/370))
 - Decouple light components from transformation override ([#350](https://github.com/freezy/VisualPinball.Engine/pull/350)).
 - Refactored drag points. They are nicely separated and typed now.
 - Collider debug view is now much faster and intuitive. It's also activated per default when there is no visible mesh.

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Playfield/PlayfieldInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Playfield/PlayfieldInspector.cs
@@ -28,6 +28,7 @@ namespace VisualPinball.Unity.Editor
 		private SerializedProperty _tableHeightProperty;
 		private SerializedProperty _angleTiltMinProperty;
 		private SerializedProperty _angleTiltMaxProperty;
+		private SerializedProperty _renderSlopeProperty;
 
 		protected override void OnEnable()
 		{
@@ -39,6 +40,7 @@ namespace VisualPinball.Unity.Editor
 			_tableHeightProperty = serializedObject.FindProperty(nameof(PlayfieldComponent.TableHeight));
 			_angleTiltMinProperty = serializedObject.FindProperty(nameof(PlayfieldComponent.AngleTiltMin));
 			_angleTiltMaxProperty = serializedObject.FindProperty(nameof(PlayfieldComponent.AngleTiltMax));
+			_renderSlopeProperty = serializedObject.FindProperty(nameof(PlayfieldComponent.RenderSlope));
 		}
 
 		public override void OnInspectorGUI()
@@ -59,6 +61,7 @@ namespace VisualPinball.Unity.Editor
 			});
 			PropertyField(_angleTiltMinProperty, "Slope for Min. Difficulty");
 			PropertyField(_angleTiltMaxProperty, "Slope for Max. Difficulty");
+			PropertyField(_renderSlopeProperty, "Rendered Playfield Angle");
 
 			base.OnInspectorGUI();
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Playfield/PlayfieldComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Playfield/PlayfieldComponent.cs
@@ -61,6 +61,9 @@ namespace VisualPinball.Unity
 
 		public float AngleTiltMin = 6f;
 
+		[Tooltip("How much the playfield should be rotated during runtime (in edit time, we keep it horizontal)")]
+		public float RenderSlope = 3.6f;
+
 		public int PlayfieldDetailLevel = 10;
 
 		public float GravityStrength = 1.762985f;
@@ -102,6 +105,8 @@ namespace VisualPinball.Unity
 			if (meshComp) {
 				World.DefaultGameObjectInjectionWorld.GetOrCreateSystem<StaticNarrowPhaseSystem>().CollideAgainstPlayfieldPlane = meshComp.AutoGenerate;
 			}
+
+			transform.RotateAround(Vector3.zero, Vector3.right, -RenderSlope);
 		}
 
 		public override IEnumerable<MonoBehaviour> SetData(TableData data)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerMeshComponent.cs
@@ -33,8 +33,9 @@ namespace VisualPinball.Unity
 
 		public int Shape;
 
-		[Min(0)]
+		[Range(0, 6)]
 		[Tooltip("Thickness of the trigger wire. Doesn't have any impact on the ball.")]
+
 		public float WireThickness;
 
 		#endregion


### PR DESCRIPTION
If we put the playfield into a cabinet model, we'll need to fix its rotation. We can't do it in the editor, because we need a horizontal playfield for editing. This PR adds a new *rendering slope* angle to the playfield component which rotates the playfield when a game starts.

Before:

![image](https://user-images.githubusercontent.com/70426/150015862-2022df7c-047a-49b4-8231-7c8905909c95.png)

After:

![image](https://user-images.githubusercontent.com/70426/150015926-a82339b9-a6f2-4497-a82c-dc786f9ba6c3.png)
