### PR TITLE
Fix mesh duplication

### DIFF
--- a/VisualPinball.Engine/VPT/Rubber/RubberMeshGenerator.cs
+++ b/VisualPinball.Engine/VPT/Rubber/RubberMeshGenerator.cs
@@ -93,11 +93,10 @@ namespace VisualPinball.Engine.VPT.Rubber
 
 
 			// one ring for each Splinevertex
-			
+
 			var numRings = sv.VertexCount;
 			var numSegments = accuracy;
 
-			var up = new Vertex3D(0f, 0f, 1f);
 			var points = new Vertex3D[numRings]; // middlepoints of rings
 			var tangents = new Vertex3D[numRings]; // pointing into the direction of the spline, even first and last
 			var right = new Vertex3D[numRings]; // pointing right, looking into tangent direction
@@ -125,7 +124,7 @@ namespace VisualPinball.Engine.VPT.Rubber
 			accLength[0] = 0.0f;
 			for (int i = 1; i < numRings; i++)
 				accLength[i] = accLength[i - 1] + (points[i] - points[i - 1]).Length();
-			// add the lenth from the last ring to the first ring
+			// add the length from the last ring to the first ring
 			var totalLength = accLength[numRings - 1] + (points[0] - points[numRings - 1]).Length();  ;
 
 			var numVertices = (numRings + 1) * numSegments;
@@ -156,7 +155,7 @@ namespace VisualPinball.Engine.VPT.Rubber
 						X = points[currentRing].X + right[currentRing].X * ringsX[currentSegment] + down[currentRing].X * ringsY[currentSegment],
 						Y = points[currentRing].Y + right[currentRing].Y * ringsX[currentSegment] + down[currentRing].Y * ringsY[currentSegment],
 						Z = points[currentRing].Z + right[currentRing].Z * ringsX[currentSegment] + down[currentRing].Z * ringsY[currentSegment],
-						//normals seem to be somehow off, but are caculated again at the end of mesh creation.
+						//normals seem to be somehow off, but are calculated again at the end of mesh creation.
 						Nx = right[currentRing].X * ringsX[currentSegment] + down[currentRing].X * ringsY[currentSegment],
 						Ny = right[currentRing].Y * ringsX[currentSegment] + down[currentRing].Y * ringsY[currentSegment],
 						Nz = right[currentRing].Z * ringsX[currentSegment] + down[currentRing].Z * ringsY[currentSegment],
@@ -182,13 +181,13 @@ namespace VisualPinball.Engine.VPT.Rubber
 						mesh.Indices[indicesIndex++] = currentRing * numSegments + csp1;
 						mesh.Indices[indicesIndex++] = (currentRing - 1) * numSegments + csp1;
 					}
-				} 
+				}
 			}
 
 			// copy first ring into last ring
 			for (int currentSegment = 0; currentSegment < numSegments; currentSegment++)
 			{
-				mesh.Vertices[verticesIndex++] = new Vertex3DNoTex2 
+				mesh.Vertices[verticesIndex++] = new Vertex3DNoTex2
 				{
 					X = points[0].X + right[0].X * ringsX[currentSegment] + down[0].X * ringsY[currentSegment],
 					Y = points[0].Y + right[0].Y * ringsX[currentSegment] + down[0].Y * ringsY[currentSegment],

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Import/VpxPrefab.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Import/VpxPrefab.cs
@@ -45,6 +45,9 @@ namespace VisualPinball.Unity.Editor
 			GameObject = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
 			GameObject!.name = item.Name;
 			_mainComponent = GameObject.GetComponent<TMainComponent>();
+			if (_mainComponent && _mainComponent.HasProceduralMesh) {
+				PrefabUtility.UnpackPrefabInstance(GameObject, PrefabUnpackMode.OutermostRoot, InteractionMode.AutomatedAction);
+			}
 		}
 
 		public void SetData()

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperComponent.cs
@@ -68,6 +68,7 @@ namespace VisualPinball.Unity
 
 		public override ItemType ItemType => ItemType.Bumper;
 		public override string ItemName => "Bumper";
+		public override bool HasProceduralMesh => false;
 
 		public override BumperData InstantiateData() => new BumperData();
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<BumperData, BumperComponent>);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Flipper/FlipperComponent.cs
@@ -111,6 +111,9 @@ namespace VisualPinball.Unity
 		public float _rubberWidth = 24.0f;
 		public float RubberWidth => _rubberWidth;
 
+		[HideInInspector]
+		public bool InstantiateAsPrefab;
+
 		#endregion
 
 		#region Overrides and Constants
@@ -119,6 +122,8 @@ namespace VisualPinball.Unity
 		public override string ItemName => "Flipper";
 
 		public override FlipperData InstantiateData() => new FlipperData();
+
+		public override bool HasProceduralMesh => !InstantiateAsPrefab;
 
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<FlipperData, FlipperComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<FlipperData, FlipperComponent>);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateComponent.cs
@@ -88,6 +88,8 @@ namespace VisualPinball.Unity
 		public override ItemType ItemType => ItemType.Gate;
 		public override string ItemName => "Gate";
 
+		public override bool HasProceduralMesh => false;
+
 		public override GateData InstantiateData() => new GateData();
 
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<GateData, GateComponent>);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/HitTargetComponent.cs
@@ -29,6 +29,8 @@ namespace VisualPinball.Unity
 	{
 		protected override float ZOffset => 0;
 
+		public override bool HasProceduralMesh => false;
+
 		#region Conversion
 
 		public void Convert(Entity entity, EntityManager dstManager, GameObjectConversionSystem conversionSystem)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/TargetComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/HitTarget/TargetComponent.cs
@@ -88,6 +88,7 @@ namespace VisualPinball.Unity
 		public override string ItemName => "Target";
 
 		public override HitTargetData InstantiateData() => new HitTargetData();
+		public override bool HasProceduralMesh => false;
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<HitTargetData, TargetComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<HitTargetData, TargetComponent>);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/ItemComponent.cs
@@ -53,6 +53,9 @@ namespace VisualPinball.Unity
 		protected bool GetEnabled<T>() where T : Object
 		{
 			var comp = GetComponent<T>();
+			if (!comp) {
+				return false;
+			}
 			switch (comp) {
 				case Behaviour behaviourComp:
 					return behaviourComp.enabled;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerComponent.cs
@@ -74,6 +74,8 @@ namespace VisualPinball.Unity
 
 		public override KickerData InstantiateData() => new KickerData();
 
+		public override bool HasProceduralMesh => false;
+
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<KickerData, KickerComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<KickerData, KickerComponent>);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Light/LightComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Light/LightComponent.cs
@@ -75,6 +75,8 @@ namespace VisualPinball.Unity
 
 		public override LightData InstantiateData() => new LightData();
 
+		public override bool HasProceduralMesh => false;
+
 		public override bool OverrideTransform => false;
 
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<LightData, LightComponent>);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MainComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MainComponent.cs
@@ -50,6 +50,8 @@ namespace VisualPinball.Unity
 		public abstract IEnumerable<MonoBehaviour> SetReferencedData(TData data, Table table, IMaterialProvider materialProvider, ITextureProvider textureProvider, Dictionary<string, IMainComponent> components);
 		public abstract TData CopyDataTo(TData data, string[] materialNames, string[] textureNames, bool forExport);
 
+		public abstract bool HasProceduralMesh { get; }
+
 		public abstract ItemType ItemType { get; }
 
 		protected T FindComponent<T>(Dictionary<string, IMainComponent> components, string surfaceName) where T : class

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MeshComponent.cs
@@ -87,7 +87,7 @@ namespace VisualPinball.Unity
 			if (m == null) {
 				return;
 			}
-			var mesh = m.ToUnityMesh($"{name} Mesh ({gameObject.name})");
+			var mesh = m.ToUnityMesh($"{name} (Generated)");
 
 			// apply mesh to game object
 			var mf = gameObject.GetComponent<MeshFilter>();
@@ -140,7 +140,7 @@ namespace VisualPinball.Unity
 			if (mf != null) {
 				var unityMesh = mf.sharedMesh;
 				if (!unityMesh) {
-					mf.sharedMesh = new UnityEngine.Mesh() { name = $"{name} (Generated)" };
+					mf.sharedMesh = new UnityEngine.Mesh { name = $"{name} (Updated)" };
 					unityMesh = mf.sharedMesh;
 				}
 				mesh.ApplyToUnityMesh(unityMesh);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MeshComponent.cs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+// ReSharper disable InconsistentNaming
+
 using System;
 using System.Collections.Generic;
 using Unity.Mathematics;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MeshComponent.cs
@@ -73,6 +73,8 @@ namespace VisualPinball.Unity
 
 		protected abstract Mesh GetMesh(TData data);
 
+		protected virtual bool IsProcedural => true;
+
 		protected abstract PbrMaterial GetMaterial(TData data, Table table);
 
 		public void CreateMesh(TData data, Table table, ITextureProvider texProvider, IMaterialProvider matProvider)
@@ -153,7 +155,7 @@ namespace VisualPinball.Unity
 				return;
 			}
 
-			if (_instanceID == 0) {
+			if (_instanceID == 0 || !IsProcedural) {
 				SetInstanceID();
 				return;
 			}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MeshComponent.cs
@@ -144,5 +144,44 @@ namespace VisualPinball.Unity
 				mesh.ApplyToUnityMesh(unityMesh);
 			}
 		}
+
+#if UNITY_EDITOR
+		[SerializeField] private int _instanceID;
+		void Awake()
+		{
+			if (Application.isPlaying) {
+				return;
+			}
+
+			if (_instanceID == 0) {
+				SetInstanceID();
+				return;
+			}
+
+			if (_instanceID != GetInstanceID()) {
+				SetInstanceID();
+
+				var mf = GetComponent<MeshFilter>();
+				if (mf == null) {
+					return;
+				}
+
+				if (mf.sharedMesh != null) {
+					mf.sharedMesh = null;
+					RebuildMeshes();
+					Debug.Log($"[{name}] Mesh regenerated.");
+				}
+			}
+		}
+
+		private void SetInstanceID()
+		{
+			_instanceID = GetInstanceID();
+			var obj = new UnityEditor.SerializedObject(this);
+			obj.FindProperty(nameof(_instanceID)).intValue = _instanceID;
+			obj.ApplyModifiedPropertiesWithoutUndo();
+		}
+#endif
+
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MetalWireGuide/MetalWireGuideComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MetalWireGuide/MetalWireGuideComponent.cs
@@ -82,6 +82,8 @@ namespace VisualPinball.Unity
 
 		public override MetalWireGuideData InstantiateData() => new MetalWireGuideData();
 
+		public override bool HasProceduralMesh => true;
+
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<MetalWireGuideData, MetalWireGuideComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<MetalWireGuideData, MetalWireGuideComponent>);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MetalWireGuide/MetalWireGuideMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MetalWireGuide/MetalWireGuideMeshComponent.cs
@@ -39,5 +39,30 @@ namespace VisualPinball.Unity
 			var mr = GetComponent<MeshRenderer>();
 			mr.localBounds = CalculateBounds(mwgComponent.DragPoints, 25f, mwgComponent._standheight);
 		}
+
+#if UNITY_EDITOR
+		[SerializeField] private bool _isInitialized;
+		private void Awake()
+		{
+			if (Application.isPlaying) {
+				return;
+			}
+
+			if (_isInitialized) {
+				return;
+			}
+
+			_isInitialized = true;
+
+			var mf = GetComponent<MeshFilter>();
+			if (mf == null) {
+				return;
+			}
+
+			mf.sharedMesh = null;
+			RebuildMeshes();
+			Debug.Log($"[{name}] mesh regenerated.");
+		}
+#endif
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/MetalWireGuide/MetalWireGuideMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/MetalWireGuide/MetalWireGuideMeshComponent.cs
@@ -39,30 +39,5 @@ namespace VisualPinball.Unity
 			var mr = GetComponent<MeshRenderer>();
 			mr.localBounds = CalculateBounds(mwgComponent.DragPoints, 25f, mwgComponent._standheight);
 		}
-
-#if UNITY_EDITOR
-		[SerializeField] private bool _isInitialized;
-		private void Awake()
-		{
-			if (Application.isPlaying) {
-				return;
-			}
-
-			if (_isInitialized) {
-				return;
-			}
-
-			_isInitialized = true;
-
-			var mf = GetComponent<MeshFilter>();
-			if (mf == null) {
-				return;
-			}
-
-			mf.sharedMesh = null;
-			RebuildMeshes();
-			Debug.Log($"[{name}] mesh regenerated.");
-		}
-#endif
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Playfield/PlayfieldComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Playfield/PlayfieldComponent.cs
@@ -81,6 +81,8 @@ namespace VisualPinball.Unity
 
 		public override bool CanBeTransformed => false;
 
+		public override bool HasProceduralMesh => true;
+
 		public override TableData InstantiateData() => new TableData();
 
 		protected override Type MeshComponentType => typeof(PlayfieldMeshComponent);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerComponent.cs
@@ -63,6 +63,8 @@ namespace VisualPinball.Unity
 
 		public override PlungerData InstantiateData() => new PlungerData();
 
+		public override bool HasProceduralMesh => true;
+
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<PlungerData, PlungerComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<PlungerData, PlungerComponent>);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveComponent.cs
@@ -65,6 +65,8 @@ namespace VisualPinball.Unity
 
 		public override PrimitiveData InstantiateData() => new PrimitiveData();
 
+		public override bool HasProceduralMesh => false;
+
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<PrimitiveData, PrimitiveComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<PrimitiveData, PrimitiveComponent>);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveMeshComponent.cs
@@ -41,6 +41,8 @@ namespace VisualPinball.Unity
 
 		#endregion
 
+		protected override bool IsProcedural => UseLegacyMesh;
+
 		protected override Mesh GetMesh(PrimitiveData data)
 			=> new PrimitiveMeshGenerator(data).GetMesh(MainComponent.PlayfieldHeight, data.Mesh, Origin.Original, false);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ramp/RampComponent.cs
@@ -111,6 +111,8 @@ namespace VisualPinball.Unity
 
 		public override RampData InstantiateData() => new RampData();
 
+		public override bool HasProceduralMesh => true;
+
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<RampData, RampComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<RampData, RampComponent>);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberComponent.cs
@@ -78,6 +78,8 @@ namespace VisualPinball.Unity
 
 		public override RubberData InstantiateData() => new RubberData();
 
+		public override bool HasProceduralMesh => true;
+
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<RubberData, RubberComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<RubberData, RubberComponent>);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Spinner/SpinnerComponent.cs
@@ -81,6 +81,8 @@ namespace VisualPinball.Unity
 
 		public override SpinnerData InstantiateData() => new SpinnerData();
 
+		public override bool HasProceduralMesh => false;
+
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<SpinnerData, SpinnerComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<SpinnerData, SpinnerComponent>);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceComponent.cs
@@ -57,6 +57,8 @@ namespace VisualPinball.Unity
 
 		public override SurfaceData InstantiateData() => new SurfaceData();
 
+		public override bool HasProceduralMesh => true;
+
 
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<SurfaceData, SurfaceComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<SurfaceData, SurfaceComponent>);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Table/TableComponent.cs
@@ -54,6 +54,8 @@ namespace VisualPinball.Unity
 
 		public override TableData InstantiateData() => new TableData();
 
+		public override bool HasProceduralMesh => true;
+
 		protected override Type MeshComponentType => null;
 		protected override Type ColliderComponentType => null;
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trigger/TriggerComponent.cs
@@ -71,6 +71,8 @@ namespace VisualPinball.Unity
 
 		public override TriggerData InstantiateData() => new TriggerData();
 
+		public override bool HasProceduralMesh => true;
+
 		protected override Type MeshComponentType { get; } = typeof(MeshComponent<TriggerData, TriggerComponent>);
 		protected override Type ColliderComponentType { get; } = typeof(ColliderComponent<TriggerData, TriggerComponent>);
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Trough/TroughComponent.cs
@@ -93,6 +93,8 @@ namespace VisualPinball.Unity
 
 		public override TroughData InstantiateData() => new TroughData();
 
+		public override bool HasProceduralMesh => false;
+
 		#endregion
 
 		#region Wiring


### PR DESCRIPTION
This PR addresses two annoyances:

1. Mesh duplication in the editor: When you duplicate an object with a procedurally generated mesh such as rubbers, Unity keeps the reference to the mesh, meaning both items share the same mesh, which is clearly not desired. A workaround was to set the mesh object of the duplicate to null, then regenerate it, which wasn't ideal. 
  This PR serialized the GameObject's instance ID, and compares it on `Awake()` against the "real" instance ID from `GetInstanceID()`. If the object was duplicated, it's different, and we clear and re-generate the mesh to break the reference. However there is a drawback: Instance IDs don't persist across scenes, which results in all meshes being regenerated when the scene is loaded.
2. For some reason, prefabs store the last mesh along with the current mesh. So all items that store their mesh in the scene would have their mesh in the scene twice. See also [Unity Forum](https://forum.unity.com/threads/procedurally-generated-mesh-saved-twice-in-scene.1337075/).
  This PR unpacks the prefabs for items that have a procedurally generated mesh. TBH I don't see any drawback keeping those as GameObjects instead of Prefabs in the scene.