### PR TITLE
doc: Add Unity License Secrets Instructions

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,5 +1,6 @@
 name: License
-on: [workflow_dispatch]
+on:
+  workflow_dispatch: {}
 jobs:
   license:
     runs-on: ubuntu-latest

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,7 +1,5 @@
 name: License
-on:
-  workflow_dispatch:
- 
+on: [workflow_dispatch]
 jobs:
   license:
     runs-on: ubuntu-latest

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,17 @@
+name: License
+on:
+  workflow_dispatch: {}
+ 
+jobs:
+  license:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request unity license
+        id: license
+        uses: game-ci/unity-request-activation-file@v2
+        with:
+          unityVersion: 2021.3.0f1
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.license.outputs.filePath }}
+          path: ${{ steps.license.outputs.filePath }}

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,6 +1,6 @@
 name: License
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
  
 jobs:
   license:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,16 +16,16 @@ and let our peers review the code before it gets merged.
 ### Unity License Setup For Automated Testing
 
 All Pull Request must pass an automated run of all the unit tests before merging. These will fail until your fork of the `VisualPinball.Engine` is configured with Unity's license information.
-Most contributos will be using a Personal License and will need to request a key on behalf of GitHub. Professional account users can gather their key from the [Unity Subscriptions Page](https://id.unity.com/en/subscriptions) and skip to create secret setup below
+Most contributors will be using a Personal license and will need to request a key on behalf of GitHub. Professional license users can gather their key from the [Unity Subscriptions Page](https://id.unity.com/en/subscriptions) and skip to step 8.
 
-- Create a new branch. We will use the [Unity - Request Activation File](https://github.com/marketplace/actions/unity-request-activation-file) action to request an activation file
-- Create a file called `.github/workflows/activation.yml` and add the following workflow action defintion.
+1. Create a new branch. We will use the [Unity - Request Activation File](https://github.com/marketplace/actions/unity-request-activation-file) action to request an activation file
+2. Create a file called `.github/workflows/activation.yml` and add the following workflow action defintion.
 ```
 name: Acquire activation file
 on: push
 jobs:
   activation:
-    name: Request manual activation file 🔑
+    name: Request manual activation file 
     runs-on: ubuntu-latest
     steps:
       # Request manual activation file
@@ -39,13 +39,13 @@ jobs:
           name: ${{ steps.getManualLicenseFile.outputs.filePath }}
           path: ${{ steps.getManualLicenseFile.outputs.filePath }}
 ```
-- Commit and Push the new file
-- Navigate to the Actions Tab of GitHub
-- Once the action has completed download the manual activation file that now appeared as an artifact and extract the `Unity_v20XX.X.XXXX.alf` file from the zip.
-- Visit (license.unity3d.com) and upload the `Unity_v20XX.X.XXXX.alf` file.
+3. Commit and Push the new file
+4. Navigate to the Actions Tab of GitHub
+5. Once the action has completed download the manual activation file that now appeared as an artifact and extract the `Unity_v20XX.X.XXXX.alf` file from the zip.
+6. Visit (license.unity3d.com) and upload the `Unity_v20XX.X.XXXX.alf` file.
 - You should now receive your license file (Unity_v20XX.x.ulf) as a download. It's ok if the numbers don't match your Unity version exactly.
-- Open `Github` > `<Your repository>` > `Settings` > `Secrets`
-- Create the following secrets
+7. Open `Github` > `<Your repository>` > `Settings` > `Secrets`
+8. Create the following secrets
   - `UNITY_EMAIL` - (Add the email address that you use to login to Unity)
   - `UNITY_PASSWORD` - (Add the password that you use to login to Unity)
 - If Personal License

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,46 +15,15 @@ and let our peers review the code before it gets merged.
 
 ### Unity License Setup For Automated Testing
 
-It's preferred to make the automated tests run when creating your PR. Since Unity needs a license key (which can be obtained with a free account), you'll need to configure your fork to use the correct secrets.
-Most contributors will be using a Personal license and will need to request a key on behalf of GitHub. Professional license users can gather their key from the [Unity Subscriptions Page](https://id.unity.com/en/subscriptions) and skip to step 8.
+It's preferred to make the automated tests run when creating your PR. Since Unity needs a license key (which can be obtained with a free account), you'll need to configure your fork to use the correct secrets.  You will need to use a Personal license and request a key on behalf of GitHub: 
 
-1. Create a new branch. We will use the [Unity - Request Activation File](https://github.com/marketplace/actions/unity-request-activation-file) action to request an activation file
-2. Create a file called `.github/workflows/activation.yml` and add the following workflow action defintion.
-```
-name: Acquire activation file
-on: push
-jobs:
-  activation:
-    name: Request manual activation file 
-    runs-on: ubuntu-latest
-    steps:
-      # Request manual activation file
-      - name: Request manual activation file
-        id: getManualLicenseFile
-        uses: game-ci/unity-request-activation-file@v2
-      # Upload artifact (Unity_v20XX.X.XXXX.alf)
-      - name: Expose as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ steps.getManualLicenseFile.outputs.filePath }}
-          path: ${{ steps.getManualLicenseFile.outputs.filePath }}
-```
-3. Commit and Push the new file.
-4. Navigate to the Actions Tab of GitHub.
-5. Once the action has completed download the manual activation file that now appeared as an artifact and extract the `Unity_v20XX.X.XXXX.alf` file from the zip.
-6. Visit (license.unity3d.com) and upload the `Unity_v20XX.X.XXXX.alf` file.
-7. You should now receive your license file (Unity_v20XX.x.ulf) as a download. It's ok if the numbers don't match your Unity version exactly.
-8. Open `Github` > `<Your repository>` > `Settings` > `Secrets`
-- Create the following secrets
-  - `UNITY_EMAIL` - (Add the email address that you use to login to Unity)
-  - `UNITY_PASSWORD` - (Add the password that you use to login to Unity)
-- Personal License
-  - `UNITY_LICENSE` - (Copy the contents of your ulf license file into here)
-- Professional License
-  - `UNITY_SERIAL` - (Add you serial key it should look like XX-XXXX-XXXX-XXXX-XXXX-XXXX)
-  
-9. You can delete the branch. This license can now be used by the automated build and test steps required for pull requests. 
-
+1. Run the `License` workflow by clicking the `Run workflow` button in the `Actions` tab. When the workflow completes, download and unzip the `Unity_v2021.3.0f1.alf` artifact. 
+2. Visit [license.unity3d.com](https://license.unity3d.com), sign in, and upload the `Unity_v2021.3.0f1.alf` file.
+3. You should now receive your license file (`Unity_v2021.x.ulf`) as a download. 
+4. Open `Github` > `<Your repository>` > `Settings` > `Secrets`
+- Create the following secret:
+  - `UNITY_LICENSE` - (Copy the contents of the `Unity_v2021.x.ulf` license file here)
+5. Delete the `License` workflow run by selecting `Delete workflow run` in the `...` menu.  
 
 ## Code Style 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,11 @@ and let our peers review the code before it gets merged.
 
 ### Unity License Setup For Automated Testing
 
-All Pull Request must pass an automated run of all the unit tests before merging. These will fail until your fork of the `VisualPinball.Engine` is configured with your license information.
-Most contributos will be using a Personal Account and will need to request a key on behalf of GitHub. Professional Account Users can gather their key from the Unity Subscription and skip to secret setup below
+All Pull Request must pass an automated run of all the unit tests before merging. These will fail until your fork of the `VisualPinball.Engine` is configured with Unity's license information.
+Most contributos will be using a Personal License and will need to request a key on behalf of GitHub. Professional account users can gather their key from the [Unity Subscriptions Page](https://id.unity.com/en/subscriptions) and skip to create secret setup below
 
-- We will use the [Unity - Request Activation File](https://github.com/marketplace/actions/unity-request-activation-file) action to request an activation file
-- Create a file called `.github/workflows/activation.yml` and add the following workflow action.
+- Create a new branch. We will use the [Unity - Request Activation File](https://github.com/marketplace/actions/unity-request-activation-file) action to request an activation file
+- Create a file called `.github/workflows/activation.yml` and add the following workflow action defintion.
 ```
 name: Acquire activation file
 on: push
@@ -53,7 +53,7 @@ jobs:
 - If Professional License
   - `UNITY_SERIAL` - (Add you serial key it should look like XX-XXXX-XXXX-XXXX-XXXX-XXXX)
   
-This license can now be used by the automated build and test steps required for pull requests.
+This license can now be used by the automated build and test steps required for pull requests. You can delete the branch.
 
 
 ## Code Style 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,18 +39,18 @@ jobs:
           name: ${{ steps.getManualLicenseFile.outputs.filePath }}
           path: ${{ steps.getManualLicenseFile.outputs.filePath }}
 ```
-3. Commit and Push the new file
-4. Navigate to the Actions Tab of GitHub
+3. Commit and Push the new file.
+4. Navigate to the Actions Tab of GitHub.
 5. Once the action has completed download the manual activation file that now appeared as an artifact and extract the `Unity_v20XX.X.XXXX.alf` file from the zip.
 6. Visit (license.unity3d.com) and upload the `Unity_v20XX.X.XXXX.alf` file.
-- You should now receive your license file (Unity_v20XX.x.ulf) as a download. It's ok if the numbers don't match your Unity version exactly.
-7. Open `Github` > `<Your repository>` > `Settings` > `Secrets`
-8. Create the following secrets
+7. You should now receive your license file (Unity_v20XX.x.ulf) as a download. It's ok if the numbers don't match your Unity version exactly.
+8. Open `Github` > `<Your repository>` > `Settings` > `Secrets`
+- Create the following secrets
   - `UNITY_EMAIL` - (Add the email address that you use to login to Unity)
   - `UNITY_PASSWORD` - (Add the password that you use to login to Unity)
-- If Personal License
-  - `UNITY_LICENSE` - (Copy the contents of your license file into here)
-- If Professional License
+- Personal License
+  - `UNITY_LICENSE` - (Copy the contents of your ulf license file into here)
+- Professional License
   - `UNITY_SERIAL` - (Add you serial key it should look like XX-XXXX-XXXX-XXXX-XXXX-XXXX)
   
 This license can now be used by the automated build and test steps required for pull requests. You can delete the branch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,49 @@ and let our peers review the code before it gets merged.
 - We try to prefix our commit messages with a word that quickly tells the reader where the change happened. Examples are `editor`, `doc`, `<component-name>`, etc.
 - Changes that touch the core project should be unit-tested. 
 
+### Unity License Setup For Automated Testing
+
+All Pull Request must pass an automated run of all the unit tests before merging. These will fail until your fork of the `VisualPinball.Engine` is configured with your license information.
+Most contributos will be using a Personal Account and will need to request a key on behalf of GitHub. Professional Account Users can gather their key from the Unity Subscription and skip to secret setup below
+
+- We will use the [Unity - Request Activation File](https://github.com/marketplace/actions/unity-request-activation-file) action to request an activation file
+- Create a file called `.github/workflows/activation.yml` and add the following workflow action.
+```
+name: Acquire activation file
+on: push
+jobs:
+  activation:
+    name: Request manual activation file 🔑
+    runs-on: ubuntu-latest
+    steps:
+      # Request manual activation file
+      - name: Request manual activation file
+        id: getManualLicenseFile
+        uses: game-ci/unity-request-activation-file@v2
+      # Upload artifact (Unity_v20XX.X.XXXX.alf)
+      - name: Expose as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.getManualLicenseFile.outputs.filePath }}
+          path: ${{ steps.getManualLicenseFile.outputs.filePath }}
+```
+- Commit and Push the new file
+- Navigate to the Actions Tab of GitHub
+- Once the action has completed download the manual activation file that now appeared as an artifact and extract the `Unity_v20XX.X.XXXX.alf` file from the zip.
+- Visit (license.unity3d.com) and upload the `Unity_v20XX.X.XXXX.alf` file.
+- You should now receive your license file (Unity_v20XX.x.ulf) as a download. It's ok if the numbers don't match your Unity version exactly.
+- Open `Github` > `<Your repository>` > `Settings` > `Secrets`
+- Create the following secrets
+  - `UNITY_EMAIL` - (Add the email address that you use to login to Unity)
+  - `UNITY_PASSWORD` - (Add the password that you use to login to Unity)
+- If Personal License
+  - `UNITY_LICENSE` - (Copy the contents of your license file into here)
+- If Professional License
+  - `UNITY_SERIAL` - (Add you serial key it should look like XX-XXXX-XXXX-XXXX-XXXX-XXXX)
+  
+This license can now be used by the automated build and test steps required for pull requests.
+
+
 ## Code Style 
 
 We aren't too picky about code style. Just start reading our code and you'll get the hang of it. There

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ and let our peers review the code before it gets merged.
 
 ### Unity License Setup For Automated Testing
 
-All Pull Request must pass an automated run of all the unit tests before merging. These will fail until your fork of the `VisualPinball.Engine` is configured with Unity's license information.
+It's preferred to make the automated tests run when creating your PR. Since Unity needs a license key (which can be obtained with a free account), you'll need to configure your fork to use the correct secrets.
 Most contributors will be using a Personal license and will need to request a key on behalf of GitHub. Professional license users can gather their key from the [Unity Subscriptions Page](https://id.unity.com/en/subscriptions) and skip to step 8.
 
 1. Create a new branch. We will use the [Unity - Request Activation File](https://github.com/marketplace/actions/unity-request-activation-file) action to request an activation file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ jobs:
 - Professional License
   - `UNITY_SERIAL` - (Add you serial key it should look like XX-XXXX-XXXX-XXXX-XXXX-XXXX)
   
-This license can now be used by the automated build and test steps required for pull requests. You can delete the branch.
+9. You can delete the branch. This license can now be used by the automated build and test steps required for pull requests. 
 
 
 ## Code Style 


### PR DESCRIPTION
Unity Secrets must be configured in GitHub before automated builds will complete. Attempting to make this easier for future developers