### PR TITLE
Remove internal id from switches, lamps, and coils

### DIFF
--- a/VisualPinball.Engine/Game/Engines/GamelogicEngineCoil.cs
+++ b/VisualPinball.Engine/Game/Engines/GamelogicEngineCoil.cs
@@ -26,7 +26,6 @@ namespace VisualPinball.Engine.Game.Engines
 		public virtual string Id { get => _id; set => _id = value; }
 		public virtual string Description { get => _description; set => _description = value; }
 
-		public int InternalId;
 		public string DeviceHint { get => _deviceHint; set => _deviceHint = value; }
 		public string DeviceItemHint { get => _deviceItemHint; set => _deviceItemHint = value; }
 		public int NumMatches { get => _numMatches; set => _numMatches = value; }
@@ -46,13 +45,11 @@ namespace VisualPinball.Engine.Game.Engines
 		public GamelogicEngineCoil(string id)
 		{
 			Id = id;
-			InternalId = int.TryParse(id, out var internalId) ? internalId : 0;
 		}
 
-		public GamelogicEngineCoil(string id, int internalId)
+		public GamelogicEngineCoil(int id)
 		{
-			Id = id;
-			InternalId = internalId;
+			Id = id.ToString();
 		}
 	}
 }

--- a/VisualPinball.Engine/Game/Engines/GamelogicEngineLamp.cs
+++ b/VisualPinball.Engine/Game/Engines/GamelogicEngineLamp.cs
@@ -35,11 +35,6 @@ namespace VisualPinball.Engine.Game.Engines
 		public virtual string Description { get => _description; set => _description = value; }
 
 		/// <summary>
-		/// Some gamelogic engines use integers for the ID. In order to avoid repetitive casting, we store it as integer as well.
-		/// </summary>
-		public int InternalId;
-
-		/// <summary>
 		/// Which channel this lamp corresponds to.
 		/// </summary>
 		public ColorChannel Channel = ColorChannel.Alpha;
@@ -84,13 +79,11 @@ namespace VisualPinball.Engine.Game.Engines
 		public GamelogicEngineLamp(string id)
 		{
 			Id = id;
-			InternalId = int.TryParse(id, out var internalId) ? internalId : 0;
 		}
 
-		public GamelogicEngineLamp(string id, int internalId)
+		public GamelogicEngineLamp(int id)
 		{
-			Id = id;
-			InternalId = internalId;
+			Id = id.ToString();
 		}
 	}
 

--- a/VisualPinball.Engine/Game/Engines/GamelogicEngineSwitch.cs
+++ b/VisualPinball.Engine/Game/Engines/GamelogicEngineSwitch.cs
@@ -41,12 +41,6 @@ namespace VisualPinball.Engine.Game.Engines
 		public virtual string Id { get => _id; set => _id = value; }
 
 		/// <summary>
-		/// A numerical identifier that can be used in gamelogic engines that
-		/// are tied to numerical identifiers.
-		/// </summary>
-		public int InternalId;
-
-		/// <summary>
 		/// If true, inverts the signal, i.e. disabled switches return "closed" (true),
 		/// while enabled switched return "open" (false).
 		/// </summary>
@@ -76,13 +70,11 @@ namespace VisualPinball.Engine.Game.Engines
 		public GamelogicEngineSwitch(string id)
 		{
 			Id = id;
-			InternalId = int.TryParse(id, out var internalId) ? internalId : 0;
 		}
 
-		public GamelogicEngineSwitch(string id, int internalId)
+		public GamelogicEngineSwitch(int id)
 		{
-			Id = id;
-			InternalId = internalId;
+			Id = id.ToString();
 		}
 	}
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Coil/CoilListData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Coil/CoilListData.cs
@@ -34,7 +34,6 @@ namespace VisualPinball.Unity.Editor
 		public string Element;
 
 		public string Id;
-		public int InternalId { get; set; }
 		public ICoilDeviceComponent Device;
 		public string DeviceItem { get; set; }
 
@@ -44,7 +43,6 @@ namespace VisualPinball.Unity.Editor
 
 		public CoilListData(CoilMapping coilMapping) {
 			Id = coilMapping.Id;
-			InternalId = coilMapping.InternalId;
 			Description = coilMapping.Description;
 			Destination = coilMapping.Destination;
 			Device = coilMapping.Device;
@@ -61,7 +59,6 @@ namespace VisualPinball.Unity.Editor
 		public void Update()
 		{
 			CoilMapping.Id = Id;
-			CoilMapping.InternalId = InternalId;
 			CoilMapping.Description = Description;
 			CoilMapping.Destination = Destination;
 			CoilMapping.Device = Device;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Coil/CoilListViewItemRenderer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Coil/CoilListViewItemRenderer.cs
@@ -117,7 +117,6 @@ namespace VisualPinball.Unity.Editor
 					} else if (index == CoilDestination.Lamp) {
 						_tableComponent.MappingConfig.AddLamp(new LampMapping {
 							Id = coilListData.Id,
-							InternalId = coilListData.InternalId,
 							Source = LampSource.Lamp,
 							IsCoil = true,
 							Description = coilListData.Description

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Coil/CoilManager.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Coil/CoilManager.cs
@@ -151,7 +151,6 @@ namespace VisualPinball.Unity.Editor
 			RecordUndo(undoName);
 			TableComponent.MappingConfig.AddCoil(new CoilMapping {
 				Id = data.Id,
-				InternalId = data.InternalId,
 				Description = data.Description,
 				Destination = data.Destination,
 				Device = data.Device,

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/IDeviceListData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/IDeviceListData.cs
@@ -22,7 +22,6 @@ namespace VisualPinball.Unity.Editor
 	{
 		IDeviceComponent<T> DeviceComponent { get; }
 		string DeviceItem { get; set; }
-		int InternalId { get; set; }
 		string Description { get; set; }
 
 		void ClearDevice();

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Lamp/LampListData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Lamp/LampListData.cs
@@ -24,8 +24,6 @@ namespace VisualPinball.Unity.Editor
 		[ManagerListColumn(Order = 0, HeaderName = "ID", Width = 135)]
 		public string Name => Id;
 
-		public int InternalId { get; set; }
-
 		[ManagerListColumn(Order = 1, HeaderName = "Description", Width = 300)]
 		public string Description { get; set; }
 
@@ -55,7 +53,6 @@ namespace VisualPinball.Unity.Editor
 		public LampListData(LampMapping lampMapping)
 		{
 			Id = lampMapping.Id;
-			InternalId = lampMapping.InternalId;
 			IsCoil = lampMapping.IsCoil;
 			Source = lampMapping.Source;
 			Description = lampMapping.Description;
@@ -71,7 +68,6 @@ namespace VisualPinball.Unity.Editor
 		public void Update()
 		{
 			LampMapping.Id = Id;
-			LampMapping.InternalId = InternalId;
 			LampMapping.IsCoil = IsCoil;
 			LampMapping.Source = Source;
 			LampMapping.Description = Description;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Lamp/LampListViewItemRenderer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Lamp/LampListViewItemRenderer.cs
@@ -136,8 +136,6 @@ namespace VisualPinball.Unity.Editor
 			}
 			cellRect.x += 20;
 			cellRect.width -= 20;
-
-			EditorGUI.LabelField(cellRect, lampListData.InternalId.ToString());
 		}
 
 		protected override void RenderDeviceElement(LampListData listData, Rect cellRect, Action<LampListData> updateAction)

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Lamp/LampListViewItemRenderer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Lamp/LampListViewItemRenderer.cs
@@ -134,8 +134,6 @@ namespace VisualPinball.Unity.Editor
 				EditorGUI.DrawTextureTransparent(iconRect, icon, ScaleMode.ScaleToFit);
 				GUI.color = guiColor;
 			}
-			cellRect.x += 20;
-			cellRect.width -= 20;
 		}
 
 		protected override void RenderDeviceElement(LampListData listData, Rect cellRect, Action<LampListData> updateAction)

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Lamp/LampManager.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Lamp/LampManager.cs
@@ -195,7 +195,6 @@ namespace VisualPinball.Unity.Editor
 
 			TableComponent.MappingConfig.AddLamp(new LampMapping {
 				Id = data.Id,
-				InternalId = data.InternalId,
 				Description = data.Description,
 				Device = data.Device,
 				DeviceItem = data.DeviceItem,

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/ListViewItemRenderer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/ListViewItemRenderer.cs
@@ -44,7 +44,6 @@ namespace VisualPinball.Unity.Editor
 
 		protected void RenderId(Dictionary<string, TStatus> statuses, ref string id, Action<string> setId, TListData listData, Rect cellRect, Action<TListData> updateAction)
 		{
-			const float idWidth = 25f;
 			const float padding = 2f;
 
 			// add some padding
@@ -52,12 +51,7 @@ namespace VisualPinball.Unity.Editor
 			cellRect.width -= 2 * padding;
 
 			var dropdownRect = cellRect;
-			dropdownRect.width -= idWidth + 2 * padding;
-
-			var idRect = cellRect;
-			idRect.width = idWidth;
-			idRect.x += cellRect.width - idWidth;
-
+			
 			var options = new List<string>(GleItems.Select(entry => entry.Id).ToArray());
 			if (options.Count > 0) {
 				options.Add("");
@@ -65,7 +59,6 @@ namespace VisualPinball.Unity.Editor
 			options.Add("Add...");
 
 			if (Application.isPlaying && statuses != null) {
-
 				var iconRect = cellRect;
 				iconRect.width = 20;
 
@@ -107,13 +100,6 @@ namespace VisualPinball.Unity.Editor
 					setId(GleItems[index].Id);
 					updateAction(listData);
 				}
-			}
-
-			EditorGUI.BeginChangeCheck();
-			var value = EditorGUI.IntField(idRect, listData.InternalId);
-			if (EditorGUI.EndChangeCheck()) {
-				listData.InternalId = value;
-				updateAction(listData);
 			}
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/ManagerListView.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/ManagerListView.cs
@@ -145,7 +145,12 @@ namespace VisualPinball.Unity.Editor
 							} else if (bVal == null) {
 								compareResult = -1;
 							} else {
-								compareResult = aVal.CompareTo(bVal);
+								if (aVal is string && bVal is string && int.TryParse((string)aVal, out int aNum) && int.TryParse((string)bVal, out int bNum)) {
+									compareResult = aNum.CompareTo(bNum);
+								}
+								else {
+									compareResult = aVal.CompareTo(bVal);
+								}
 							}
 						}
 						// not equal in this column, then return that

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Switch/SwitchListData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Switch/SwitchListData.cs
@@ -40,7 +40,6 @@ namespace VisualPinball.Unity.Editor
 		public int PulseDelay;
 
 		public string Id;
-		public int InternalId { get; set; }
 		public string InputActionMap;
 		public string InputAction;
 		public SwitchConstant Constant;
@@ -53,7 +52,6 @@ namespace VisualPinball.Unity.Editor
 
 		public SwitchListData(SwitchMapping switchMapping) {
 			Id = switchMapping.Id;
-			InternalId = switchMapping.InternalId;
 			NormallyClosed = switchMapping.IsNormallyClosed;
 			Description = switchMapping.Description;
 			Source = switchMapping.Source;
@@ -76,7 +74,6 @@ namespace VisualPinball.Unity.Editor
 		public void Update()
 		{
 			SwitchMapping.Id = Id;
-			SwitchMapping.InternalId = InternalId;
 			SwitchMapping.IsNormallyClosed = NormallyClosed;
 			SwitchMapping.Description = Description;
 			SwitchMapping.Source = Source;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Switch/SwitchManager.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Switch/SwitchManager.cs
@@ -151,7 +151,6 @@ namespace VisualPinball.Unity.Editor
 
 			TableComponent.MappingConfig.AddSwitch(new SwitchMapping {
 				Id = data.Id,
-				InternalId = data.InternalId,
 				IsNormallyClosed = data.NormallyClosed,
 				Description = data.Description,
 				Source = data.Source,

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Wire/WireListData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Managers/Wire/WireListData.cs
@@ -51,7 +51,6 @@ namespace VisualPinball.Unity.Editor
 
 		public IDeviceComponent<IGamelogicEngineDeviceItem> DeviceComponent => DestinationDevice;
 		public string DeviceItem { get => DestinationDeviceItem; set => DestinationDeviceItem = value; }
-		public int InternalId { get; set; }
 
 		public WireListData(WireMapping wireMapping)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity.Test/Mappings/CoilPopulationTests.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Test/Mappings/CoilPopulationTests.cs
@@ -55,10 +55,9 @@ namespace VisualPinball.Unity.Test
 		{
 			var coil = new CoilMapping {
 				Id = "c_left_flipper",
-				InternalId = 12,
 				Description = "Left Flipper"
 			};
-			coil.ToString().Should().Be("coil c_left_flipper (12) Left Flipper");
+			coil.ToString().Should().Be("coil c_left_flipper Left Flipper");
 		}
 
 		[Test]

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/SegmentDisplayComponent.cs
@@ -22,7 +22,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using NLog;
-using NLog.LayoutRenderers.Wrappers;
 using Unity.Mathematics;
 using UnityEngine;
 using Logger = NLog.Logger;
@@ -242,7 +241,6 @@ namespace VisualPinball.Unity
 
 		public override void UpdateFrame(DisplayFrameFormat format, byte[] source)
 		{
-			Debug.Log($"Getting segment data!");
 			ushort[] target;
 			switch (format) {
 				case DisplayFrameFormat.Dmd2:

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/CoilPlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/CoilPlayer.cs
@@ -136,7 +136,7 @@ namespace VisualPinball.Unity
 					}
 
 					if (destConfig.IsLampCoil) {
-						_lampPlayer!.HandleCoilEvent(coilEvent.Id, coilEvent.InternalId, coilEvent.IsEnabled);
+						_lampPlayer!.HandleCoilEvent(coilEvent.Id, coilEvent.IsEnabled);
 						continue;
 					}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/IGamelogicEngine.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/IGamelogicEngine.cs
@@ -213,10 +213,6 @@ namespace VisualPinball.Unity
 		/// </summary>
 		public readonly string Id;
 
-		/// Internal ID of the coil.
-		/// </summary>
-		public readonly int InternalId;
-
 		/// <summary>
 		/// State of the coil, true if the coil is under voltage, false if not.
 		/// </summary>
@@ -225,14 +221,6 @@ namespace VisualPinball.Unity
 		public CoilEventArgs(string id, bool isEnabled)
 		{
 			Id = id;
-			InternalId = int.TryParse(id, out var internalId) ? internalId : 0;
-			IsEnabled = isEnabled;
-		}
-
-		public CoilEventArgs(string id, int internalId, bool isEnabled)
-		{
-			Id = id;
-			InternalId = internalId;
 			IsEnabled = isEnabled;
 		}
 	}
@@ -243,11 +231,6 @@ namespace VisualPinball.Unity
 		/// ID of the lamp, as defined by <see cref="IGamelogicEngine.RequestedLamps"/>.
 		/// </summary>
 		public readonly string Id;
-
-		/// <summary>
-		/// Internal ID of the lamp. Some lamps have multiple internal IDs per ID, like RGBs.
-		/// </summary>
-		public readonly int InternalId;
 
 		/// <summary>
 		/// The intensity of the light. The range is dependent on the GLE,
@@ -269,16 +252,6 @@ namespace VisualPinball.Unity
 		public LampEventArgs(string id, float value, LampSource source = LampSource.Lamp)
 		{
 			Id = id;
-			InternalId = int.TryParse(id, out var internalId) ? internalId : 0;
-			Value = value;
-			Source = source;
-			IsCoil = false;
-		}
-
-		public LampEventArgs(string id, int internalId, float value, LampSource source = LampSource.Lamp)
-		{
-			Id = id;
-			InternalId = internalId;
 			Value = value;
 			Source = source;
 			IsCoil = false;
@@ -287,7 +260,6 @@ namespace VisualPinball.Unity
 		public LampEventArgs(string id, float value, bool isCoil, LampSource source = LampSource.Lamp)
 		{
 			Id = id;
-			InternalId = int.TryParse(id, out var internalId) ? internalId : 0;
 			Value = value;
 			Source = source;
 			IsCoil = isCoil;

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
@@ -116,9 +116,9 @@ namespace VisualPinball.Unity
 		public Dictionary<string, (bool, float)> WireStatuses => _wirePlayer.WireStatuses;
 		public float3 Gravity => _playfieldComponent.Gravity;
 
-		public void SetLamp(string lampId, int internalId, float value) => _lampPlayer.HandleLampEvent(lampId, internalId, value);
-		public void SetLamp(string lampId, int internalId, LampStatus status) => _lampPlayer.HandleLampEvent(lampId, internalId, status);
-		public void SetLamp(string lampId, int internalId, VisualPinball.Engine.Math.Color color) => _lampPlayer.HandleLampEvent(lampId, internalId, color);
+		public void SetLamp(string lampId, float value) => _lampPlayer.HandleLampEvent(lampId, value);
+		public void SetLamp(string lampId, LampStatus status) => _lampPlayer.HandleLampEvent(lampId, status);
+		public void SetLamp(string lampId, VisualPinball.Engine.Math.Color color) => _lampPlayer.HandleLampEvent(lampId, color);
 
 		#endregion
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Mappings/CoilMapping.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Mappings/CoilMapping.cs
@@ -26,8 +26,6 @@ namespace VisualPinball.Unity
 	{
 		public string Id = string.Empty;
 
-		public int InternalId;
-
 		public string Description = string.Empty;
 
 		public CoilDestination Destination = CoilDestination.Playfield;
@@ -40,7 +38,7 @@ namespace VisualPinball.Unity
 
 		public override string ToString()
 		{
-			return $"coil {Id} ({InternalId}) {Description}";
+			return $"coil {Id} {Description}";
 		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/Mappings/LampMapping.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Mappings/LampMapping.cs
@@ -28,8 +28,6 @@ namespace VisualPinball.Unity
 	{
 		public string Id = string.Empty;
 
-		public int InternalId;
-
 		public LampSource Source = LampSource.Lamp;
 
 		public int FadingSteps;

--- a/VisualPinball.Unity/VisualPinball.Unity/Mappings/MappingConfig.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Mappings/MappingConfig.cs
@@ -87,7 +87,6 @@ namespace VisualPinball.Unity
 						AddSwitch(new SwitchMapping
 						{
 							Id = engineSwitch.Id,
-							InternalId = engineSwitch.InternalId,
 							IsNormallyClosed = engineSwitch.NormallyClosed,
 							Description = description,
 							Source = source,
@@ -106,7 +105,6 @@ namespace VisualPinball.Unity
 					AddSwitch(new SwitchMapping
 					{
 						Id = engineSwitch.Id,
-						InternalId = engineSwitch.InternalId,
 						IsNormallyClosed = engineSwitch.NormallyClosed,
 						Description = description,
 						Source = source,
@@ -265,7 +263,6 @@ namespace VisualPinball.Unity
 						AddCoil(new CoilMapping
 						{
 							Id = engineCoil.Id,
-							InternalId = engineCoil.InternalId,
 							Description = description,
 							Destination = destination,
 							Device = matchedDevice,
@@ -280,7 +277,6 @@ namespace VisualPinball.Unity
 					AddCoil(new CoilMapping
 					{
 						Id = engineCoil.Id,
-						InternalId = engineCoil.InternalId,
 						Description = description,
 						Destination = destination,
 						Device = null,
@@ -487,7 +483,6 @@ namespace VisualPinball.Unity
 
 					AddLamp(new LampMapping {
 						Id = engineLamp.Id,
-						InternalId = engineLamp.InternalId,
 						Channel = engineLamp.Channel,
 						Source = engineLamp.Source,
 						Description = description,
@@ -503,7 +498,6 @@ namespace VisualPinball.Unity
 				if (!deviceAdded) {
 					AddLamp(new LampMapping {
 						Id = engineLamp.Id,
-						InternalId = engineLamp.InternalId,
 						Channel = engineLamp.Channel,
 						Source = engineLamp.Source,
 						Description = description,

--- a/VisualPinball.Unity/VisualPinball.Unity/Mappings/SwitchMapping.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Mappings/SwitchMapping.cs
@@ -26,8 +26,6 @@ namespace VisualPinball.Unity
 	{
 		public string Id = string.Empty;
 
-		public int InternalId;
-
 		public bool IsNormallyClosed;
 
 		public string Description = string.Empty;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughApi.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using NLog;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
@@ -196,10 +197,14 @@ namespace VisualPinball.Unity
 
 			} else {
 				_stackSwitches = new DeviceSwitch[MainComponent.SwitchCount];
-				foreach (var sw in MainComponent.AvailableSwitches) {
-					if (sw.InternalId > 0) {
-						_stackSwitches[sw.InternalId - 1] = CreateSwitch(sw.Id, false, MainComponent.Type == TroughType.ModernOpto ? SwitchDefault.NormallyClosed : SwitchDefault.NormallyOpen);
-						_switchLookup[sw.Id] = _stackSwitches[sw.InternalId - 1];
+				foreach (var @switch in MainComponent.AvailableSwitches) {
+					var match = new Regex(@"^ball_switch_(\d+)$").Match(@switch.Id);
+					if (match.Success) {
+						int.TryParse(match.Groups[1].Value, out int id);
+						if (id > 0) {
+							_stackSwitches[id - 1] = CreateSwitch(@switch.Id, false, MainComponent.Type == TroughType.ModernOpto ? SwitchDefault.NormallyClosed : SwitchDefault.NormallyOpen);
+							_switchLookup[@switch.Id] = _stackSwitches[id - 1];
+						}
 					}
 				}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughApi.cs
@@ -197,8 +197,11 @@ namespace VisualPinball.Unity
 
 			} else {
 				_stackSwitches = new DeviceSwitch[MainComponent.SwitchCount];
+
+				// ball_switch_# switches created in TroughComponent
+				var ballSwitchRegex = new Regex(@"^ball_switch_(\d+)$");
 				foreach (var @switch in MainComponent.AvailableSwitches) {
-					var match = new Regex(@"^ball_switch_(\d+)$").Match(@switch.Id);
+					var match = ballSwitchRegex.Match(@switch.Id);
 					if (match.Success) {
 						int.TryParse(match.Groups[1].Value, out int id);
 						if (id > 0) {

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughComponent.cs
@@ -207,6 +207,7 @@ namespace VisualPinball.Unity
 				switch (Type) {
 					case TroughType.ModernOpto:
 					case TroughType.ModernMech:
+						// ball_switch_# is matched with regex in TroughApi
 						return Enumerable.Repeat(0, SwitchCount)
 							.Select((_, i) => new GamelogicEngineSwitch($"ball_switch_{i + 1}")
 								{ Description = SwitchDescription(i) })
@@ -216,6 +217,7 @@ namespace VisualPinball.Unity
 							);
 
 					case TroughType.TwoCoilsNSwitches:
+						// ball_switch_# is matched with regex in TroughApi
 						return new[] {
 							new GamelogicEngineSwitch(EntrySwitchId) { Description = "Entry Switch" }
 						}.Concat(Enumerable.Repeat(0, SwitchCount)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughComponent.cs
@@ -208,7 +208,7 @@ namespace VisualPinball.Unity
 					case TroughType.ModernOpto:
 					case TroughType.ModernMech:
 						return Enumerable.Repeat(0, SwitchCount)
-							.Select((_, i) => new GamelogicEngineSwitch($"ball_switch_{i + 1}", i + 1)
+							.Select((_, i) => new GamelogicEngineSwitch($"ball_switch_{i + 1}")
 								{ Description = SwitchDescription(i) })
 							.Concat(JamSwitch
 								? new [] { new GamelogicEngineSwitch(JamSwitchId) { Description = "Jam Switch" }}
@@ -219,7 +219,7 @@ namespace VisualPinball.Unity
 						return new[] {
 							new GamelogicEngineSwitch(EntrySwitchId) { Description = "Entry Switch" }
 						}.Concat(Enumerable.Repeat(0, SwitchCount)
-							.Select((_, i) => new GamelogicEngineSwitch($"ball_switch_{i + 1}", i + 1)
+							.Select((_, i) => new GamelogicEngineSwitch($"ball_switch_{i + 1}")
 								{ Description = SwitchDescription(i) } )
 						).Concat(JamSwitch
 							? new [] { new GamelogicEngineSwitch(JamSwitchId) { Description = "Jam Switch" }}


### PR DESCRIPTION
Switch, lamps, and coils in VisualPinball.Engine are identified with an `Id` variable that is a string.

PinMAME internally uses integers to identify switches, lamps, and coils.

Because of this, an `InternalId` variable was added to VisualPinball.Engine to help mapping.

When working on RGB lamps for TWD, we had issues and needed to pass `InternalId` to the lamp player. 

We then noticed missing lamps when auto `Populating` lamps in the lamp manager. Lamps that don't have an internal id default as 0. Auto `populating` overwrites existing entries by internal ids. 

Since `InternalId` is real only needed for PinMAME, (Visual Scripting and MPF only use `Id`), we could remove `InternalId` all together, and make the PinMAME GLE deal with the `Id`.

This PR does exactly that. There are additional PRs for PinMAME, Visual Scripting, and MPF.