### PR TITLE
Feature/live catch

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Flipper/FlipperColliderInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Flipper/FlipperColliderInspector.cs
@@ -58,7 +58,8 @@ namespace VisualPinball.Unity.Editor
 		private SerializedProperty _LiveCatchMinimalBallSpeed;
 		private SerializedProperty _LiveCatchPerfectTime;
 		private SerializedProperty _LiveCatchFullTime;
-		private SerializedProperty _LiveCatchInaccuracySpeed;
+		private SerializedProperty _LiveCatchInaccurateBounceSpeedMultiplier;
+		private SerializedProperty _LiveCatchMinimumBounceSpeedMultiplier;
 
 		protected override void OnEnable()
 		{
@@ -95,9 +96,10 @@ namespace VisualPinball.Unity.Editor
 			_LiveCatchMinimalBallSpeed = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchMinimalBallSpeed));
 			_LiveCatchPerfectTime = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchPerfectTime));
 			_LiveCatchFullTime = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchFullTime));
-			_LiveCatchInaccuracySpeed = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchInaccuracySpeed));
-			# endregion
-	}
+			_LiveCatchInaccurateBounceSpeedMultiplier = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchInaccurateBounceSpeedMultiplier));
+			_LiveCatchMinimumBounceSpeedMultiplier = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchMinmalBounceSpeedMultiplier));
+			#endregion
+		}
 
 		public override void OnInspectorGUI()
 		{
@@ -151,7 +153,8 @@ namespace VisualPinball.Unity.Editor
 				PropertyField(_LiveCatchMinimalBallSpeed, "Min Ball Speed");
 				PropertyField(_LiveCatchPerfectTime, "Perfect Time");
 				PropertyField(_LiveCatchFullTime, "Full Time");
-				PropertyField(_LiveCatchInaccuracySpeed, "Inaccuracy Speed");
+				PropertyField(_LiveCatchMinimumBounceSpeedMultiplier, "Perfect Bounce");
+				PropertyField(_LiveCatchInaccurateBounceSpeedMultiplier, "Inaccurate Bounce");
 
 				EditorGUI.EndDisabledGroup();
 			}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Flipper/FlipperColliderInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Flipper/FlipperColliderInspector.cs
@@ -39,27 +39,34 @@ namespace VisualPinball.Unity.Editor
 		private SerializedProperty _flipperCorrectionProperty;
 
 		private bool _foldoutFlipperTricks = true;
+		private bool _foldoutLiveCatch = true;
 
-		#region FlipperTricks
+		#region Flipper Tricks
+
 		private SerializedProperty _useFlipperTricksPhysicsProperty;
-		private SerializedProperty _SOSRampUpProperty;
-		private SerializedProperty _SOSEMProperty;
-		private SerializedProperty _EOSReturnProperty;
-		private SerializedProperty _EOSTNewProperty;
-		private SerializedProperty _EOSANewProperty;
-		private SerializedProperty _EOSRampupProperty;
-		private SerializedProperty _OvershootProperty;
-		private SerializedProperty _BumpOnReleaseProperty;
+		private SerializedProperty _sosRampUpProperty;
+		private SerializedProperty _sosEmProperty;
+		private SerializedProperty _eosReturnProperty;
+		private SerializedProperty _eosTNewProperty;
+		private SerializedProperty _eosANewProperty;
+		private SerializedProperty _eosRampUpProperty;
+		private SerializedProperty _overshootProperty;
+		private SerializedProperty _bumpOnReleaseProperty;
+
 		#endregion
 
-		private SerializedProperty _UseFlipperLiveCatch;
-		private SerializedProperty _LiveCatchDistanceMin; 
-		private SerializedProperty _LiveCatchDistanceMax; 
-		private SerializedProperty _LiveCatchMinimalBallSpeed;
-		private SerializedProperty _LiveCatchPerfectTime;
-		private SerializedProperty _LiveCatchFullTime;
-		private SerializedProperty _LiveCatchInaccurateBounceSpeedMultiplier;
-		private SerializedProperty _LiveCatchMinimumBounceSpeedMultiplier;
+		#region Live Catch
+
+		private SerializedProperty _useFlipperLiveCatch;
+		private SerializedProperty _liveCatchDistanceMin;
+		private SerializedProperty _liveCatchDistanceMax;
+		private SerializedProperty _liveCatchMinimalBallSpeed;
+		private SerializedProperty _liveCatchPerfectTime;
+		private SerializedProperty _liveCatchFullTime;
+		private SerializedProperty _liveCatchInaccurateBounceSpeedMultiplier;
+		private SerializedProperty _liveCatchMinimumBounceSpeedMultiplier;
+
+		#endregion
 
 		protected override void OnEnable()
 		{
@@ -77,27 +84,27 @@ namespace VisualPinball.Unity.Editor
 			_scatterProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.Scatter));
 			_flipperCorrectionProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.FlipperCorrection));
 
-			#region FlipperTricks
+			#region Flipper Tricks
 			_useFlipperTricksPhysicsProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.useFlipperTricksPhysics));
-			_SOSRampUpProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.SOSRampUp));
-			_SOSEMProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.SOSEM));
-			_EOSReturnProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.EOSReturn));
-			_EOSTNewProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.EOSTNew));
-			_EOSANewProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.EOSANew));
-			_EOSRampupProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.EOSRampup));
-			_OvershootProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.Overshoot));
-			_BumpOnReleaseProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.BumpOnRelease));
+			_sosRampUpProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.SOSRampUp));
+			_sosEmProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.SOSEM));
+			_eosReturnProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.EOSReturn));
+			_eosTNewProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.EOSTNew));
+			_eosANewProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.EOSANew));
+			_eosRampUpProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.EOSRampup));
+			_overshootProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.Overshoot));
+			_bumpOnReleaseProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.BumpOnRelease));
 			#endregion
 
-			#region LiveCatch
-			_UseFlipperLiveCatch = serializedObject.FindProperty(nameof(FlipperColliderComponent.useFlipperLiveCatch));
-			_LiveCatchDistanceMin = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchDistanceMin));
-			_LiveCatchDistanceMax = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchDistanceMax));
-			_LiveCatchMinimalBallSpeed = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchMinimalBallSpeed));
-			_LiveCatchPerfectTime = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchPerfectTime));
-			_LiveCatchFullTime = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchFullTime));
-			_LiveCatchInaccurateBounceSpeedMultiplier = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchInaccurateBounceSpeedMultiplier));
-			_LiveCatchMinimumBounceSpeedMultiplier = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchMinmalBounceSpeedMultiplier));
+			#region Live Catch
+			_useFlipperLiveCatch = serializedObject.FindProperty(nameof(FlipperColliderComponent.useFlipperLiveCatch));
+			_liveCatchDistanceMin = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchDistanceMin));
+			_liveCatchDistanceMax = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchDistanceMax));
+			_liveCatchMinimalBallSpeed = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchMinimalBallSpeed));
+			_liveCatchPerfectTime = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchPerfectTime));
+			_liveCatchFullTime = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchFullTime));
+			_liveCatchInaccurateBounceSpeedMultiplier = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchInaccurateBounceSpeedMultiplier));
+			_liveCatchMinimumBounceSpeedMultiplier = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchMinmalBounceSpeedMultiplier));
 			#endregion
 		}
 
@@ -128,34 +135,36 @@ namespace VisualPinball.Unity.Editor
 			}
 			EditorGUILayout.EndFoldoutHeaderGroup();
 
-			if (_foldoutFlipperTricks = EditorGUILayout.BeginFoldoutHeaderGroup(_foldoutFlipperTricks, "Flipper Tricks"))
-			{
+			if (_foldoutFlipperTricks = EditorGUILayout.BeginFoldoutHeaderGroup(_foldoutFlipperTricks, "Flipper Tricks")) {
 
 				PropertyField(_useFlipperTricksPhysicsProperty, "Use Flipper Tricks");
 
 				EditorGUI.BeginDisabledGroup(!_useFlipperTricksPhysicsProperty.boolValue);
-				PropertyField(_SOSRampUpProperty, "SOSRampUP");
-				PropertyField(_SOSEMProperty, "SOSEM");
-				PropertyField(_EOSReturnProperty, "EOSReturn");
-				PropertyField(_EOSTNewProperty, "EOSTNew");
-				PropertyField(_EOSANewProperty, "EOSANew");
-				PropertyField(_EOSRampupProperty, "EOSRampup");
-				PropertyField(_OvershootProperty, "Overshoot Angle");
-				PropertyField(_BumpOnReleaseProperty, "Bump on Release");
+				PropertyField(_sosRampUpProperty, "SOSRampUP");
+				PropertyField(_sosEmProperty, "SOSEM");
+				PropertyField(_eosReturnProperty, "EOSReturn");
+				PropertyField(_eosTNewProperty, "EOSTNew");
+				PropertyField(_eosANewProperty, "EOSANew");
+				PropertyField(_eosRampUpProperty, "EOSRampup");
+				PropertyField(_overshootProperty, "Overshoot Angle");
+				PropertyField(_bumpOnReleaseProperty, "Bump on Release");
 				EditorGUI.EndDisabledGroup();
 
+			}
+			EditorGUILayout.EndFoldoutHeaderGroup();
 
-				PropertyField(_UseFlipperLiveCatch, "Use Live Catch");
+			if (_foldoutLiveCatch = EditorGUILayout.BeginFoldoutHeaderGroup(_foldoutLiveCatch, "Live Catch")) {
 
-				EditorGUI.BeginDisabledGroup(!_UseFlipperLiveCatch.boolValue);
-				PropertyField(_LiveCatchDistanceMin, "Min Distance");
-				PropertyField(_LiveCatchDistanceMax, "Max Distance");
-				PropertyField(_LiveCatchMinimalBallSpeed, "Min Ball Speed");
-				PropertyField(_LiveCatchPerfectTime, "Perfect Time");
-				PropertyField(_LiveCatchFullTime, "Full Time");
-				PropertyField(_LiveCatchMinimumBounceSpeedMultiplier, "Perfect Bounce");
-				PropertyField(_LiveCatchInaccurateBounceSpeedMultiplier, "Inaccurate Bounce");
+				PropertyField(_useFlipperLiveCatch, "Use Live Catch");
 
+				EditorGUI.BeginDisabledGroup(!_useFlipperLiveCatch.boolValue);
+				PropertyField(_liveCatchDistanceMin, "Min Distance");
+				PropertyField(_liveCatchDistanceMax, "Max Distance");
+				PropertyField(_liveCatchMinimalBallSpeed, "Min Ball Speed");
+				PropertyField(_liveCatchPerfectTime, "Perfect Time");
+				PropertyField(_liveCatchFullTime, "Full Time");
+				PropertyField(_liveCatchMinimumBounceSpeedMultiplier, "Perfect Bounce");
+				PropertyField(_liveCatchInaccurateBounceSpeedMultiplier, "Inaccurate Bounce");
 				EditorGUI.EndDisabledGroup();
 			}
 			EditorGUILayout.EndFoldoutHeaderGroup();

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Flipper/FlipperColliderInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Flipper/FlipperColliderInspector.cs
@@ -52,6 +52,13 @@ namespace VisualPinball.Unity.Editor
 		private SerializedProperty _BumpOnReleaseProperty;
 		#endregion
 
+		private SerializedProperty _UseFlipperLiveCatch;
+		private SerializedProperty _LiveCatchDistanceMin; 
+		private SerializedProperty _LiveCatchDistanceMax; 
+		private SerializedProperty _LiveCatchMinimalBallSpeed;
+		private SerializedProperty _LiveCatchPerfectTime;
+		private SerializedProperty _LiveCatchFullTime;
+		private SerializedProperty _LiveCatchInaccuracySpeed;
 
 		protected override void OnEnable()
 		{
@@ -69,7 +76,7 @@ namespace VisualPinball.Unity.Editor
 			_scatterProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.Scatter));
 			_flipperCorrectionProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.FlipperCorrection));
 
-			#region Flipper_Tricks
+			#region FlipperTricks
 			_useFlipperTricksPhysicsProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.useFlipperTricksPhysics));
 			_SOSRampUpProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.SOSRampUp));
 			_SOSEMProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.SOSEM));
@@ -81,7 +88,16 @@ namespace VisualPinball.Unity.Editor
 			_BumpOnReleaseProperty = serializedObject.FindProperty(nameof(FlipperColliderComponent.BumpOnRelease));
 			#endregion
 
-		}
+			#region LiveCatch
+			_UseFlipperLiveCatch = serializedObject.FindProperty(nameof(FlipperColliderComponent.useFlipperLiveCatch));
+			_LiveCatchDistanceMin = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchDistanceMin));
+			_LiveCatchDistanceMax = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchDistanceMax));
+			_LiveCatchMinimalBallSpeed = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchMinimalBallSpeed));
+			_LiveCatchPerfectTime = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchPerfectTime));
+			_LiveCatchFullTime = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchFullTime));
+			_LiveCatchInaccuracySpeed = serializedObject.FindProperty(nameof(FlipperColliderComponent.LiveCatchInaccuracySpeed));
+			# endregion
+	}
 
 		public override void OnInspectorGUI()
 		{
@@ -123,7 +139,20 @@ namespace VisualPinball.Unity.Editor
 				PropertyField(_EOSANewProperty, "EOSANew");
 				PropertyField(_EOSRampupProperty, "EOSRampup");
 				PropertyField(_OvershootProperty, "Overshoot Angle");
-				PropertyField(_BumpOnReleaseProperty, "Bump on release");
+				PropertyField(_BumpOnReleaseProperty, "Bump on Release");
+				EditorGUI.EndDisabledGroup();
+
+
+				PropertyField(_UseFlipperLiveCatch, "Use Live Catch");
+
+				EditorGUI.BeginDisabledGroup(!_UseFlipperLiveCatch.boolValue);
+				PropertyField(_LiveCatchDistanceMin, "Min Distance");
+				PropertyField(_LiveCatchDistanceMax, "Max Distance");
+				PropertyField(_LiveCatchMinimalBallSpeed, "Min Ball Speed");
+				PropertyField(_LiveCatchPerfectTime, "Perfect Time");
+				PropertyField(_LiveCatchFullTime, "Full Time");
+				PropertyField(_LiveCatchInaccuracySpeed, "Inaccuracy Speed");
+
 				EditorGUI.EndDisabledGroup();
 			}
 			EditorGUILayout.EndFoldoutHeaderGroup();

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
@@ -117,9 +117,9 @@ namespace VisualPinball.Unity
 								var flipperHitData = GetComponent<FlipperHitData>(coll.Entity);
 								var flipperTricksData = GetComponent<FlipperTricksData>(coll.Entity);
 								// do liveCatch - check before collision
-								((FlipperCollider*)collider)->LiveCatch(
+								FlipperCollider.LiveCatch(
 									ref ballData, ref collEvent, ref flipperTricksData, in flipperMaterialData, timeMsec
-								) ; 
+								);
 								((FlipperCollider*)collider)->Collide(
 									ref ballData, ref collEvent, ref flipperMovementData, ref events,
 									in ballEntity, in flipperTricksData,in flipperMaterialData, in flipperVelocityData, in flipperHitData, timeMsec

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
@@ -116,7 +116,10 @@ namespace VisualPinball.Unity
 								var flipperMaterialData = GetComponent<FlipperStaticData>(coll.Entity);
 								var flipperHitData = GetComponent<FlipperHitData>(coll.Entity);
 								var flipperTricksData = GetComponent<FlipperTricksData>(coll.Entity);
-
+								// do liveCatch - check before collision
+								((FlipperCollider*)collider)->LiveCatch(
+									ref ballData, in flipperTricksData, in flipperMaterialData, timeMsec
+								) ; 
 								((FlipperCollider*)collider)->Collide(
 									ref ballData, ref collEvent, ref flipperMovementData, ref events,
 									in ballEntity, in flipperTricksData,in flipperMaterialData, in flipperVelocityData, in flipperHitData, timeMsec

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/StaticCollisionSystem.cs
@@ -118,7 +118,7 @@ namespace VisualPinball.Unity
 								var flipperTricksData = GetComponent<FlipperTricksData>(coll.Entity);
 								// do liveCatch - check before collision
 								((FlipperCollider*)collider)->LiveCatch(
-									ref ballData, in flipperTricksData, in flipperMaterialData, timeMsec
+									ref ballData, ref collEvent, ref flipperTricksData, in flipperMaterialData, timeMsec
 								) ; 
 								((FlipperCollider*)collider)->Collide(
 									ref ballData, ref collEvent, ref flipperMovementData, ref events,

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
@@ -722,12 +722,17 @@ namespace VisualPinball.Unity
 		#region LiveCatch
 		public void LiveCatch(ref BallData ball, ref CollisionEventData collEvent, ref FlipperTricksData tricks, in FlipperStaticData matData, uint msec )
 		{
+			var normalSpeed = math.dot(collEvent.HitNormal, ball.Velocity) * -1f;
 
-			if (ball.Velocity.y > 6)
-			{
-				Logger.Info("LiveCatchTest - Ball with y-speed {0}, at CollisionTime: {1}, livecatchTime is {2}, difference is {3} msecs", ball.Velocity.y, msec, tricks.FlipperAngleEndTime*1000, tricks.FlipperAngleEndTime*1000-msec);
-				ball.Velocity.y = 0.6f;
-			}
+			// only test for LiveCatch if Ballspeed is greater as set Minimal Speed (default = 6)
+			if (normalSpeed >= tricks.LiveCatchMinimalBallSpeed)
+
+				if (ball.Velocity.y > 6)
+				{
+					Logger.Info("LiveCatchTest - Ball with y-speed {0}, at CollisionTime: {1}, livecatchTime is {2}, difference is {3} msecs", ball.Velocity.y, msec, tricks.FlipperAngleEndTime * 1000, tricks.FlipperAngleEndTime * 1000 - msec);
+					Logger.Info("LiveCatchTest - normalspeed = {0}", normalSpeed);
+					ball.Velocity.y = 0.6f;
+				}
 		}
 
 		#endregion

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
@@ -724,8 +724,8 @@ namespace VisualPinball.Unity
 			var normalSpeed = math.dot(collEvent.HitNormal, ball.Velocity) * -1f;
 			// Vector from position of the flipper ball to ball
 			var flipperToBall = ball.Position - matData.Position;
-			var HatTangent = Math.CrossZ(1f, collEvent.HitNormal);
-			var ballPosition = math.dot(HatTangent, flipperToBall);
+			var HitTangent = Math.CrossZ(1f, collEvent.HitNormal);
+			var ballPosition = math.dot(HitTangent, flipperToBall);
 			//Logger.Info("BallPosition = {0}", ballPosition);
 			if (math.abs(ballPosition) > tricks.LiveCatchDistanceMax) {
 				//Logger.Info("BallPosition = {0} -> no calculation", ballPosition);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
@@ -14,13 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-using NLog;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Entities;
 using Unity.Mathematics;
 using VisualPinball.Engine.Common;
 using VisualPinball.Engine.Game;
+// using NLog;
 
 namespace VisualPinball.Unity
 {
@@ -718,7 +718,7 @@ namespace VisualPinball.Unity
 
 		#endregion
 
-		public static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+		//public static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 		#region LiveCatch
 		public void LiveCatch(ref BallData ball, ref CollisionEventData collEvent, ref FlipperTricksData tricks, in FlipperStaticData matData, uint msec ) {
 			var normalSpeed = math.dot(collEvent.HitNormal, ball.Velocity) * -1f;
@@ -733,21 +733,22 @@ namespace VisualPinball.Unity
 					// do we have some bounce
 					// as a difference to the nFozzy implementation, we don't deal with hard-coded speeds, but multiplier to current speed against the flipper.
 					var liveCatchBounceMultiplier = tricks.LiveCatchMinimalBounceSpeedMultiplier;
-					Logger.Info("We have a live catch");
+					//Logger.Info("We have a live catch");
 					if (catchTime > tricks.LiveCatchPerfectTime) {
 						// but it's imperfect, so we have add some bounce
 						// example: hit after 10 msecs, fulltime is 16, perfect time is 8, should be (10-8)/(16-8)*inaccuracySpeedMultiplier
 						liveCatchBounceMultiplier = (catchTime - tricks.LiveCatchPerfectTime) / (tricks.LiveCatchFullTime - tricks.LiveCatchPerfectTime) * (tricks.LiveCatchInaccurateBounceSpeedMultiplier-tricks.LiveCatchMinimalBounceSpeedMultiplier) + tricks.LiveCatchMinimalBounceSpeedMultiplier;
 					
 					}
-					Logger.Info("Bounce Multiplicator is {0}, catchtime {1}", liveCatchBounceMultiplier, catchTime);
+					//Logger.Info("Bounce Multiplicator is {0}, catchtime {1}", liveCatchBounceMultiplier, catchTime);
+					// re-add speed (to the flipper, since the rubber has still to be calculated)
 					ball.Velocity -= collEvent.HitNormal * normalSpeed * liveCatchBounceMultiplier;
+					// kill momentum, but not z... (why is this in nFozzy's?)
 					ball.AngularMomentum.x = 0;
 					ball.AngularMomentum.y = 0;
-
 				}
-				Logger.Info("LiveCatchTest - Ball with y-speed {0}, at CollisionTime: {1}, livecatchTime is {2}, difference is {3} msecs", ball.Velocity.y, msec, tricks.FlipperAngleEndTime * 1000, tricks.FlipperAngleEndTime * 1000 - msec);
-				Logger.Info("LiveCatchTest - normalspeed = {0}, catchTime = {1}", normalSpeed, catchTime);
+				//Logger.Info("LiveCatchTest - Ball with y-speed {0}, at CollisionTime: {1}, livecatchTime is {2}, difference is {3} msecs", ball.Velocity.y, msec, tricks.FlipperAngleEndTime * 1000, tricks.FlipperAngleEndTime * 1000 - msec);
+				//Logger.Info("LiveCatchTest - normalspeed = {0}, catchTime = {1}", normalSpeed, catchTime);
 
 			}
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
@@ -720,7 +720,7 @@ namespace VisualPinball.Unity
 
 		public static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 		#region LiveCatch
-		public void LiveCatch(ref BallData ball, in FlipperTricksData tricks, in FlipperStaticData matData, uint msec )
+		public void LiveCatch(ref BallData ball, ref CollisionEventData collEvent, ref FlipperTricksData tricks, in FlipperStaticData matData, uint msec )
 		{
 
 			if (ball.Velocity.y > 6)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
@@ -722,9 +722,10 @@ namespace VisualPinball.Unity
 		#region LiveCatch
 		public void LiveCatch(ref BallData ball, in FlipperTricksData tricks, in FlipperStaticData matData, uint msec )
 		{
+
 			if (ball.Velocity.y > 6)
 			{
-				Logger.Info("LiveCatchTest - Ball with y-speed {0}, at CollisionTime: {1}, livecatchTime is {2}, difference is {3} msecs", ball.Velocity.y, msec, tricks.liveCatchTime*1000, tricks.liveCatchTime*1000-msec);
+				Logger.Info("LiveCatchTest - Ball with y-speed {0}, at CollisionTime: {1}, livecatchTime is {2}, difference is {3} msecs", ball.Velocity.y, msec, tricks.FlipperAngleEndTime*1000, tricks.FlipperAngleEndTime*1000-msec);
 				ball.Velocity.y = 0.6f;
 			}
 		}
@@ -800,7 +801,7 @@ namespace VisualPinball.Unity
 			 * 0 = no falloff, 1 = half the COR at 1 m/s (18.53 speed units)
 			 */
 			var epsilon = Math.ElasticityWithFalloff(_header.Material.Elasticity, _header.Material.ElasticityFalloff, bnv);
-			if (tricks.useFlipperTricksPhysics)
+			if (tricks.UseFlipperTricksPhysics)
 				epsilon *= tricks.ElasticityMultiplier;
 
 			var pv1 = angResp / matData.Inertia;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
@@ -722,7 +722,19 @@ namespace VisualPinball.Unity
 		#region LiveCatch
 		public void LiveCatch(ref BallData ball, ref CollisionEventData collEvent, ref FlipperTricksData tricks, in FlipperStaticData matData, uint msec ) {
 			var normalSpeed = math.dot(collEvent.HitNormal, ball.Velocity) * -1f;
-
+			// Vector from position of the flipper ball to ball
+			var flipperToBall = ball.Position - matData.Position;
+			var HatTangent = Math.CrossZ(1f, collEvent.HitNormal);
+			var ballPosition = math.dot(HatTangent, flipperToBall);
+			Logger.Info("BallPosition = {0}", ballPosition);
+			if (math.abs(ballPosition) > tricks.LiveCatchDistanceMax) {
+				Logger.Info("BallPosition = {0} -> no calculation", ballPosition);
+				return;
+			}
+			if (math.abs(ballPosition) < tricks.LiveCatchDistanceMin) {
+				Logger.Info("BallPosition = {0} -> no calculation", ballPosition);
+				return;
+			}
 			// only test for LiveCatch if Ballspeed is greater as set Minimal Speed (default = 6)
 			// different to nFozzys implementation we calculate all speeds based on the angle of the flipper, not y direction.
 			if (normalSpeed >= tricks.LiveCatchMinimalBallSpeed) {

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
@@ -721,6 +721,8 @@ namespace VisualPinball.Unity
 		//public static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 		#region LiveCatch
 		public void LiveCatch(ref BallData ball, ref CollisionEventData collEvent, ref FlipperTricksData tricks, in FlipperStaticData matData, uint msec ) {
+			if (!tricks.UseFlipperLiveCatch)
+				return;
 			var normalSpeed = math.dot(collEvent.HitNormal, ball.Velocity) * -1f;
 			// Vector from position of the flipper ball to ball
 			var flipperToBall = ball.Position - matData.Position;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-using NLog;
+//using NLog;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Entities;
@@ -718,7 +718,7 @@ namespace VisualPinball.Unity
 
 		#endregion
 
-		public static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+		//public static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 		#region LiveCatch
 		public void LiveCatch(ref BallData ball, ref CollisionEventData collEvent, ref FlipperTricksData tricks, in FlipperStaticData matData, uint msec ) {
 			var normalSpeed = math.dot(collEvent.HitNormal, ball.Velocity) * -1f;
@@ -726,13 +726,13 @@ namespace VisualPinball.Unity
 			var flipperToBall = ball.Position - matData.Position;
 			var HatTangent = Math.CrossZ(1f, collEvent.HitNormal);
 			var ballPosition = math.dot(HatTangent, flipperToBall);
-			Logger.Info("BallPosition = {0}", ballPosition);
+			//Logger.Info("BallPosition = {0}", ballPosition);
 			if (math.abs(ballPosition) > tricks.LiveCatchDistanceMax) {
-				Logger.Info("BallPosition = {0} -> no calculation", ballPosition);
+				//Logger.Info("BallPosition = {0} -> no calculation", ballPosition);
 				return;
 			}
 			if (math.abs(ballPosition) < tricks.LiveCatchDistanceMin) {
-				Logger.Info("BallPosition = {0} -> no calculation", ballPosition);
+				//Logger.Info("BallPosition = {0} -> no calculation", ballPosition);
 				return;
 			}
 			// only test for LiveCatch if Ballspeed is greater as set Minimal Speed (default = 6)
@@ -745,21 +745,21 @@ namespace VisualPinball.Unity
 					// do we have some bounce
 					// as a difference to the nFozzy implementation, we don't deal with hard-coded speeds, but multiplier to current speed against the flipper.
 					var liveCatchBounceMultiplier = tricks.LiveCatchMinimalBounceSpeedMultiplier;
-					Logger.Info("We have a live catch");
+					//Logger.Info("We have a live catch");
 					if (catchTime > tricks.LiveCatchPerfectTime) {
 						// but it's imperfect, so we have add some bounce
 						// example: hit after 10 msecs, fulltime is 16, perfect time is 8, should be (10-8)/(16-8)*inaccuracySpeedMultiplier
 						liveCatchBounceMultiplier = (catchTime - tricks.LiveCatchPerfectTime) / (tricks.LiveCatchFullTime - tricks.LiveCatchPerfectTime) * (tricks.LiveCatchInaccurateBounceSpeedMultiplier-tricks.LiveCatchMinimalBounceSpeedMultiplier) + tricks.LiveCatchMinimalBounceSpeedMultiplier;
 					
 					}
-					Logger.Info("Bounce Multiplicator is {0}, catchtime {1}", liveCatchBounceMultiplier, catchTime);
+					//Logger.Info("Bounce Multiplicator is {0}, catchtime {1}", liveCatchBounceMultiplier, catchTime);
 					ball.Velocity -= collEvent.HitNormal * normalSpeed * liveCatchBounceMultiplier;
 					ball.AngularMomentum.x = 0;
 					ball.AngularMomentum.y = 0;
 
 				}
-				Logger.Info("LiveCatchTest - Ball with y-speed {0}, at CollisionTime: {1}, livecatchTime is {2}, difference is {3} msecs", ball.Velocity.y, msec, tricks.FlipperAngleEndTime * 1000, tricks.FlipperAngleEndTime * 1000 - msec);
-				Logger.Info("LiveCatchTest - normalspeed = {0}, catchTime = {1}", normalSpeed, catchTime);
+				//Logger.Info("LiveCatchTest - Ball with y-speed {0}, at CollisionTime: {1}, livecatchTime is {2}, difference is {3} msecs", ball.Velocity.y, msec, tricks.FlipperAngleEndTime * 1000, tricks.FlipperAngleEndTime * 1000 - msec);
+				//Logger.Info("LiveCatchTest - normalspeed = {0}, catchTime = {1}", normalSpeed, catchTime);
 
 			}
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//using NLog;
+using NLog;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Entities;
@@ -35,6 +35,10 @@ namespace VisualPinball.Unity
 		private readonly float _zHigh;
 
 		public ColliderBounds Bounds { get; private set; }
+
+		public static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+		#region Setup
 
 		public FlipperCollider(CircleCollider hitCircleBase, float flipperRadius, float startRadius, float endRadius, float startAngle, float endAngle, ColliderInfo info) : this()
 		{
@@ -143,6 +147,8 @@ namespace VisualPinball.Unity
 				sizeof(FlipperCollider)
 			);
 		}
+
+		#endregion
 
 		#region Narrowphase
 
@@ -718,16 +724,16 @@ namespace VisualPinball.Unity
 
 		#endregion
 
-		//public static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 		#region LiveCatch
-		public void LiveCatch(ref BallData ball, ref CollisionEventData collEvent, ref FlipperTricksData tricks, in FlipperStaticData matData, uint msec ) {
+
+		public static void LiveCatch(ref BallData ball, ref CollisionEventData collEvent, ref FlipperTricksData tricks, in FlipperStaticData matData, uint msec ) {
 			if (!tricks.UseFlipperLiveCatch)
 				return;
 			var normalSpeed = math.dot(collEvent.HitNormal, ball.Velocity) * -1f;
 			// Vector from position of the flipper ball to ball
 			var flipperToBall = ball.Position - matData.Position;
-			var HitTangent = Math.CrossZ(1f, collEvent.HitNormal);
-			var ballPosition = math.dot(HitTangent, flipperToBall);
+			var hitTangent = Math.CrossZ(1f, collEvent.HitNormal);
+			var ballPosition = math.dot(hitTangent, flipperToBall);
 			//Logger.Info("BallPosition = {0}", ballPosition);
 			if (math.abs(ballPosition) > tricks.LiveCatchDistanceMax) {
 				//Logger.Info("BallPosition = {0} -> no calculation", ballPosition);
@@ -752,7 +758,7 @@ namespace VisualPinball.Unity
 						// but it's imperfect, so we have add some bounce
 						// example: hit after 10 msecs, fulltime is 16, perfect time is 8, should be (10-8)/(16-8)*inaccuracySpeedMultiplier
 						liveCatchBounceMultiplier = (catchTime - tricks.LiveCatchPerfectTime) / (tricks.LiveCatchFullTime - tricks.LiveCatchPerfectTime) * (tricks.LiveCatchInaccurateBounceSpeedMultiplier-tricks.LiveCatchMinimalBounceSpeedMultiplier) + tricks.LiveCatchMinimalBounceSpeedMultiplier;
-					
+
 					}
 					//Logger.Info("Bounce Multiplicator is {0}, catchtime {1}", liveCatchBounceMultiplier, catchTime);
 					ball.Velocity -= collEvent.HitNormal * normalSpeed * liveCatchBounceMultiplier;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+using NLog;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Entities;
@@ -574,7 +575,7 @@ namespace VisualPinball.Unity
 
 			// hit limits ???
 			if (contactAng >= angleMax && angleSpeed > 0 || contactAng <= angleMin && angleSpeed < 0) {
-				angleSpeed = 0; // rotation stopped
+				angleSpeed = 0f; // rotation stopped
 			}
 
 			// Unit Tangent vector velocity of contact point(rotate normal right)
@@ -713,6 +714,19 @@ namespace VisualPinball.Unity
 			var vB = BallData.SurfaceVelocity(in ball, in rB);
 			var vF = FlipperMovementData.SurfaceVelocity(in movementData, in rF);
 			vRel = vB - vF;
+		}
+
+		#endregion
+
+		public static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+		#region LiveCatch
+		public void LiveCatch(ref BallData ball, in FlipperTricksData tricks, in FlipperStaticData matData, uint msec )
+		{
+			if (ball.Velocity.y > 6)
+			{
+				Logger.Info("LiveCatchTest - Ball with y-speed {0}, at CollisionTime: {1}, livecatchTime is {2}, difference is {3} msecs", ball.Velocity.y, msec, tricks.liveCatchTime*1000, tricks.liveCatchTime*1000-msec);
+				ball.Velocity.y = 0.6f;
+			}
 		}
 
 		#endregion

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperCollider.cs
@@ -14,13 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+using NLog;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Entities;
 using Unity.Mathematics;
 using VisualPinball.Engine.Common;
 using VisualPinball.Engine.Game;
-// using NLog;
 
 namespace VisualPinball.Unity
 {
@@ -718,7 +718,7 @@ namespace VisualPinball.Unity
 
 		#endregion
 
-		//public static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+		public static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 		#region LiveCatch
 		public void LiveCatch(ref BallData ball, ref CollisionEventData collEvent, ref FlipperTricksData tricks, in FlipperStaticData matData, uint msec ) {
 			var normalSpeed = math.dot(collEvent.HitNormal, ball.Velocity) * -1f;
@@ -733,22 +733,21 @@ namespace VisualPinball.Unity
 					// do we have some bounce
 					// as a difference to the nFozzy implementation, we don't deal with hard-coded speeds, but multiplier to current speed against the flipper.
 					var liveCatchBounceMultiplier = tricks.LiveCatchMinimalBounceSpeedMultiplier;
-					//Logger.Info("We have a live catch");
+					Logger.Info("We have a live catch");
 					if (catchTime > tricks.LiveCatchPerfectTime) {
 						// but it's imperfect, so we have add some bounce
 						// example: hit after 10 msecs, fulltime is 16, perfect time is 8, should be (10-8)/(16-8)*inaccuracySpeedMultiplier
 						liveCatchBounceMultiplier = (catchTime - tricks.LiveCatchPerfectTime) / (tricks.LiveCatchFullTime - tricks.LiveCatchPerfectTime) * (tricks.LiveCatchInaccurateBounceSpeedMultiplier-tricks.LiveCatchMinimalBounceSpeedMultiplier) + tricks.LiveCatchMinimalBounceSpeedMultiplier;
 					
 					}
-					//Logger.Info("Bounce Multiplicator is {0}, catchtime {1}", liveCatchBounceMultiplier, catchTime);
-					// re-add speed (to the flipper, since the rubber has still to be calculated)
+					Logger.Info("Bounce Multiplicator is {0}, catchtime {1}", liveCatchBounceMultiplier, catchTime);
 					ball.Velocity -= collEvent.HitNormal * normalSpeed * liveCatchBounceMultiplier;
-					// kill momentum, but not z... (why is this in nFozzy's?)
 					ball.AngularMomentum.x = 0;
 					ball.AngularMomentum.y = 0;
+
 				}
-				//Logger.Info("LiveCatchTest - Ball with y-speed {0}, at CollisionTime: {1}, livecatchTime is {2}, difference is {3} msecs", ball.Velocity.y, msec, tricks.FlipperAngleEndTime * 1000, tricks.FlipperAngleEndTime * 1000 - msec);
-				//Logger.Info("LiveCatchTest - normalspeed = {0}, catchTime = {1}", normalSpeed, catchTime);
+				Logger.Info("LiveCatchTest - Ball with y-speed {0}, at CollisionTime: {1}, livecatchTime is {2}, difference is {3} msecs", ball.Velocity.y, msec, tricks.FlipperAngleEndTime * 1000, tricks.FlipperAngleEndTime * 1000 - msec);
+				Logger.Info("LiveCatchTest - normalspeed = {0}, catchTime = {1}", normalSpeed, catchTime);
 
 			}
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperColliderComponent.cs
@@ -16,7 +16,6 @@
 
 // ReSharper disable InconsistentNaming
 
-using System;
 using Unity.Entities;
 using UnityEngine;
 using VisualPinball.Engine.VPT.Flipper;
@@ -127,25 +126,27 @@ namespace VisualPinball.Unity
 		#endregion
 		[Tooltip("The nFozzy's LiveCatch Physics")]
 		public bool useFlipperLiveCatch = false;
-		
+
 		[Min(0f)]
 		[Tooltip("Minimum distance in vp units from flipper base live catch dampening will occur")]
 		public float LiveCatchDistanceMin = 40f;
 
 		[Min(0f)]
 		[Tooltip("Maxium distance in vp units from flipper base live catch dampening will occur")]
-		public float LiveCatchDistanceMax = 100f; 
+		public float LiveCatchDistanceMax = 100f;
 
 		[Min(0f)]
 		[Tooltip("Minimal ball speed for live catch")]
 		public float LiveCatchMinimalBallSpeed = 6f;
 
+		[Unit("ms")]
 		[Min(0f)]
-		[Tooltip("Maximum Time in msecs for (perfect or imperfect) live catch")]
+		[Tooltip("Maximum Time in for (perfect or imperfect) live catch")]
 		public float LiveCatchFullTime = 16;
 
+		[Unit("ms")]
 		[Min(0f)]
-		[Tooltip("Maximum Time in msecs for a perfect live catch")]
+		[Tooltip("Maximum Time for a perfect live catch")]
 		public float LiveCatchPerfectTime = 8;
 
 		[Min(0f)]

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperColliderComponent.cs
@@ -149,8 +149,12 @@ namespace VisualPinball.Unity
 		public float LiveCatchPerfectTime = 8;
 
 		[Min(0f)]
-		[Tooltip("Maximum bounce speed for an inaccurate live catch")]
-		public float LiveCatchInaccuracySpeed = 32;
+		[Tooltip("Minimum bounce speed multiplier for a live catch (0 allows perfect live catches)")]
+		public float LiveCatchMinmalBounceSpeedMultiplier = 0.1f;
+
+		[Min(0f)]
+		[Tooltip("Maximum bounce speed multiplier for an inaccurate live catch")]
+		public float LiveCatchInaccurateBounceSpeedMultiplier = 1.0f;
 
 		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
 			=> new FlipperApi(gameObject, entity, player);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperColliderComponent.cs
@@ -122,7 +122,7 @@ namespace VisualPinball.Unity
 
 		#region LiveCatch
 		/// <summary>
-		/// If set, apply Flipper Tricks Physics (nFozzy/RothBauerW)
+		/// If set, apply Live Catch (nFozzy/RothBauerW)
 		/// </summary>
 		#endregion
 		[Tooltip("The nFozzy's LiveCatch Physics")]

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperColliderComponent.cs
@@ -79,7 +79,7 @@ namespace VisualPinball.Unity
 
 		public override PhysicsMaterialData PhysicsMaterialData => GetPhysicsMaterialData(Elasticity, ElasticityFalloff, Friction, Scatter);
 
-		#region Flipper_Tricks
+		#region FlipperTricks
 		/// <summary>
 		/// If set, apply Flipper Tricks Physics (nFozzy/RothBauerW)
 		/// </summary>
@@ -119,6 +119,38 @@ namespace VisualPinball.Unity
 		[Tooltip("Bump Ball vertically on release button (speed, up)")]
 		public float BumpOnRelease = 0.4f;
 		#endregion
+
+		#region LiveCatch
+		/// <summary>
+		/// If set, apply Flipper Tricks Physics (nFozzy/RothBauerW)
+		/// </summary>
+		#endregion
+		[Tooltip("The nFozzy's LiveCatch Physics")]
+		public bool useFlipperLiveCatch = false;
+		
+		[Min(0f)]
+		[Tooltip("Minimum distance in vp units from flipper base live catch dampening will occur")]
+		public float LiveCatchDistanceMin = 30f;
+
+		[Min(0f)]
+		[Tooltip("Maxium distance in vp units from flipper base live catch dampening will occur")]
+		public float LiveCatchDistanceMax = 114f; 
+
+		[Min(0f)]
+		[Tooltip("Minimal ball speed for live catch")]
+		public float LiveCatchMinimalBallSpeed = 6f;
+
+		[Min(0f)]
+		[Tooltip("Maximum Time in msecs for (perfect or imperfect) live catch")]
+		public float LiveCatchFullTime = 16;
+
+		[Min(0f)]
+		[Tooltip("Maximum Time in msecs for a perfect live catch")]
+		public float LiveCatchPerfectTime = 8;
+
+		[Min(0f)]
+		[Tooltip("Maximum bounce speed for an inaccurate live catch")]
+		public float LiveCatchInaccuracySpeed = 32;
 
 		protected override IApiColliderGenerator InstantiateColliderApi(Player player, Entity entity)
 			=> new FlipperApi(gameObject, entity, player);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperColliderComponent.cs
@@ -130,11 +130,11 @@ namespace VisualPinball.Unity
 		
 		[Min(0f)]
 		[Tooltip("Minimum distance in vp units from flipper base live catch dampening will occur")]
-		public float LiveCatchDistanceMin = 30f;
+		public float LiveCatchDistanceMin = 40f;
 
 		[Min(0f)]
 		[Tooltip("Maxium distance in vp units from flipper base live catch dampening will occur")]
-		public float LiveCatchDistanceMax = 114f; 
+		public float LiveCatchDistanceMax = 100f; 
 
 		[Min(0f)]
 		[Tooltip("Minimal ball speed for live catch")]

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperComponent.cs
@@ -600,7 +600,8 @@ namespace VisualPinball.Unity
 				LiveCatchMinimalBallSpeed = colliderComponent.LiveCatchMinimalBallSpeed,
 				LiveCatchPerfectTime = colliderComponent.LiveCatchPerfectTime,
 				LiveCatchFullTime = colliderComponent.LiveCatchFullTime,
-				LiveCatchInaccuracySpeed = colliderComponent.LiveCatchInaccuracySpeed,
+				LiveCatchInaccurateBounceSpeedMultiplier = colliderComponent.LiveCatchInaccurateBounceSpeedMultiplier,
+				LiveCatchMinimalBounceSpeedMultiplier = colliderComponent.LiveCatchMinmalBounceSpeedMultiplier,
 
 		//initialize
 		OriginalAngleEnd = staticData.AngleEnd,

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperComponent.cs
@@ -581,7 +581,7 @@ namespace VisualPinball.Unity
 		{
 			return new FlipperTricksData
 			{
-				useFlipperTricksPhysics = colliderComponent.useFlipperTricksPhysics,
+				UseFlipperTricksPhysics = colliderComponent.useFlipperTricksPhysics,
 				SOSRampUp = colliderComponent.SOSRampUp,
 				SOSEM = colliderComponent.SOSEM,
 				EOSReturn = colliderComponent.EOSReturn,

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperComponent.cs
@@ -592,7 +592,15 @@ namespace VisualPinball.Unity
 				AngleEnd = staticData.AngleEnd,
 				TorqueDamping = staticData.TorqueDamping,
 				TorqueDampingAngle = staticData.TorqueDampingAngle,
-				RampUpSpeed = staticData.RampUpSpeed, 
+				RampUpSpeed = staticData.RampUpSpeed,
+
+				UseFlipperLiveCatch = colliderComponent.useFlipperLiveCatch,
+				LiveCatchDistanceMin = colliderComponent.LiveCatchDistanceMin, // vp units from base
+				LiveCatchDistanceMax = colliderComponent.LiveCatchDistanceMax, // vp units from base
+				LiveCatchMinimalBallSpeed = colliderComponent.LiveCatchMinimalBallSpeed,
+				LiveCatchPerfectTime = colliderComponent.LiveCatchPerfectTime,
+				LiveCatchFullTime = colliderComponent.LiveCatchFullTime,
+				LiveCatchInaccuracySpeed = colliderComponent.LiveCatchInaccuracySpeed,
 
 		//initialize
 		OriginalAngleEnd = staticData.AngleEnd,

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperDisplacementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperDisplacementSystem.cs
@@ -78,7 +78,7 @@ namespace VisualPinball.Unity
 				var handleEvent = false;
 
 				if (state.Angle == tricks.AngleEnd) {
-					tricks.liveCatchTime = currentTime;
+					tricks.FlipperAngleEndTime = currentTime;
 				}
 
 				if (state.Angle >= angleMax) {

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperDisplacementSystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperDisplacementSystem.cs
@@ -50,8 +50,9 @@ namespace VisualPinball.Unity
 			var dTime = _simulateCycleSystemGroup.HitTime;
 			var events = _eventQueue.AsParallelWriter();
 			var marker = PerfMarker;
+			var currentTime = Time.ElapsedTime;
 
-			Entities.WithName("FlipperDisplacementJob").ForEach((Entity entity, ref FlipperMovementData state, in FlipperTricksData tricks,in FlipperStaticData data) => {
+			Entities.WithName("FlipperDisplacementJob").ForEach((Entity entity, ref FlipperMovementData state, ref FlipperTricksData tricks, in FlipperStaticData data) => {
 
 				marker.Begin();
 
@@ -75,6 +76,10 @@ namespace VisualPinball.Unity
 				}
 
 				var handleEvent = false;
+
+				if (state.Angle == tricks.AngleEnd) {
+					tricks.liveCatchTime = currentTime;
+				}
 
 				if (state.Angle >= angleMax) {
 					// hit stop?

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperTricksData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperTricksData.cs
@@ -39,10 +39,11 @@ namespace VisualPinball.Unity
 		public bool WasInContact;
 
 		// time used for live Catch
-		public double liveCatchTime;
+		public double FlipperAngleEndTime;
 
 		// externals
-		public bool useFlipperTricksPhysics;
+		//  Flipper Tricksdeu absolut
+		public bool UseFlipperTricksPhysics;
 		public float SOSRampUp;
 		public float SOSEM;
 		public float EOSReturn;
@@ -50,7 +51,15 @@ namespace VisualPinball.Unity
 		public float EOSANew;
 		public float EOSRampup;
 		public float Overshoot;
-		public bool useFlipperLiveCatch;
+		
+		//  Live Catch
+		public bool UseFlipperLiveCatch;
+		public float LiveCatchDistanceMin; // vp units from base
+		public float LiveCatchDistanceMax; // vp units from base
+		public float LiveCatchMinimalBallSpeed; 
+		public float LiveCatchPerfectTime;
+		public float LiveCatchFullTime;
+		public float LiveCatchInaccuracySpeed;
 
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperTricksData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperTricksData.cs
@@ -59,7 +59,8 @@ namespace VisualPinball.Unity
 		public float LiveCatchMinimalBallSpeed; 
 		public float LiveCatchPerfectTime;
 		public float LiveCatchFullTime;
-		public float LiveCatchInaccuracySpeed;
+		public float LiveCatchMinimalBounceSpeedMultiplier;
+		public float LiveCatchInaccurateBounceSpeedMultiplier;
 
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperTricksData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperTricksData.cs
@@ -38,6 +38,9 @@ namespace VisualPinball.Unity
 
 		public bool WasInContact;
 
+		// time used for live Catch
+		public double liveCatchTime;
+
 		// externals
 		public bool useFlipperTricksPhysics;
 		public float SOSRampUp;
@@ -47,5 +50,7 @@ namespace VisualPinball.Unity
 		public float EOSANew;
 		public float EOSRampup;
 		public float Overshoot;
+		public bool useFlipperLiveCatch;
+
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperTricksData.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperTricksData.cs
@@ -42,7 +42,7 @@ namespace VisualPinball.Unity
 		public double FlipperAngleEndTime;
 
 		// externals
-		//  Flipper Tricksdeu absolut
+		//  Flipper Tricks
 		public bool UseFlipperTricksPhysics;
 		public float SOSRampUp;
 		public float SOSEM;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperVelocitySystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperVelocitySystem.cs
@@ -48,7 +48,7 @@ namespace VisualPinball.Unity
 					desiredTorque *= -data.ReturnRatio;
 				}
 
-				if (tricks.useFlipperTricksPhysics) { 
+				if (tricks.UseFlipperTricksPhysics) { 
 					// check if solenoid was just activated or deactivated
 					if (solenoid.Value != tricks.lastSolState)
 					{
@@ -75,7 +75,7 @@ namespace VisualPinball.Unity
 				if (math.abs(mState.Angle - tricks.AngleEnd) < eosAngle) {
 					// fade in/out damping, depending on angle to end
 					var lerp = math.pow(math.abs(mState.Angle - tricks.AngleEnd) / eosAngle, 4);
-					if (tricks.useFlipperTricksPhysics)
+					if (tricks.UseFlipperTricksPhysics)
 						desiredTorque *= lerp + tricks.TorqueDamping * (1 - lerp);
 					else 
 						desiredTorque *= lerp + tricks.TorqueDamping * (1 - lerp);
@@ -128,7 +128,7 @@ namespace VisualPinball.Unity
 				mState.AngleSpeed = mState.AngularMomentum / data.Inertia;
 				vState.AngularAcceleration = torque / data.Inertia;
 
-				if (tricks.useFlipperTricksPhysics)
+				if (tricks.UseFlipperTricksPhysics)
 				{
 					// Flippertricks, case 3 (OnFlipperDown) and 4 (OnFlipperUpResting)
 					if (!tricks.WasInContact && vState.IsInContact)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperVelocitySystem.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperVelocitySystem.cs
@@ -71,11 +71,7 @@ namespace VisualPinball.Unity
 				}
 
 				// hold coil is weaker
-				float eosAngle;
-				if (tricks.useFlipperTricksPhysics)
-					eosAngle = math.radians(tricks.TorqueDampingAngle);
-				else
-					eosAngle = math.radians(tricks.TorqueDampingAngle);
+				float eosAngle = math.radians(tricks.TorqueDampingAngle);
 				if (math.abs(mState.Angle - tricks.AngleEnd) < eosAngle) {
 					// fade in/out damping, depending on angle to end
 					var lerp = math.pow(math.abs(mState.Angle - tricks.AngleEnd) / eosAngle, 4);


### PR DESCRIPTION
Adds live catch to flippers.

There are some differences to nFozzy:
1. Max and min distance is not calculated on x axis, but on tangent to the flipperface from the flippers base. (so that live catches could probably also be done with vertical flippers) 
2. The minimal ball speed for a live catch is a variable and not a constant in the code
3. Not only the time for live catches (from flipped flipper to collision) can be set, but also the minimal time for a "perfect" live catch. (was always 0.5*liveCatchTime)
4. perfect live catches were always zero velocity at nFozzy's, now you can set a multiplicator (default = 0.1), so even a perfect catch has some little bounce - this adds some realism, but can be turned off, when setting is set to 0.0.
5. imperfect live catches added some constant velocities at nFozzy's (depending on the time). Now a multiplicator can be set. maximum inaccurate bounce multiplicator to original speed is applied at full time. Linear regessed to perfect bounce multiplicator, when getting to perfect time. (like at nFozzy).
6. Rubber and the collision to it is still calculated for imperfect (or perfect bounces). 
7. Z-Rotation is not nulled. A rotating ball can rotate from the flipper, as seen in live-catch videos.
8. Every change to the speed of the ball is calculated with the normal direction of the flipper face in mind. So there is no live catch for balls that come from wrong diagonal (for left flipper: fast balls coming from top right had very strange bounces at nFozzy's).  

The default vales differ from nFozzy's script, because of 1 and 5.