### PR TITLE
Fix Mesh Bounding Boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Built with Unity 2021.3.0
 - Put game-, mesh-, collision- animation data into separate components ([#227](https://github.com/freezy/VisualPinball.Engine/pull/227), [Documentation](https://docs.visualpinball.org/creators-guide/editor/unity-components.html)). 
 
 ### Fixed
+- Disappearing objects due to wrong bounding box ([#441](https://github.com/freezy/VisualPinball.Engine/pull/441)).
 - Default table import ([#434](https://github.com/freezy/VisualPinball.Engine/pull/434))
 - Remaining ball spinning issue should now be solved ([#397](https://github.com/freezy/VisualPinball.Engine/pull/397)).
 - Physics error when the ball would stop rotate ([#393](https://github.com/freezy/VisualPinball.Engine/pull/393)).

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.cs
@@ -20,9 +20,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using NLog;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
+using Logger = NLog.Logger;
 
 namespace VisualPinball.Unity.Editor
 {
@@ -58,6 +60,8 @@ namespace VisualPinball.Unity.Editor
 
 		private readonly Dictionary<LibraryAsset, VisualElement> _elementByAsset = new();
 		private readonly Dictionary<VisualElement, AssetResult> _assetsByElement = new();
+
+		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
 		[MenuItem("Visual Pinball/Asset Browser")]
 		public static void ShowWindow()
@@ -297,10 +301,10 @@ namespace VisualPinball.Unity.Editor
 				var category = getCategory(assetLibrary);
 
 				if (assetLibrary.AddAsset(obj, category)) {
-					Debug.Log($"{Path.GetFileName(path)} added to library {assetLibrary.Name}.");
+					Logger.Debug($"{Path.GetFileName(path)} added to library {assetLibrary.Name}.");
 					numAdded++;
 				} else {
-					Debug.Log($"{Path.GetFileName(path)} updated in library {assetLibrary.Name}.");
+					Logger.Debug($"{Path.GetFileName(path)} updated in library {assetLibrary.Name}.");
 					numUpdated++;
 				}
 				updatedLibrary = assetLibrary;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetQuery.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetQuery.cs
@@ -18,9 +18,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using NLog;
 using Unity.Mathematics;
 using UnityEditor;
-using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace VisualPinball.Unity.Editor
@@ -40,6 +40,8 @@ namespace VisualPinball.Unity.Editor
 		private Dictionary<AssetLibrary, List<LibraryCategory>> _categories;
 		private readonly Dictionary<string, HashSet<string>> _attributes = new();
 		private readonly HashSet<string> _tags = new();
+
+		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
 		public AssetQuery(List<AssetLibrary> libraries)
 		{
@@ -135,7 +137,7 @@ namespace VisualPinball.Unity.Editor
 						});
 
 					} catch (Exception e) {
-						Debug.LogError($"Error reading assets from {lib.Name}, maybe corruption? ({e.Message})\n{e.StackTrace}");
+						Logger.Error($"Error reading assets from {lib.Name}, maybe corruption? ({e.Message})\n{e.StackTrace}");
 						// old data or whatever, just don't crash here.
 						return Array.Empty<AssetResult>();
 					}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Utils/PropertyDrawers/TypeRestrictionPropertyDrawer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Utils/PropertyDrawers/TypeRestrictionPropertyDrawer.cs
@@ -16,9 +16,11 @@
 
 using System;
 using System.Linq;
+using NLog;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+using Logger = NLog.Logger;
 
 namespace VisualPinball.Unity.Editor
 {
@@ -28,6 +30,8 @@ namespace VisualPinball.Unity.Editor
 		private MonoBehaviour _component;
 		private AdvancedDropdownState _itemPickDropdownState;
 
+		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
 		public override float GetPropertyHeight(SerializedProperty property, GUIContent label) => EditorGUIUtility.singleLineHeight + 2;
 
 		public override void OnGUI(Rect pos, SerializedProperty property, GUIContent label)
@@ -36,7 +40,7 @@ namespace VisualPinball.Unity.Editor
 			#region Sanity Checks
 
 			if (property.propertyType != SerializedPropertyType.ObjectReference) {
-				Debug.LogError("[TypeRestriction] attribute must be on an object reference.");
+				Logger.Error("[TypeRestriction] attribute must be on an object reference.");
 				return;
 			}
 
@@ -46,7 +50,7 @@ namespace VisualPinball.Unity.Editor
 
 			var comp = property.serializedObject.targetObject as Component;
 			if (comp == null) {
-				Debug.LogError($"Cannot find component of {property.serializedObject.targetObject.name}.");
+				Logger.Error($"Cannot find component of {property.serializedObject.targetObject.name}.");
 				return;
 			}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Common/BoundingBoxComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Common/BoundingBoxComponent.cs
@@ -1,0 +1,42 @@
+﻿// Visual Pinball Engine
+// Copyright (C) 2022 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using UnityEngine;
+
+namespace VisualPinball.Unity.Editor
+{
+	public class BoundingBoxComponent : MonoBehaviour
+	{
+
+		void OnDrawGizmosSelected()
+		{
+			Gizmos.color = Color.yellow;
+			var r = GetComponent<Renderer>();
+			if (r != null) {
+				var b = r.bounds;
+				Gizmos.DrawSphere(b.center, 0.001f); //center sphere
+				Gizmos.DrawWireCube(b.center, b.size);
+			} else {
+				var rs = GetComponentsInChildren<Renderer>();
+				foreach (var r2 in rs) {
+					var b = r2.bounds;
+					Gizmos.DrawSphere(b.center, 0.001f); //center sphere
+					Gizmos.DrawWireCube(b.center, b.size);
+				}
+			}
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/Common/BoundingBoxComponent.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/Common/BoundingBoxComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5aa9d03717239ed4e872ccba5e14b6e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MeshComponent.cs
@@ -101,7 +101,7 @@ namespace VisualPinball.Unity
 			}
 		}
 
-		protected static Bounds CalculateBounds(IEnumerable<DragPointData> dragPoints, float margin = 0, float sizeZ = 0)
+		protected static Bounds CalculateBounds(IEnumerable<DragPointData> dragPoints, float margin = 0, float sizeZ = 0, float posZ = 0)
 		{
 			var min = new float3(float.MaxValue, float.MaxValue, float.MaxValue);
 			var max = new float3(float.MinValue, float.MinValue, float.MinValue);
@@ -111,10 +111,13 @@ namespace VisualPinball.Unity
 				max = math.max(max, p);
 			}
 			var middle = min + (max - min) / 2;
-			var sizeXy = max - min;
-			var size = new float3(sizeXy.x, sizeXy.y, sizeZ > 0 ? sizeZ : sizeXy.z) + margin * new float3(1f, 1f, 1f);
+			var size = max - min;
+			if (sizeZ > 0) {
+				middle.z = posZ + sizeZ / 2;
+				size.z = sizeZ;
+			}
 
-			return new Bounds(middle, size);
+			return new Bounds(middle, size + margin * new float3(1f, 1f, 1f));
 		}
 
 		private void UpdateMesh()

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MeshComponent.cs
@@ -15,7 +15,10 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
+using Unity.Mathematics;
 using UnityEngine;
+using VisualPinball.Engine.Math;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.Table;
 using Mesh = VisualPinball.Engine.VPT.Mesh;
@@ -96,6 +99,22 @@ namespace VisualPinball.Unity
 				var mr = gameObject.AddComponent<MeshRenderer>();
 				mr.sharedMaterial = material.ToUnityMaterial(matProvider, texProvider);
 			}
+		}
+
+		protected static Bounds CalculateBounds(IEnumerable<DragPointData> dragPoints, float margin = 0, float sizeZ = 0)
+		{
+			var min = new float3(float.MaxValue, float.MaxValue, float.MaxValue);
+			var max = new float3(float.MinValue, float.MinValue, float.MinValue);
+			foreach (var t in dragPoints) {
+				var p = (float3)t.Center.ToUnityVector3();
+				min = math.min(min, p);
+				max = math.max(max, p);
+			}
+			var middle = min + (max - min) / 2;
+			var sizeXy = max - min;
+			var size = new float3(sizeXy.x, sizeXy.y, sizeZ > 0 ? sizeZ : sizeXy.z) + margin * new float3(1f, 1f, 1f);
+
+			return new Bounds(middle, size);
 		}
 
 		private void UpdateMesh()

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MetalWireGuide/MetalWireGuideComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MetalWireGuide/MetalWireGuideComponent.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using Unity.Entities;
+using Unity.Mathematics;
 using UnityEngine;
 using VisualPinball.Engine.Math;
 using VisualPinball.Engine.VPT;
@@ -195,7 +196,7 @@ namespace VisualPinball.Unity
 
 		#region Editor Tooling
 
-		private Vector3 DragPointCenter {
+		internal Vector3 DragPointCenter {
 			get {
 				var sum = Vertex3D.Zero;
 				foreach (var t in DragPoints) {
@@ -203,6 +204,34 @@ namespace VisualPinball.Unity
 				}
 				var center = sum / DragPoints.Length;
 				return center.ToUnityVector3();
+			}
+		}
+
+		internal Vector3 DragPointMiddle {
+			get {
+				var min = new float3(float.MaxValue, float.MaxValue, float.MaxValue);
+				var max = new float3(float.MinValue, float.MinValue, float.MinValue);
+				foreach (var t in DragPoints) {
+					var p = (float3)t.Center.ToUnityVector3();
+					min = math.min(min, p);
+					max = math.max(max, p);
+				}
+				var xy = min + (max - min) / 2;
+				return new Vector3(xy.x, xy.y, 0);
+			}
+		}
+
+		internal Vector3 DragPointSize {
+			get {
+				var min = new float3(float.MaxValue, float.MaxValue, float.MaxValue);
+				var max = new float3(float.MinValue, float.MinValue, float.MinValue);
+				foreach (var t in DragPoints) {
+					var p = (float3)t.Center.ToUnityVector3();
+					min = math.min(min, p);
+					max = math.max(max, p);
+				}
+				var xy = max - min;
+				return new Vector3(xy.x, xy.y, _standheight);
 			}
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MetalWireGuide/MetalWireGuideComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MetalWireGuide/MetalWireGuideComponent.cs
@@ -207,34 +207,6 @@ namespace VisualPinball.Unity
 			}
 		}
 
-		internal Vector3 DragPointMiddle {
-			get {
-				var min = new float3(float.MaxValue, float.MaxValue, float.MaxValue);
-				var max = new float3(float.MinValue, float.MinValue, float.MinValue);
-				foreach (var t in DragPoints) {
-					var p = (float3)t.Center.ToUnityVector3();
-					min = math.min(min, p);
-					max = math.max(max, p);
-				}
-				var xy = min + (max - min) / 2;
-				return new Vector3(xy.x, xy.y, 0);
-			}
-		}
-
-		internal Vector3 DragPointSize {
-			get {
-				var min = new float3(float.MaxValue, float.MaxValue, float.MaxValue);
-				var max = new float3(float.MinValue, float.MinValue, float.MinValue);
-				foreach (var t in DragPoints) {
-					var p = (float3)t.Center.ToUnityVector3();
-					min = math.min(min, p);
-					max = math.max(max, p);
-				}
-				var xy = max - min;
-				return new Vector3(xy.x, xy.y, _standheight);
-			}
-		}
-
 		public override ItemDataTransformType EditorPositionType => ItemDataTransformType.ThreeD;
 		public override Vector3 GetEditorPosition()
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MetalWireGuide/MetalWireGuideMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MetalWireGuide/MetalWireGuideMeshComponent.cs
@@ -37,11 +37,7 @@ namespace VisualPinball.Unity
 			base.RebuildMeshes();
 			var mwgComponent = GetComponentInParent<MetalWireGuideComponent>();
 			var mr = GetComponent<MeshRenderer>();
-
-			var bounds = mr.localBounds;
-			bounds.center = mwgComponent.DragPointMiddle;
-			bounds.size = mwgComponent.DragPointSize + 25f * Vector3.one;
-			mr.localBounds = bounds;
+			mr.localBounds = CalculateBounds(mwgComponent.DragPoints, 25f, mwgComponent._standheight);
 		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MetalWireGuide/MetalWireGuideMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MetalWireGuide/MetalWireGuideMeshComponent.cs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-using System;
 using UnityEngine;
 using VisualPinball.Engine.VPT;
 using VisualPinball.Engine.VPT.MetalWireGuide;
@@ -32,5 +31,17 @@ namespace VisualPinball.Unity
 
 		protected override PbrMaterial GetMaterial(MetalWireGuideData data, Table table)
 			=> new MetalWireGuideMeshGenerator(MainComponent).GetMaterial(table, data);
+
+		public override void RebuildMeshes()
+		{
+			base.RebuildMeshes();
+			var mwgComponent = GetComponentInParent<MetalWireGuideComponent>();
+			var mr = GetComponent<MeshRenderer>();
+
+			var bounds = mr.localBounds;
+			bounds.center = mwgComponent.DragPointMiddle;
+			bounds.size = mwgComponent.DragPointSize + 25f * Vector3.one;
+			mr.localBounds = bounds;
+		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceSideMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceSideMeshComponent.cs
@@ -35,5 +35,13 @@ namespace VisualPinball.Unity
 
 		protected override PbrMaterial GetMaterial(SurfaceData data, Table table)
 			=> new SurfaceMeshGenerator(data).GetMaterial(SurfaceMeshGenerator.Side, table, data);
+
+		public override void RebuildMeshes()
+		{
+			base.RebuildMeshes();
+			var sc = GetComponentInParent<SurfaceComponent>();
+			var mr = GetComponent<MeshRenderer>();
+			mr.localBounds = CalculateBounds(sc.DragPoints, 0, sc.HeightTop - sc.HeightBottom, sc.HeightBottom);
+		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceTopMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceTopMeshComponent.cs
@@ -35,5 +35,13 @@ namespace VisualPinball.Unity
 
 		protected override PbrMaterial GetMaterial(SurfaceData data, Table table)
 			=> new SurfaceMeshGenerator(data).GetMaterial(SurfaceMeshGenerator.Top, table, data);
+
+		public override void RebuildMeshes()
+		{
+			base.RebuildMeshes();
+			var sc = GetComponentInParent<SurfaceComponent>();
+			var mr = GetComponent<MeshRenderer>();
+			mr.localBounds = CalculateBounds(sc.DragPoints, 0, 2f, sc.HeightTop - 1f);
+		}
 	}
 }


### PR DESCRIPTION
A few meshes where disappearing from the scene depending on camera angle due to wrong bounding boxes, namely metal wire guides and walls.

This PR properly sets the BBs when generating the mesh. In an existing scene, click on the "Regenerate Mesh" button to re-apply.