### PR TITLE
ci: Action for Unity License Request

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,16 @@
+name: License
+on:
+  workflow_dispatch: {}
+jobs:
+  license:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request unity license
+        id: license
+        uses: game-ci/unity-request-activation-file@v2
+        with:
+          unityVersion: 2021.3.0f1
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.license.outputs.filePath }}
+          path: ${{ steps.license.outputs.filePath }}


### PR DESCRIPTION
In order to test the onboarding of new developers the default action for license request must be part of the master branch. Including this separately so a full test of the process can be done along with the documentation.