### PR TITLE
Ball-orientation-Nan-fix

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallData.cs
@@ -26,7 +26,24 @@ namespace VisualPinball.Unity
 		public float3 Position;
 		public float3 EventPosition; // m_lastEventPos
 		public float3 Velocity;
+
+		/// <summary>
+		/// AngularVelocity 
+		///		* Set to 0 at start
+		///			(in BallManualRoll(in Entity entity, in float3 targetWorldPosition)
+		///			(which is not used anywhere)
+		///		* Used to get  tangential velocity due to rotation when rolling / colliding on surfaces (alsways added to normal velocity) 
+		///			(in BallData.SurfaceVelocity(in BallData ball, in float3 surfP))
+		///		* Calculated from AngularMomentum / inertia 
+		///			(In BallDisplacementSystem.OnUpdate())
+		///			(Where Inertia is a "constant" based on radius and mass (2/5 m r^2))
+		/// </summary>
 		public float3 AngularVelocity;
+		/// <summary>
+		/// AngularMomentum
+		///		* set to 0 at Start.
+		///		* When a survace applies an impule, it applies it to velocity and to angMom. ()
+		/// </summary>
 		public float3 AngularMomentum;
 		public float3x3 Orientation;
 		public float Radius;
@@ -72,7 +89,12 @@ namespace VisualPinball.Unity
 			}
 		}
 
+		/// <summary>
+		/// Calculates Moment of Inertia for a Ball 
+		/// https://en.wikipedia.org/wiki/Moment_of_inertia#Examples_2
+		/// </summary>
 		public float Inertia => 2.0f / 5.0f * Radius * Radius * Mass;
+		
 		public float InvMass => 1f / Mass;
 
 		public void ApplySurfaceImpulse(in float3 rotI, in float3 impulse)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallData.cs
@@ -29,20 +29,39 @@ namespace VisualPinball.Unity
 
 		/// <summary>
 		/// AngularVelocity 
-		///		* Set to 0 at start
+		///		* Set to 0 at Manual Roll
 		///			(in BallManualRoll(in Entity entity, in float3 targetWorldPosition)
 		///			(which is not used anywhere)
-		///		* Used to get  tangential velocity due to rotation when rolling / colliding on surfaces (alsways added to normal velocity) 
-		///			(in BallData.SurfaceVelocity(in BallData ball, in float3 surfP))
+		///		* Is set to zero At RotatorComponent. Possibly an error and should be AngularVelocity 
+		///			(in UpdateRotation(float angleDeg))
 		///		* Calculated from AngularMomentum / inertia 
 		///			(In BallDisplacementSystem.OnUpdate())
 		///			(Where Inertia is a "constant" based on radius and mass (2/5 m r^2))
+		///		* Used to get tangential velocity due to rotation when rolling / colliding on surfaces (alsways added to normal velocity) 
+		///			(in BallData.SurfaceVelocity(in BallData ball, in float3 surfP))
+
 		/// </summary>
 		public float3 AngularVelocity;
 		/// <summary>
 		/// AngularMomentum
-		///		* set to 0 at Start.
-		///		* When a survace applies an impule, it applies it to velocity and to angMom. ()
+		///		* Set to 0 at Manual Roll
+		///			(in BallManualRoll(in Entity entity, in float3 targetWorldPosition)
+		///		* Set to 0 at every new ball	
+		///			(in Ballmanager.CreateEntity(GameObject ballGo, int id, in float3 worldPos, in float3 localPos, in float3 localVel, in float scale, in float mass, in float radius, in Entity kickerEntity)
+		///		* Set to 0 in KickerApi, KickerCollider and RotatorComponent
+		///			(in several places)
+		///		* Calculated when a survace applies an impulse, it applies it to velocity (div by mass) and to angMom fully. 
+		///			(ApplySurfaceImpulse(in float3 rotI, in float3 impulse))
+		///			(Where rotI seems to be the Rotation impulse and impulse is the (non angular)velocity (makes sense to divide by mass)
+		///			(angularMomenmtom = rotI;)
+		///		* used to calculate Angular Velocity (ball.AngularVelocity = ball.AngularMomentum / inertia;)
+		///			(in BalldisplacementSystem.OnUpdate())
+		///		* used to add and thus calculate Orientation 
+		///			(in BalldisplacementSystem.OnUpdate())
+		///			skewSymmetricMatrix is created from the Angular Momentum divided by Inertia
+		///			The original orientation is multiplied with the skewSymmetric Matrix
+		///			and added to the old Orientation to form new orientation
+		///			
 		/// </summary>
 		public float3 AngularMomentum;
 		public float3x3 Orientation;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallData.cs
@@ -28,7 +28,8 @@ namespace VisualPinball.Unity
 		public float3 Velocity;
 
 		/// <summary>
-		/// AngularVelocity 
+		/// AngularVelocity  -  german: Winkelgeschwindigkeit
+
 		///		* Set to 0 at Manual Roll
 		///			(in BallManualRoll(in Entity entity, in float3 targetWorldPosition)
 		///			(which is not used anywhere)
@@ -39,11 +40,10 @@ namespace VisualPinball.Unity
 		///			(Where Inertia is a "constant" based on radius and mass (2/5 m r^2))
 		///		* Used to get tangential velocity due to rotation when rolling / colliding on surfaces (alsways added to normal velocity) 
 		///			(in BallData.SurfaceVelocity(in BallData ball, in float3 surfP))
-
 		/// </summary>
 		public float3 AngularVelocity;
 		/// <summary>
-		/// AngularMomentum
+		/// AngularMomentum  - german: drehimpuls, Impulsmomemt
 		///		* Set to 0 at Manual Roll
 		///			(in BallManualRoll(in Entity entity, in float3 targetWorldPosition)
 		///		* Set to 0 at every new ball	

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallData.cs
@@ -32,7 +32,7 @@ namespace VisualPinball.Unity
 
 		///		* Set to 0 at Manual Roll
 		///			(in BallManualRoll(in Entity entity, in float3 targetWorldPosition)
-		///			(which is not used anywhere)
+		///			(which is not used anywhere in this Project, but is at least used in Ravarcade's ImGui Physics Debugger - Addon)
 		///		* Is set to zero At RotatorComponent. Possibly an error and should be AngularVelocity 
 		///			(in UpdateRotation(float angleDeg))
 		///		* Calculated from AngularMomentum / inertia 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallDisplacementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallDisplacementSystem.cs
@@ -56,6 +56,7 @@ namespace VisualPinball.Unity
 
 				ball.Orientation += addedOrientation;
 				math.orthonormalize(ball.Orientation);
+				NormalizeOrientation(ball.Orientation);
 				// https://docs.unity.cn/Packages/com.unity.mathematics@1.2/api/Unity.Mathematics.math.orthonormalize.html#Unity_Mathematics_math_orthonormalize_Unity_Mathematics_float3x3_
 
 				// angular momentum = drehimpuls / Schwung, Impulsmomemt
@@ -65,6 +66,23 @@ namespace VisualPinball.Unity
 				marker.End();
 
 			}).Run();
+		}
+
+		private void NormalizeOrientation(float3x3 orientation)
+		{
+			float lengthX, lengthY, lengthZ = 0f;
+			lengthX = math.sqrt(orientation.c0.x * orientation.c0.x + orientation.c1.x * orientation.c1.x + orientation.c2.x * orientation.c2.x);
+			lengthY = math.sqrt(orientation.c0.y * orientation.c0.y + orientation.c1.y * orientation.c1.y + orientation.c2.y * orientation.c2.y);
+			lengthZ = math.sqrt(orientation.c0.z * orientation.c0.z + orientation.c1.z * orientation.c1.z + orientation.c2.z * orientation.c2.z);
+			orientation.c0.x /= lengthX;
+			orientation.c1.x /= lengthX;
+			orientation.c2.x /= lengthX;
+			orientation.c0.y /= lengthY;
+			orientation.c1.y /= lengthY;
+			orientation.c2.y /= lengthY;
+			orientation.c0.z /= lengthZ;
+			orientation.c1.z /= lengthZ;
+			orientation.c2.z /= lengthZ;
 		}
 
 		private static float3x3 CreateSkewSymmetric(in float3 pv3D)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallDisplacementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallDisplacementSystem.cs
@@ -56,33 +56,43 @@ namespace VisualPinball.Unity
 
 				ball.Orientation += addedOrientation;
 				math.orthonormalize(ball.Orientation);
-				NormalizeOrientation(ball.Orientation);
-				// https://docs.unity.cn/Packages/com.unity.mathematics@1.2/api/Unity.Mathematics.math.orthonormalize.html#Unity_Mathematics_math_orthonormalize_Unity_Mathematics_float3x3_
 
-				// angular momentum = drehimpuls / Schwung, Impulsmomemt
-				// angular velocity = Winkelgeschwindigkeit
+				// after Othonomalization, the Orientation vectors also have to be normalized - this is not done by othonomalize, since the skew matrix creates quite lengthy vectors.
+				// in fact, they dont have to be normalized, but just shortened, so we can abs-add the x, y and z together and just divide by the sum.
+				// This saves three qrts in the game loop per ball. 
+				float lengthX, lengthY, lengthZ;
+				/* Correct normalization would be: 
+				 * lengthX = math.sqrt(ball.Orientation.c0.x * ball.Orientation.c0.x + ball.Orientation.c0.y * ball.Orientation.c0.y + ball.Orientation.c0.z * ball.Orientation.c0.z);
+				 * lengthY = math.sqrt(ball.Orientation.c1.x * ball.Orientation.c1.x + ball.Orientation.c1.y * ball.Orientation.c1.y + ball.Orientation.c1.z * ball.Orientation.c1.z);
+				 * lengthZ = math.sqrt(ball.Orientation.c2.x * ball.Orientation.c2.x + ball.Orientation.c2.y * ball.Orientation.c2.y + ball.Orientation.c2.z * ball.Orientation.c2.z);
+				 */
+				lengthX = math.abs(ball.Orientation.c0.x) + math.abs(ball.Orientation.c0.y) + math.abs(ball.Orientation.c0.z);
+				lengthY = math.abs(ball.Orientation.c1.x) + math.abs(ball.Orientation.c1.y) + math.abs(ball.Orientation.c1.z);
+				lengthZ = math.abs(ball.Orientation.c2.x) + math.abs(ball.Orientation.c2.y) + math.abs(ball.Orientation.c2.z);
+				if (lengthX != 0f)
+				{
+					ball.Orientation.c0.x /= lengthX;
+					ball.Orientation.c0.y /= lengthX;
+					ball.Orientation.c0.z /= lengthX;
+				}
+				if (lengthY != 0f)
+				{
+					ball.Orientation.c1.x /= lengthY;
+					ball.Orientation.c1.y /= lengthY;
+					ball.Orientation.c1.z /= lengthY;
+				}
+				if (lengthZ != 0f)
+				{
+					ball.Orientation.c2.x /= lengthZ;
+					ball.Orientation.c2.y /= lengthZ;
+					ball.Orientation.c2.z /= lengthZ;
+				}
+
 				ball.AngularVelocity = ball.AngularMomentum / inertia;
 
 				marker.End();
 
 			}).Run();
-		}
-
-		private void NormalizeOrientation(float3x3 orientation)
-		{
-			float lengthX, lengthY, lengthZ = 0f;
-			lengthX = math.sqrt(orientation.c0.x * orientation.c0.x + orientation.c1.x * orientation.c1.x + orientation.c2.x * orientation.c2.x);
-			lengthY = math.sqrt(orientation.c0.y * orientation.c0.y + orientation.c1.y * orientation.c1.y + orientation.c2.y * orientation.c2.y);
-			lengthZ = math.sqrt(orientation.c0.z * orientation.c0.z + orientation.c1.z * orientation.c1.z + orientation.c2.z * orientation.c2.z);
-			orientation.c0.x /= lengthX;
-			orientation.c1.x /= lengthX;
-			orientation.c2.x /= lengthX;
-			orientation.c0.y /= lengthY;
-			orientation.c1.y /= lengthY;
-			orientation.c2.y /= lengthY;
-			orientation.c0.z /= lengthZ;
-			orientation.c1.z /= lengthZ;
-			orientation.c2.z /= lengthZ;
 		}
 
 		private static float3x3 CreateSkewSymmetric(in float3 pv3D)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallDisplacementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallDisplacementSystem.cs
@@ -1,4 +1,4 @@
-// Visual Pinball Engine
+// Visual Pinball Engineball.Orientation
 // Copyright (C) 2022 freezy and VPE Team
 //
 // This program is free software: you can redistribute it and/or modify
@@ -56,7 +56,10 @@ namespace VisualPinball.Unity
 
 				ball.Orientation += addedOrientation;
 				math.orthonormalize(ball.Orientation);
+				// https://docs.unity.cn/Packages/com.unity.mathematics@1.2/api/Unity.Mathematics.math.orthonormalize.html#Unity_Mathematics_math_orthonormalize_Unity_Mathematics_float3x3_
 
+				// angular momentum = drehimpuls / Schwung, Impulsmomemt
+				// angular velocity = Winkelgeschwindigkeit
 				ball.AngularVelocity = ball.AngularMomentum / inertia;
 
 				marker.End();

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallDisplacementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallDisplacementSystem.cs
@@ -57,9 +57,9 @@ namespace VisualPinball.Unity
 				ball.Orientation += addedOrientation;
 				math.orthonormalize(ball.Orientation);
 
-				// after Othonomalization, the Orientation vectors also have to be normalized - this is not done by othonomalize, since the skew matrix creates quite lengthy vectors.
+				// after Orthonormalization, the orientation vectors also have to be normalized - this is not done by othonomalize, since the skew matrix creates quite lengthy vectors.
 				// in fact, they dont have to be normalized, but just shortened, so we can abs-add the x, y and z together and just divide by the sum.
-				// This saves three qrts in the game loop per ball. 
+				// This saves three sqrts in the game loop per ball. 
 				float lengthX, lengthY, lengthZ;
 				/* Correct normalization would be: 
 				 * lengthX = math.sqrt(ball.Orientation.c0.x * ball.Orientation.c0.x + ball.Orientation.c0.y * ball.Orientation.c0.y + ball.Orientation.c0.z * ball.Orientation.c0.z);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallMovementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallMovementSystem.cs
@@ -60,8 +60,20 @@ namespace VisualPinball.Unity
 				var zHeight = !ball.IsFrozen ? ball.Position.z : ball.Position.z - ball.Radius;
 
 				var or = ball.Orientation;
+				var vpright = new Vector3(or.c0.x, or.c1.x, or.c2.x);
+				var vpfront = new Vector3(or.c0.y, or.c1.y, or.c2.y);
+				var vptop = new Vector3(or.c0.z, or.c1.z, or.c2.z);
+				Debug.Log("c0: (" + or.c0.x + ", " + or.c0.y + ", " + or.c0.z + ")");
+				Debug.Log("c1: (" + or.c1.x + ", " + or.c1.y + ", " + or.c1.z + ")");
+				Debug.Log("c2: (" + or.c2.x + ", " + or.c2.y + ", " + or.c2.z + ")");
 				var ballTransform = _player.Balls[entity].transform;
 				ballTransform.localPosition = new Vector3(ball.Position.x, ball.Position.y, zHeight);
+				Vector3.OrthoNormalize(ref vptop, ref vpfront, ref vpright);
+
+				var unitytop = new Vector3(vptop.x, vptop.z, vptop.y);
+				var unityfront = new Vector3(vpfront.x, vpfront.z, vpfront.y);
+
+				Vector3.OrthoNormalize(ref unitytop, ref unityfront);
 
 				// Following is the transistion from VP-Physics Ball Orientation to the Unity Ball-Orientation.
 				// following statements: when looking at the backglass:
@@ -81,7 +93,14 @@ namespace VisualPinball.Unity
 				//1st iteration by (looks strange, but less strange)  (cupiii)
 				//ballTransform.localRotation = Quaternion.LookRotation(new Vector3(or.c0.x*-1, or.c1.x*-1, or.c2.x), new Vector3(or.c0.z*-1, or.c1.z*-1, or.c2.z));
 				//newest iteration (hopefully correct))
-				ballTransform.localRotation = Quaternion.LookRotation(new Vector3(or.c0.z*1f, or.c2.z*1f, or.c1.z*1f), new Vector3(or.c0.y*1f, or.c2.y*1f, or.c1.y*1f));
+
+				// Better Ways than skew matrix: 
+				//    https://gamedev.stackexchange.com/questions/108920/applying-angular-velocity-to-quaternion
+				//	  https://stackoverflow.com/questions/23503151/how-to-update-quaternion-based-on-3d-gyro-data
+				//    https://stackoverflow.com/questions/12053895/converting-angular-velocity-to-quaternion-in-opencv
+
+				ballTransform.localRotation = Quaternion.LookRotation(unityfront, unitytop);
+
 
 				marker.End();
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallMovementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallMovementSystem.cs
@@ -58,16 +58,17 @@ namespace VisualPinball.Unity
 
 				// calculate/adapt height of ball
 				var zHeight = !ball.IsFrozen ? ball.Position.z : ball.Position.z - ball.Radius;
+				var ballTransform = _player.Balls[entity].transform;
+				ballTransform.localPosition = new Vector3(ball.Position.x, ball.Position.y, zHeight);
+
 
 				var or = ball.Orientation;
 				var vpright = new Vector3(or.c0.x, or.c1.x, or.c2.x);
 				var vpfront = new Vector3(or.c0.y, or.c1.y, or.c2.y);
 				var vptop = new Vector3(or.c0.z, or.c1.z, or.c2.z);
-				Debug.Log("c0: (" + or.c0.x + ", " + or.c0.y + ", " + or.c0.z + ")");
-				Debug.Log("c1: (" + or.c1.x + ", " + or.c1.y + ", " + or.c1.z + ")");
-				Debug.Log("c2: (" + or.c2.x + ", " + or.c2.y + ", " + or.c2.z + ")");
-				var ballTransform = _player.Balls[entity].transform;
-				ballTransform.localPosition = new Vector3(ball.Position.x, ball.Position.y, zHeight);
+				// Debug.Log("c0: (" + or.c0.x + ", " + or.c0.y + ", " + or.c0.z + ")");
+				// Debug.Log("c1: (" + or.c1.x + ", " + or.c1.y + ", " + or.c1.z + ")");
+				// Debug.Log("c2: (" + or.c2.x + ", " + or.c2.y + ", " + or.c2.z + ")");
 				Vector3.OrthoNormalize(ref vptop, ref vpfront, ref vpright);
 				var unitytop = new Vector3(vptop.x, vptop.z, vptop.y);
 				var unityfront = new Vector3(vpfront.x, vpfront.z, vpfront.y);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallMovementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallMovementSystem.cs
@@ -69,7 +69,6 @@ namespace VisualPinball.Unity
 				var ballTransform = _player.Balls[entity].transform;
 				ballTransform.localPosition = new Vector3(ball.Position.x, ball.Position.y, zHeight);
 				Vector3.OrthoNormalize(ref vptop, ref vpfront, ref vpright);
-
 				var unitytop = new Vector3(vptop.x, vptop.z, vptop.y);
 				var unityfront = new Vector3(vpfront.x, vpfront.z, vpfront.y);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallMovementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallMovementSystem.cs
@@ -99,6 +99,9 @@ namespace VisualPinball.Unity
 				//	  https://stackoverflow.com/questions/23503151/how-to-update-quaternion-based-on-3d-gyro-data
 				//    https://stackoverflow.com/questions/12053895/converting-angular-velocity-to-quaternion-in-opencv
 
+				// also implementing VP's "Orthonormalize" Code - although it does not really orthonormalize could give a performance benefit:
+				// https://github.com/vpinball/vpinball/blob/be08b04d61096272df97bd45e6f0682043228a73/math/matrix.h#L208
+
 				ballTransform.localRotation = Quaternion.LookRotation(unityfront, unitytop);
 
 


### PR DESCRIPTION
This fixes the ball orientation lock that occoured after a while playing.

The Skew Matrix produced more and more longer vectors in the orientation matrix. 
Fix is to "kind of" normalize the single vectors inside the orientation matrix. 
"Kind of": we don't need to normalize fully (dividing by sqrt(x^2+y^2+z^2)), since we don't use the vector lengthes anywhere (and also should not use them anywhere).
So we can divide by the sum of absolute values of x, y and z). Giving "somewhat" normalized vectors.

Also made the BallMovementsystem a little bit more clear, introducing some inbetween-vectors. I think the clearity is worth the small performance cost.

While analysing I added some comments about general ball-physics that may be useful in the future. 