### PR TITLE
Fix drag points behavior in editor

### DIFF
--- a/VisualPinball.Engine/Math/DragPoint.cs
+++ b/VisualPinball.Engine/Math/DragPoint.cs
@@ -59,9 +59,11 @@ namespace VisualPinball.Engine.Math
 				vertex1.Smooth = pdp1.IsSmooth;
 				vertex1.IsSlingshot = pdp1.IsSlingshot;
 				vertex1.IsControlPoint = true;
+				vertex1.Id = pdp1.Id;
 
 				// Properties of last point don't matter, because it won't be added to the list on this pass (it'll get added as the first point of the next curve)
 				vertex2.Set(pdp2.Center);
+				vertex2.Id = pdp2.Id;
 
 				vertices = RecurseSmoothLine(vertices, cc, 0.0f, 1.0f, vertex1, vertex2, accuracy);
 			}

--- a/VisualPinball.Engine/Math/DragPointData.cs
+++ b/VisualPinball.Engine/Math/DragPointData.cs
@@ -111,26 +111,6 @@ namespace VisualPinball.Engine.Math
 			};
 		}
 
-		public DragPointData Move(float x, float y)
-		{
-			Center.X += x;
-			Center.Y += y;
-			return this;
-		}
-
-		public DragPointData CloneWithId()
-		{
-			var clone = Clone();
-			clone.Id = Id;
-			return clone;
-		}
-
-		public DragPointData ResetZ()
-		{
-			PosZ = 0;
-			return this;
-		}
-
 		#region BIFF
 
 		static DragPointData()

--- a/VisualPinball.Engine/Math/DragPointData.cs
+++ b/VisualPinball.Engine/Math/DragPointData.cs
@@ -35,6 +35,8 @@ namespace VisualPinball.Engine.Math
 	[Serializable]
 	public class DragPointData : BiffData
 	{
+		public string Id;
+		
 		[BiffVertex("VCEN", Pos = 1, WriteAsVertex2D = true)]
 		public Vertex3D Center;
 
@@ -64,13 +66,19 @@ namespace VisualPinball.Engine.Math
 
 		[BiffBool("LVIS", Pos = 10, WasAddedInVp107 = true)]
 		public bool EditorLayerVisibility = true;
-
+		
 		public float CalcHeight;
 
 		[ExcludeFromCodeCoverage]
 		public override string ToString()
 		{
 			return $"DragPoint({Center.X}/{Center.Y}/{Center.Z}, {(IsSmooth ? "S" : "")}{(IsSlingshot ? "SS" : "")}{(HasAutoTexture ? "A" : "")})";
+		}
+
+		public DragPointData AssertId()
+		{
+			Id ??= GenerateId();
+			return this;
 		}
 
 		public DragPointData Lerp(DragPointData dp, float pos)
@@ -103,6 +111,26 @@ namespace VisualPinball.Engine.Math
 			};
 		}
 
+		public DragPointData Move(float x, float y)
+		{
+			Center.X += x;
+			Center.Y += y;
+			return this;
+		}
+
+		public DragPointData CloneWithId()
+		{
+			var clone = Clone();
+			clone.Id = Id;
+			return clone;
+		}
+
+		public DragPointData ResetZ()
+		{
+			PosZ = 0;
+			return this;
+		}
+
 		#region BIFF
 
 		static DragPointData()
@@ -112,18 +140,21 @@ namespace VisualPinball.Engine.Math
 
 		public DragPointData(Vertex3D center) : base(null)
 		{
+			Id = GenerateId();
 			Center = center;
 			HasAutoTexture = true;
 		}
 
 		public DragPointData(float x, float y) : base(null)
 		{
+			Id = GenerateId();
 			Center = new Vertex3D(x, y, 0f);
 			HasAutoTexture = true;
 		}
 
 		public DragPointData(DragPointData rf) : base(null)
 		{
+			Id = GenerateId();
 			Center = rf.Center;
 			PosZ = rf.PosZ;
 			IsSmooth = rf.IsSmooth;
@@ -138,6 +169,7 @@ namespace VisualPinball.Engine.Math
 		public DragPointData(BinaryReader reader) : base(null)
 		{
 			Load(this, reader, Attributes);
+			Id = GenerateId();
 		}
 
 		public override void Write(BinaryWriter writer, HashWriter hashWriter)
@@ -147,6 +179,8 @@ namespace VisualPinball.Engine.Math
 		}
 
 		private static readonly Dictionary<string, List<BiffAttribute>> Attributes = new Dictionary<string, List<BiffAttribute>>();
+		
+		private static string GenerateId() => Guid.NewGuid().ToString()[..8];
 
 		#endregion
 

--- a/VisualPinball.Engine/Math/RenderVertex.cs
+++ b/VisualPinball.Engine/Math/RenderVertex.cs
@@ -20,6 +20,8 @@ namespace VisualPinball.Engine.Math
 	{
 		public float X;
 		public float Y;
+		
+		public string Id { get; set; }
 
 		public float GetX() => X;
 		public float GetY() => Y;
@@ -53,6 +55,8 @@ namespace VisualPinball.Engine.Math
 		public float X;
 		public float Y;
 		public float Z;
+		
+		public string Id { get; set; }
 
 		public float GetX() => X;
 		public float GetY() => Y;
@@ -89,8 +93,9 @@ namespace VisualPinball.Engine.Math
 
 	public interface IRenderVertex
 	{
+		string Id { get; set; }
+		
 		void Set(Vertex3D v);
-
 		float GetX();
 		float GetY();
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/ControlPoint.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/ControlPoint.cs
@@ -37,23 +37,16 @@ namespace VisualPinball.Unity.Editor
 		/// Reference to the drag point data
 		/// </summary>
 		public DragPointData DragPoint;
-
+		
 		/// <summary>
-		/// Position in local space
+		/// Position in VPX space
 		/// </summary>
-		public Vector3 VpxPosition {
-			get => DragPoint.Center.ToUnityVector3()
-			       + _dragPointsInspector.EditableOffset
-			       + _dragPointsInspector.GetDragPointOffset(IndexRatio);
-			set => DragPoint.Center = value.ToVertex3D()
-			       - _dragPointsInspector.EditableOffset.ToVertex3D()
-			       - _dragPointsInspector.GetDragPointOffset(IndexRatio).ToVertex3D();
-		}
+		public Vector3 AbsolutePosition => new(DragPoint.Center.X, DragPoint.Center.Y, DragPoint.CalcHeight);
 
 		/// <summary>
 		/// Position in world space
 		/// </summary>
-		public Vector3 Position => VpxPosition.TranslateToWorld();
+		public Vector3 Position => AbsolutePosition.TranslateToWorld();
 
 		public float HandleSize => HandleUtility.GetHandleSize(Position) * ScreenRadius;
 
@@ -68,24 +61,20 @@ namespace VisualPinball.Unity.Editor
 		public readonly int ControlId;
 
 		/// <summary>
+		/// The DragPoint ID that is saved within the drag point.
+		/// </summary>
+		public string DragPointId => DragPoint.Id;
+
+		/// <summary>
 		/// Index of the drag point within the game item's drag point array.
 		/// </summary>
 		public readonly int Index;
-
-		/// <summary>
-		/// Relative position on the curve, from 0.0 to 1.0.
-		/// </summary>
-		public readonly float IndexRatio;
 		
-		private readonly IDragPointsInspector _dragPointsInspector;
-
-		public ControlPoint(IDragPointsInspector dragPointsInspector, int controlId, int idx, float indexRatio)
+		public ControlPoint(IDragPointsInspector dragPointsInspector, int controlId, int idx)
 		{
 			DragPoint = dragPointsInspector.DragPoints[idx];
-			_dragPointsInspector = dragPointsInspector;
 			ControlId = controlId;
 			Index = idx;
-			IndexRatio = indexRatio;
 		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/ControlPoint.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/ControlPoint.cs
@@ -43,12 +43,14 @@ namespace VisualPinball.Unity.Editor
 		/// </summary>
 		public Vector3 AbsolutePosition => new(DragPoint.Center.X, DragPoint.Center.Y, DragPoint.CalcHeight);
 
+		public Vector3 EditorPositionVpx => AbsolutePosition + new Vector3(0, 0, _dragPointsInspector.ZOffset);
+
 		/// <summary>
 		/// Position in world space
 		/// </summary>
-		public Vector3 Position => AbsolutePosition.TranslateToWorld();
+		public Vector3 EditorPositionWorld => EditorPositionVpx.TranslateToWorld();
 
-		public float HandleSize => HandleUtility.GetHandleSize(Position) * ScreenRadius;
+		public float HandleSize => HandleUtility.GetHandleSize(EditorPositionWorld) * ScreenRadius;
 
 		/// <summary>
 		/// Currently selected or not?
@@ -69,12 +71,15 @@ namespace VisualPinball.Unity.Editor
 		/// Index of the drag point within the game item's drag point array.
 		/// </summary>
 		public readonly int Index;
+
+		private readonly IDragPointsInspector _dragPointsInspector;
 		
 		public ControlPoint(IDragPointsInspector dragPointsInspector, int controlId, int idx)
 		{
 			DragPoint = dragPointsInspector.DragPoints[idx];
 			ControlId = controlId;
 			Index = idx;
+			_dragPointsInspector = dragPointsInspector;
 		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointMenuItems.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointMenuItems.cs
@@ -198,6 +198,16 @@ namespace VisualPinball.Unity.Editor
 			inspector.DragPointsHelper.FlipDragPoints(FlipAxis.Z);
 		}
 
+		[MenuItem(CurveTravellerMenuPath + "/Flip Drag Points/Z", true, 103)]
+		[MenuItem(ControlPointsMenuPath + "/Flip Drag Points/Z", true, 203)]
+		private static bool FlipZValidate(MenuCommand command)
+		{
+			if (command.context is IDragPointsInspector inspector) {
+				return inspector.HandleType == ItemDataTransformType.ThreeD;
+			}
+			return false;
+		}
+
 		[MenuItem(CurveTravellerMenuPath + "/Reverse", false, 501)]
 		[MenuItem(ControlPointsMenuPath + "/Reverse", false, 601)]
 		private static void Reverse(MenuCommand command)

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsHandler.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsHandler.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Unity.Mathematics;
 using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -26,7 +25,7 @@ using Object = UnityEngine.Object;
 
 namespace VisualPinball.Unity.Editor
 {
-	public delegate void OnDragPointPositionChange();
+	public delegate void DragPointPositionChange();
 
 	public class DragPointsHandler
 	{
@@ -293,7 +292,7 @@ namespace VisualPinball.Unity.Editor
 		///
 		/// <param name="evt">Event from the inspector</param>
 		/// <param name="onChange"></param>
-		public void OnSceneGUI(Event evt, OnDragPointPositionChange onChange = null)
+		public void OnSceneGUI(Event evt, DragPointPositionChange onChange = null)
 		{
 			switch (evt.type) {
 				case EventType.Layout:
@@ -309,8 +308,9 @@ namespace VisualPinball.Unity.Editor
 					break;
 			}
 
-			// Handle the common position handler for all selected control points
 			if (SelectedControlPoints.Count > 0) {
+				
+				// set start positions since clicked
 				if (evt.type == EventType.MouseDown) {
 					_startPos = _centerSelected;
 					_startPosZ.Clear();
@@ -318,21 +318,17 @@ namespace VisualPinball.Unity.Editor
 						_startPosZ[cp.DragPointId] = cp.DragPoint.Center.Z;
 					}
 				}
-				EditorGUI.BeginChangeCheck();
+				
 				// get new pos since last frame
+				EditorGUI.BeginChangeCheck();
 				var newHandlePos = HandlesUtils.HandlePosition(Transform.GetComponentInParent<PlayfieldComponent>(), _centerSelected, DragPointInspector.HandleType);
 				if (EditorGUI.EndChangeCheck()) {
-					var deltaPos = newHandlePos - _centerSelected;
-					
-					// get heights of new position(s)
-					var selectedIds = new HashSet<string>(SelectedControlPoints.Select(cp => cp.DragPointId));
-					var dragPointsPosZ = DragPointInspector.GetDragPointBaseHeight(selectedIds, deltaPos.x, deltaPos.y);
+					var delta = newHandlePos - _centerSelected;
 					var deltaZ = newHandlePos.z - _startPos.z;
-					
 					foreach (var controlPoint in SelectedControlPoints) {
 						controlPoint.DragPoint.Center = new Vertex3D(
-							controlPoint.DragPoint.Center.X + deltaPos.x,
-							controlPoint.DragPoint.Center.Y + deltaPos.y,
+							controlPoint.DragPoint.Center.X + delta.x,
+							controlPoint.DragPoint.Center.Y + delta.y,
 							_startPosZ[controlPoint.DragPointId] + deltaZ
 						);
 					}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsHandler.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsHandler.cs
@@ -93,7 +93,8 @@ namespace VisualPinball.Unity.Editor
 		private Vector3 _center = Vector3.zero;
 
 		private Vector3 _startPos;
-		private Dictionary<string, float> _startPosZ = new();
+		private readonly Dictionary<string, float> _startPosZ = new();
+		private float[] _startTopBottomZ;
 
 		/// <summary>
 		/// Every DragPointsInspector instantiates this to manage its curve handling.
@@ -314,6 +315,7 @@ namespace VisualPinball.Unity.Editor
 				// set start positions since clicked
 				if (evt.type == EventType.MouseDown) {
 					_startPos = _centerSelected;
+					_startTopBottomZ = DragPointInspector.TopBottomZ;
 					_startPosZ.Clear();
 					foreach (var cp in SelectedControlPoints) {
 						_startPosZ[cp.DragPointId] = cp.DragPoint.Center.Z;
@@ -329,11 +331,11 @@ namespace VisualPinball.Unity.Editor
 					
 					Undo.RecordObject(MainComponent as MonoBehaviour, "move Drag Points");
 					foreach (var controlPoint in SelectedControlPoints) {
-						controlPoint.DragPoint.Center = new Vertex3D(
+						DragPointInspector.SetDragPointPosition(controlPoint.DragPoint, new Vertex3D(
 							controlPoint.DragPoint.Center.X + delta.x,
 							controlPoint.DragPoint.Center.Y + delta.y,
 							_startPosZ[controlPoint.DragPointId] + deltaZ
-						);
+						), SelectedControlPoints.Count, _startTopBottomZ);
 					}
 					onChange?.Invoke();
 				}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsHandler.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsHandler.cs
@@ -326,6 +326,8 @@ namespace VisualPinball.Unity.Editor
 				if (EditorGUI.EndChangeCheck()) {
 					var delta = newHandlePos - _centerSelected;
 					var deltaZ = newHandlePos.z - _startPos.z;
+					
+					Undo.RecordObject(MainComponent as MonoBehaviour, "move Drag Points");
 					foreach (var controlPoint in SelectedControlPoints) {
 						controlPoint.DragPoint.Center = new Vertex3D(
 							controlPoint.DragPoint.Center.X + delta.x,

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsHandler.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsHandler.cs
@@ -136,6 +136,7 @@ namespace VisualPinball.Unity.Editor
 		}
 
 		public DragPointData GetDragPoint(int controlId) => GetControlPoint(controlId)?.DragPoint;
+		public ControlPoint GetControlPoint(string dragPointId) => ControlPoints.Find(cp => cp.DragPointId == dragPointId);
 		private ControlPoint GetControlPoint(int controlId) => ControlPoints.Find(cp => cp.ControlId == controlId);
 
 		/// <summary>
@@ -355,7 +356,7 @@ namespace VisualPinball.Unity.Editor
 				HandleUtility.AddControl(
 					controlPoint.ControlId,
 					HandleUtility.DistanceToCircle(
-						controlPoint.Position,
+						controlPoint.EditorPositionWorld,
 						controlPoint.HandleSize
 					)
 				);
@@ -369,7 +370,7 @@ namespace VisualPinball.Unity.Editor
 			if (SelectedControlPoints.Count > 0) {
 				_centerSelected = Vector3.zero;
 				foreach (var sCp in SelectedControlPoints) {
-					_centerSelected += sCp.AbsolutePosition;
+					_centerSelected += sCp.EditorPositionVpx;
 				}
 				_centerSelected /= SelectedControlPoints.Count;
 			}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsInspectorHelper.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsInspectorHelper.cs
@@ -65,7 +65,7 @@ namespace VisualPinball.Unity.Editor
 		public void RebuildMeshes()
 		{
 			_mainComponent.RebuildMeshes();
-			if (_playfieldComponent != null) {
+			if (_playfieldComponent) {
 				WalkChildren(_playfieldComponent.transform, UpdateSurfaceReferences);
 			} else {
 				Debug.LogWarning($"{_mainComponent.name} doesn't seem to have a playfield parent.");
@@ -172,6 +172,7 @@ namespace VisualPinball.Unity.Editor
 		{
 			PrepareUndo($"Add drag point at position {DragPointsHandler.CurveTravellerPosition}");
 			DragPointsHandler.AddDragPointOnTraveller();
+			RebuildMeshes();
 		}
 
 		/// <summary>
@@ -247,7 +248,7 @@ namespace VisualPinball.Unity.Editor
 			}
 		}
 
-		private void OnDragPointPositionChange(Vector3 newPos)
+		private void OnDragPointPositionChange()
 		{
 			RebuildMeshes();
 			PrepareUndo("Change Drag Point Position");

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsInspectorHelper.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsInspectorHelper.cs
@@ -36,7 +36,7 @@ namespace VisualPinball.Unity.Editor
 		/// <summary>
 		/// If true, a list of the drag points is displayed in the inspector.
 		/// </summary>
-		private bool _foldoutControlPoints;
+		private bool _foldoutControlPoints = true;
 
 		/// <summary>
 		/// stored vector during the copy/paste process
@@ -215,7 +215,7 @@ namespace VisualPinball.Unity.Editor
 				for (var i = 0; i < DragPointsHandler.ControlPoints.Count; ++i) {
 					var controlPoint = DragPointsHandler.ControlPoints[i];
 					EditorGUILayout.BeginHorizontal();
-					EditorGUILayout.LabelField($"#{i} ({controlPoint.DragPoint.Center.X},{controlPoint.DragPoint.Center.Y},{controlPoint.DragPoint.Center.Z})");
+					EditorGUILayout.LabelField($"Drag Point #{i}");
 					if (GUILayout.Button("Copy")) {
 						CopyDragPoint(controlPoint.ControlId);
 					}
@@ -224,6 +224,22 @@ namespace VisualPinball.Unity.Editor
 					}
 					EditorGUILayout.EndHorizontal();
 					EditorGUI.indentLevel++;
+					EditorGUI.BeginChangeCheck();
+					if (_dragPointsInspector.HandleType == ItemDataTransformType.TwoD) {
+						var pos = EditorGUILayout.Vector2Field("Position", controlPoint.DragPoint.Center.ToUnityVector2());
+						if (EditorGUI.EndChangeCheck()) {
+							controlPoint.DragPoint.Center.X = pos.x;
+							controlPoint.DragPoint.Center.Y = pos.y;
+							RebuildMeshes();
+						}
+					} else {
+						var pos = EditorGUILayout.Vector3Field("Position", controlPoint.DragPoint.Center.ToUnityVector3());
+						if (EditorGUI.EndChangeCheck()) {
+							controlPoint.DragPoint.Center = pos.ToVertex3D();
+							RebuildMeshes();
+						}
+					}
+
 					if (HasDragPointExposure(DragPointExposure.SlingShot)) {
 						inspector.ItemDataField("Slingshot", ref controlPoint.DragPoint.IsSlingshot);
 					}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsInspectorHelper.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsInspectorHelper.cs
@@ -115,6 +115,7 @@ namespace VisualPinball.Unity.Editor
 			if (dp != null) {
 				PrepareUndo($"Paste drag point {controlId}");
 				dp.Center = _storedControlPoint.ToVertex3D();
+				RebuildMeshes();
 			}
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsInspectorHelper.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsInspectorHelper.cs
@@ -113,7 +113,7 @@ namespace VisualPinball.Unity.Editor
 		{
 			var dp = GetDragPoint(controlId);
 			if (dp != null) {
-				PrepareUndo($"Paste drag point {controlId}");
+				PrepareUndo($"Paste Drag Point {controlId}");
 				dp.Center = _storedControlPoint.ToVertex3D();
 				RebuildMeshes();
 			}
@@ -150,7 +150,9 @@ namespace VisualPinball.Unity.Editor
 
 			PrepareUndo($"Flip-{flipAxis} Drag Points");
 			DragPointsHandler.FlipDragPoints(flipAxis);
-			DragPointsHandler.ReverseDragPoints();
+			if (_dragPointsInspector.PointsAreLooping) {
+				DragPointsHandler.ReverseDragPoints(); // keep counter-clockwise orientation
+			}
 			RebuildMeshes();
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsSceneViewHandler.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsSceneViewHandler.cs
@@ -83,10 +83,11 @@ namespace VisualPinball.Unity.Editor
 				Profiler.BeginSample("Transform Points");
 				var dragPointsVpx = new DragPointData[_handler.ControlPoints.Count];
 				for (var i = 0; i < _handler.ControlPoints.Count; i++) {
+					var pos = _handler.ControlPoints[i].AbsolutePosition.ToVertex3D();
 					dragPointsVpx[i] = new DragPointData(_handler.ControlPoints[i].DragPoint) {
-						Center = _handler.ControlPoints[i].AbsolutePosition.ToVertex3D()
+						Center = new Vertex3D(pos.X, pos.Y, _handler.DragPointInspector.ZOffset),
+						Id = _handler.ControlPoints[i].DragPoint.Id
 					};
-					Handles.DrawWireCube(dragPointsVpx[i].Center.ToUnityVector3().TranslateToWorld(), Vector3.one * 0.01f);
 				}
 				Profiler.EndSample();
 			
@@ -108,12 +109,12 @@ namespace VisualPinball.Unity.Editor
 					// Fill Control points paths
 					ControlPoint currentControlPoint = null;
 					foreach (var curveVertex in curveVerticesVpx) {
-//						Handles.DrawWireCube(curveVertex.ToUnityVector3().TranslateToWorld(), Vector3.one * 0.005f);
 						if (curveVertex.IsControlPoint) {
 							if (currentControlPoint != null) {
 								curveVerticesByDragPoint[currentControlPoint.Index].Add(curveVertex.ToUnityVector3());
 							}
-							currentControlPoint = _handler.ControlPoints.Find(cp => cp.AbsolutePosition == curveVertex.ToUnityVector3());
+
+							currentControlPoint = _handler.GetControlPoint(curveVertex.Id);
 						}
 						if (currentControlPoint != null) {
 							curveVerticesByDragPoint[currentControlPoint.Index].Add(curveVertex.ToUnityVector3());
@@ -232,11 +233,11 @@ namespace VisualPinball.Unity.Editor
 						? Color.green
 						: Color.gray;
 
-				var pos = controlPoint.Position;
+				var pos = controlPoint.EditorPositionWorld;
 				var handleSize = controlPoint.HandleSize;
 				Handles.SphereHandleCap(-1, pos, Quaternion.identity, handleSize, EventType.Repaint);
 				Handles.Label(pos - (Vector3.right * handleSize - Vector3.forward * handleSize * 2f) * 0.1f, $"{i}", style);
-				var dist = Vector3.Distance(_handler.CurveTravellerPosition, controlPoint.Position);
+				var dist = Vector3.Distance(_handler.CurveTravellerPosition, controlPoint.EditorPositionWorld);
 				distToCPoint = Mathf.Min(distToCPoint, dist);
 			}
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsSceneViewHandler.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsSceneViewHandler.cs
@@ -85,7 +85,7 @@ namespace VisualPinball.Unity.Editor
 				for (var i = 0; i < _handler.ControlPoints.Count; i++) {
 					var pos = _handler.ControlPoints[i].AbsolutePosition.ToVertex3D();
 					dragPointsVpx[i] = new DragPointData(_handler.ControlPoints[i].DragPoint) {
-						Center = new Vertex3D(pos.X, pos.Y, _handler.DragPointInspector.ZOffset),
+						Center = new Vertex3D(pos.X, pos.Y, pos.Z + _handler.DragPointInspector.ZOffset),
 						Id = _handler.ControlPoints[i].DragPoint.Id
 					};
 				}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/IDragPointsInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/IDragPointsInspector.cs
@@ -62,17 +62,14 @@ namespace VisualPinball.Unity
 		bool DragPointsActive { get; }
 
 		/// <summary>
-		/// Returns the global offset applied on all drag points.
-		/// </summary>
-		Vector3 EditableOffset { get; }
-
-		/// <summary>
-		/// Returns the height offset regarding a given position along the curve.
+		/// Returns the base height regarding a given position along the curve.
 		/// </summary>
 		/// <param name="ratio">Position on the curve, from 0.0 to 1.0.</param>
-		/// <returns></returns>
-		Vector3 GetDragPointOffset(float ratio);
+		/// <returns>Height of the curve at given position.</returns>
+		Vector3 GetDragPointBaseHeight(float ratio);
 
+		Dictionary<string, float> GetDragPointBaseHeight(ISet<string> ids, float diffX, float diffY);
+		
 		/// <summary>
 		/// Returns whether the drag points are looping or not.
 		/// </summary>

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/IDragPointsInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/IDragPointsInspector.cs
@@ -82,5 +82,16 @@ namespace VisualPinball.Unity
 		/// The global z-offset of all drag points, to render properly in editor.
 		/// </summary>
 		float ZOffset { get; }
+
+		float[] TopBottomZ { get; }
+
+		/// <summary>
+		/// Sets the drag point position
+		/// </summary>
+		/// <param name="dragPoint">Drag point to which the new position is applied to</param>
+		/// <param name="value">The new value, where Z is the z-offset for ramps (and irrelevant for other items)</param>
+		/// <param name="numSelectedDragPoints">How many other drag points are selected</param>
+		/// <param name="topBottomZ">Only used for ramps, so top and bottom height can be adapted instead of the drag point's z.</param>
+		void SetDragPointPosition(DragPointData dragPoint, Vertex3D value, int numSelectedDragPoints = 1, float[] topBottomZ = null);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/IDragPointsInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/IDragPointsInspector.cs
@@ -15,7 +15,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System.Collections.Generic;
-using UnityEngine;
 using VisualPinball.Engine.Math;
 using VisualPinball.Unity.Editor;
 
@@ -61,15 +60,6 @@ namespace VisualPinball.Unity
 		/// </summary>
 		bool DragPointsActive { get; }
 
-		/// <summary>
-		/// Returns the base height regarding a given position along the curve.
-		/// </summary>
-		/// <param name="ratio">Position on the curve, from 0.0 to 1.0.</param>
-		/// <returns>Height of the curve at given position.</returns>
-		Vector3 GetDragPointBaseHeight(float ratio);
-
-		Dictionary<string, float> GetDragPointBaseHeight(ISet<string> ids, float diffX, float diffY);
-		
 		/// <summary>
 		/// Returns whether the drag points are looping or not.
 		/// </summary>

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/IDragPointsInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/IDragPointsInspector.cs
@@ -77,5 +77,10 @@ namespace VisualPinball.Unity
 		ItemDataTransformType HandleType { get; }
 
 		DragPointsInspectorHelper DragPointsHelper { get; }
+		
+		/// <summary>
+		/// The global z-offset of all drag points, to render properly in editor.
+		/// </summary>
+		float ZOffset { get; }
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Utils/HandlesUtils.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Utils/HandlesUtils.cs
@@ -27,47 +27,45 @@ namespace VisualPinball.Unity.Editor
 		/// <param name="playfield">Reference to parent playfield</param>
 		/// <param name="position">Original position in VPX space</param>
 		/// <param name="type">Allowed position type</param>
+		/// <param name="handleSize"></param>
+		/// <param name="snap"></param>
 		/// <returns>Moved position in VPX space.</returns>
-		public static Vector3 HandlePosition(PlayfieldComponent playfield, Vector3 position, ItemDataTransformType type)
+		public static Vector3 HandlePosition(PlayfieldComponent playfield, Vector3 position, ItemDataTransformType type, float handleSize = 0.2f, float snap = 0.0f)
 		{
-			return HandlePosition(playfield, position, type, 0.2f, 0.0f);
-		}
-
-		private static Vector3 HandlePosition(PlayfieldComponent playfield, Vector3 position, ItemDataTransformType type, float handleSize, float snap)
-		{
-			var forward = Vector3.forward.TranslateToWorld();
-			var right = Vector3.right.TranslateToWorld();
-			var up = Vector3.up.TranslateToWorld();
-			var newPos = position.TranslateToWorld();
+			var pos = position.TranslateToWorld();
 			Handles.matrix = playfield == null ? Matrix4x4.identity : playfield.transform.localToWorldMatrix;
 			
 			switch (type) {
 				case ItemDataTransformType.TwoD: {
 
+					var forward = Vector3.forward.TranslateToWorld().normalized;
+					var right = Vector3.right.TranslateToWorld().normalized;
+					var up = Vector3.up.TranslateToWorld().normalized;
+
 					Handles.color = Handles.xAxisColor;
-					newPos = Handles.Slider(newPos, right);
+					pos = Handles.Slider(pos, right);
 
 					Handles.color = Handles.yAxisColor;
-					newPos = Handles.Slider(newPos, up);
+					pos = Handles.Slider(pos, up);
 
 					Handles.color = Handles.zAxisColor;
-					newPos = Handles.Slider2D(
-						newPos,
+					pos = Handles.Slider2D(
+						pos,
 						forward,
 						right,
 						up,
-						HandleUtility.GetHandleSize(newPos) * handleSize,
+						HandleUtility.GetHandleSize(pos) * handleSize,
 						Handles.RectangleHandleCap,
 						snap);
 					break;
 				}
 
 				case ItemDataTransformType.ThreeD: {
-					newPos = Handles.PositionHandle(newPos, Quaternion.identity.RotateToWorld());
+					pos = Handles.PositionHandle(pos, Quaternion.identity.RotateToWorld());
 					break;
 				}
 			}
-			return newPos.TranslateToVpx();
+			return pos.TranslateToVpx();
 		}
 
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Light/LightInsertMeshInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Light/LightInsertMeshInspector.cs
@@ -17,7 +17,6 @@
 // ReSharper disable AssignmentInConditionalExpression
 
 using System.Collections.Generic;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -80,8 +79,6 @@ namespace VisualPinball.Unity.Editor
 
 		public DragPointData[] DragPoints { get => MeshComponent.DragPoints; set => MeshComponent.DragPoints = value; }
 		public Vector3 EditableOffset => new Vector3(-MeshComponent.MainComponent.transform.localPosition.x, -MeshComponent.MainComponent.transform.localPosition.y, MeshComponent.PositionZ);
-		public Vector3 GetDragPointBaseHeight(float ratio) => Vector3.zero;
-		public Dictionary<string, float> GetDragPointBaseHeight(ISet<string> ids, float diffX, float diffY) => DragPoints.Select(dp => dp.AssertId()).ToDictionary(dp => dp.Id, dp => dp.CalcHeight);
 
 		public bool PointsAreLooping => true;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.Texture };

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Light/LightInsertMeshInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Light/LightInsertMeshInspector.cs
@@ -17,6 +17,7 @@
 // ReSharper disable AssignmentInConditionalExpression
 
 using System.Collections.Generic;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -79,7 +80,9 @@ namespace VisualPinball.Unity.Editor
 
 		public DragPointData[] DragPoints { get => MeshComponent.DragPoints; set => MeshComponent.DragPoints = value; }
 		public Vector3 EditableOffset => new Vector3(-MeshComponent.MainComponent.transform.localPosition.x, -MeshComponent.MainComponent.transform.localPosition.y, MeshComponent.PositionZ);
-		public Vector3 GetDragPointOffset(float ratio) => Vector3.zero;
+		public Vector3 GetDragPointBaseHeight(float ratio) => Vector3.zero;
+		public Dictionary<string, float> GetDragPointBaseHeight(ISet<string> ids, float diffX, float diffY) => DragPoints.Select(dp => dp.AssertId()).ToDictionary(dp => dp.Id, dp => dp.CalcHeight);
+
 		public bool PointsAreLooping => true;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.Texture };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Light/LightInsertMeshInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Light/LightInsertMeshInspector.cs
@@ -78,13 +78,12 @@ namespace VisualPinball.Unity.Editor
 		#region Dragpoint Tooling
 
 		public DragPointData[] DragPoints { get => MeshComponent.DragPoints; set => MeshComponent.DragPoints = value; }
-		public Vector3 EditableOffset => new Vector3(-MeshComponent.MainComponent.transform.localPosition.x, -MeshComponent.MainComponent.transform.localPosition.y, MeshComponent.PositionZ);
 
 		public bool PointsAreLooping => true;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.Texture };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
-		public float ZOffset => 0f;
+		public float ZOffset => MeshComponent.PositionZ;
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Light/LightInsertMeshInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Light/LightInsertMeshInspector.cs
@@ -84,6 +84,7 @@ namespace VisualPinball.Unity.Editor
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.Texture };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
+		public float ZOffset => 0f;
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Light/LightInsertMeshInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Light/LightInsertMeshInspector.cs
@@ -84,6 +84,9 @@ namespace VisualPinball.Unity.Editor
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
 		public float ZOffset => MeshComponent.PositionZ;
+		public float[] TopBottomZ => null;
+		public void SetDragPointPosition(DragPointData dragPoint, Vertex3D value, int numSelectedDragPoints,
+			float[] topBottomZ) => dragPoint.Center = value;
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/MetalWireGuide/MetalWireGuideInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/MetalWireGuide/MetalWireGuideInspector.cs
@@ -92,6 +92,7 @@ namespace VisualPinball.Unity.Editor
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
+		public float ZOffset => 0f;
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/MetalWireGuide/MetalWireGuideInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/MetalWireGuide/MetalWireGuideInspector.cs
@@ -17,6 +17,7 @@
 // ReSharper disable AssignmentInConditionalExpression
 
 using System.Collections.Generic;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -88,11 +89,12 @@ namespace VisualPinball.Unity.Editor
 		public bool DragPointsActive => true;
 		public DragPointData[] DragPoints { get => MainComponent.DragPoints; set => MainComponent.DragPoints = value; }
 		public Vector3 EditableOffset => new Vector3(0.0f, 0.0f, MainComponent._height);
-		public Vector3 GetDragPointOffset(float ratio) => Vector3.zero;
+		public Vector3 GetDragPointBaseHeight(float ratio) => Vector3.zero;
 		public bool PointsAreLooping => false;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
+		public Dictionary<string, float> GetDragPointBaseHeight(ISet<string> ids, float diffX, float diffY) => DragPoints.Select(dp => dp.AssertId()).ToDictionary(dp => dp.Id, dp => dp.CalcHeight);
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/MetalWireGuide/MetalWireGuideInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/MetalWireGuide/MetalWireGuideInspector.cs
@@ -87,7 +87,6 @@ namespace VisualPinball.Unity.Editor
 
 		public bool DragPointsActive => true;
 		public DragPointData[] DragPoints { get => MainComponent.DragPoints; set => MainComponent.DragPoints = value; }
-		public Vector3 EditableOffset => new Vector3(0.0f, 0.0f, MainComponent._height);
 		public bool PointsAreLooping => false;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/MetalWireGuide/MetalWireGuideInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/MetalWireGuide/MetalWireGuideInspector.cs
@@ -92,7 +92,10 @@ namespace VisualPinball.Unity.Editor
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
 		public float ZOffset => 0f;
-
+		public float[] TopBottomZ => null;
+		public void SetDragPointPosition(DragPointData dragPoint, Vertex3D value, int numSelectedDragPoints,
+			float[] topBottomZ) => dragPoint.Center = value;
+		
 		#endregion
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/MetalWireGuide/MetalWireGuideInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/MetalWireGuide/MetalWireGuideInspector.cs
@@ -17,7 +17,6 @@
 // ReSharper disable AssignmentInConditionalExpression
 
 using System.Collections.Generic;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -89,12 +88,10 @@ namespace VisualPinball.Unity.Editor
 		public bool DragPointsActive => true;
 		public DragPointData[] DragPoints { get => MainComponent.DragPoints; set => MainComponent.DragPoints = value; }
 		public Vector3 EditableOffset => new Vector3(0.0f, 0.0f, MainComponent._height);
-		public Vector3 GetDragPointBaseHeight(float ratio) => Vector3.zero;
 		public bool PointsAreLooping => false;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
-		public Dictionary<string, float> GetDragPointBaseHeight(ISet<string> ids, float diffX, float diffY) => DragPoints.Select(dp => dp.AssertId()).ToDictionary(dp => dp.Id, dp => dp.CalcHeight);
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Ramp/RampInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Ramp/RampInspector.cs
@@ -17,6 +17,7 @@
 // ReSharper disable AssignmentInConditionalExpression
 
 using System.Collections.Generic;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -152,11 +153,28 @@ namespace VisualPinball.Unity.Editor
 		public bool DragPointsActive => true;
 		public DragPointData[] DragPoints { get => MainComponent.DragPoints; set => MainComponent.DragPoints = value; }
 		public Vector3 EditableOffset => Vector3.zero;
-		public Vector3 GetDragPointOffset(float ratio) => new Vector3(0.0f, 0.0f, (MainComponent.HeightTop - MainComponent.HeightBottom) * ratio);
+		public Vector3 GetDragPointBaseHeight(float ratio) => new Vector3(0.0f, 0.0f, (MainComponent.HeightTop - MainComponent.HeightBottom) * ratio);
 		public bool PointsAreLooping => false;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.SlingShot };
 		public ItemDataTransformType HandleType => ItemDataTransformType.ThreeD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
+		public Dictionary<string, float> GetDragPointBaseHeight(ISet<string> ids, float diffX, float diffY)
+		{
+			var dragPoints = MainComponent.DragPoints.Select(dp => dp.AssertId().CloneWithId()).ToArray();
+			foreach (var dp in dragPoints.Where(dp => ids.Contains(dp.Id))) {
+				dp.Move(diffX, diffY);
+			}
+			var rampClone = new RampData {
+				DragPoints = dragPoints,
+				RampType = MainComponent.Type,
+				HeightTop = MainComponent.HeightTop,
+				HeightBottom = MainComponent.HeightBottom,
+				WidthTop = MainComponent.WidthTop,
+				WidthBottom = MainComponent.WidthBottom
+			};
+			new RampMeshGenerator(rampClone).GetRampVertex(0, -1, true);
+			return rampClone.DragPoints.ToDictionary(dp => dp.Id, dp => dp.CalcHeight);
+		}
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Ramp/RampInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Ramp/RampInspector.cs
@@ -151,7 +151,6 @@ namespace VisualPinball.Unity.Editor
 
 		public bool DragPointsActive => true;
 		public DragPointData[] DragPoints { get => MainComponent.DragPoints; set => MainComponent.DragPoints = value; }
-		public Vector3 EditableOffset => Vector3.zero;
 		public bool PointsAreLooping => false;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.SlingShot };
 		public ItemDataTransformType HandleType => ItemDataTransformType.ThreeD;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Ramp/RampInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Ramp/RampInspector.cs
@@ -17,7 +17,6 @@
 // ReSharper disable AssignmentInConditionalExpression
 
 using System.Collections.Generic;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -153,28 +152,10 @@ namespace VisualPinball.Unity.Editor
 		public bool DragPointsActive => true;
 		public DragPointData[] DragPoints { get => MainComponent.DragPoints; set => MainComponent.DragPoints = value; }
 		public Vector3 EditableOffset => Vector3.zero;
-		public Vector3 GetDragPointBaseHeight(float ratio) => new Vector3(0.0f, 0.0f, (MainComponent.HeightTop - MainComponent.HeightBottom) * ratio);
 		public bool PointsAreLooping => false;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.SlingShot };
 		public ItemDataTransformType HandleType => ItemDataTransformType.ThreeD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
-		public Dictionary<string, float> GetDragPointBaseHeight(ISet<string> ids, float diffX, float diffY)
-		{
-			var dragPoints = MainComponent.DragPoints.Select(dp => dp.AssertId().CloneWithId()).ToArray();
-			foreach (var dp in dragPoints.Where(dp => ids.Contains(dp.Id))) {
-				dp.Move(diffX, diffY);
-			}
-			var rampClone = new RampData {
-				DragPoints = dragPoints,
-				RampType = MainComponent.Type,
-				HeightTop = MainComponent.HeightTop,
-				HeightBottom = MainComponent.HeightBottom,
-				WidthTop = MainComponent.WidthTop,
-				WidthBottom = MainComponent.WidthBottom
-			};
-			new RampMeshGenerator(rampClone).GetRampVertex(0, -1, true);
-			return rampClone.DragPoints.ToDictionary(dp => dp.Id, dp => dp.CalcHeight);
-		}
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Ramp/RampInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Ramp/RampInspector.cs
@@ -156,6 +156,28 @@ namespace VisualPinball.Unity.Editor
 		public ItemDataTransformType HandleType => ItemDataTransformType.ThreeD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
 		public float ZOffset => 0f;
+		public float[] TopBottomZ => new[] { MainComponent._heightBottom, MainComponent._heightTop };
+
+		public void SetDragPointPosition(DragPointData dragPoint, Vertex3D value, int numSelectedDragPoints, float[] topBottomZ)
+		{
+			var isFirst = MainComponent.DragPoints[0].Id == dragPoint.Id;
+			var isLast = MainComponent.DragPoints[^1].Id == dragPoint.Id;
+			var zDiff = value.Z - dragPoint.Center.Z;
+			
+			if (isFirst && numSelectedDragPoints == 1) {
+				MainComponent._heightBottom = topBottomZ[0] + zDiff;
+				dragPoint.Center.X = value.X;
+				dragPoint.Center.Y = value.Y;
+
+			} else if (isLast && numSelectedDragPoints == 1) {
+				MainComponent._heightTop = topBottomZ[1] + zDiff;
+				dragPoint.Center.X = value.X;
+				dragPoint.Center.Y = value.Y;
+				
+			} else {
+				dragPoint.Center = value;
+			}
+		}
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Ramp/RampInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Ramp/RampInspector.cs
@@ -156,6 +156,7 @@ namespace VisualPinball.Unity.Editor
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.SlingShot };
 		public ItemDataTransformType HandleType => ItemDataTransformType.ThreeD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
+		public float ZOffset => 0f;
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Rubber/RubberInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Rubber/RubberInspector.cs
@@ -17,6 +17,7 @@
 // ReSharper disable AssignmentInConditionalExpression
 
 using System.Collections.Generic;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -82,11 +83,12 @@ namespace VisualPinball.Unity.Editor
 		public bool DragPointsActive => true;
 		public DragPointData[] DragPoints { get => MainComponent.DragPoints; set => MainComponent.DragPoints = value; }
 		public Vector3 EditableOffset => new Vector3(0.0f, 0.0f, MainComponent._height);
-		public Vector3 GetDragPointOffset(float ratio) => Vector3.zero;
+		public Vector3 GetDragPointBaseHeight(float ratio) => Vector3.zero;
 		public bool PointsAreLooping => true;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
+		public Dictionary<string, float> GetDragPointBaseHeight(ISet<string> ids, float diffX, float diffY) => DragPoints.Select(dp => dp.AssertId()).ToDictionary(dp => dp.Id, dp => dp.CalcHeight);
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Rubber/RubberInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Rubber/RubberInspector.cs
@@ -17,7 +17,6 @@
 // ReSharper disable AssignmentInConditionalExpression
 
 using System.Collections.Generic;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -83,12 +82,10 @@ namespace VisualPinball.Unity.Editor
 		public bool DragPointsActive => true;
 		public DragPointData[] DragPoints { get => MainComponent.DragPoints; set => MainComponent.DragPoints = value; }
 		public Vector3 EditableOffset => new Vector3(0.0f, 0.0f, MainComponent._height);
-		public Vector3 GetDragPointBaseHeight(float ratio) => Vector3.zero;
 		public bool PointsAreLooping => true;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
-		public Dictionary<string, float> GetDragPointBaseHeight(ISet<string> ids, float diffX, float diffY) => DragPoints.Select(dp => dp.AssertId()).ToDictionary(dp => dp.Id, dp => dp.CalcHeight);
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Rubber/RubberInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Rubber/RubberInspector.cs
@@ -86,6 +86,7 @@ namespace VisualPinball.Unity.Editor
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
+		public float ZOffset => MainComponent.Height;
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Rubber/RubberInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Rubber/RubberInspector.cs
@@ -86,6 +86,9 @@ namespace VisualPinball.Unity.Editor
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
 		public float ZOffset => MainComponent.Height;
+		public float[] TopBottomZ => null;
+		public void SetDragPointPosition(DragPointData dragPoint, Vertex3D value, int numSelectedDragPoints,
+			float[] topBottomZ) => dragPoint.Center = value;
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Rubber/RubberInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Rubber/RubberInspector.cs
@@ -81,7 +81,6 @@ namespace VisualPinball.Unity.Editor
 
 		public bool DragPointsActive => true;
 		public DragPointData[] DragPoints { get => MainComponent.DragPoints; set => MainComponent.DragPoints = value; }
-		public Vector3 EditableOffset => new Vector3(0.0f, 0.0f, MainComponent._height);
 		public bool PointsAreLooping => true;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Surface/SurfaceInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Surface/SurfaceInspector.cs
@@ -85,6 +85,9 @@ namespace VisualPinball.Unity.Editor
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
 		public float ZOffset => MainComponent.HeightTop + MainComponent.PlayfieldHeight;
+		public float[] TopBottomZ => null;
+		public void SetDragPointPosition(DragPointData dragPoint, Vertex3D value, int numSelectedDragPoints,
+			float[] topBottomZ) => dragPoint.Center = value;
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Surface/SurfaceInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Surface/SurfaceInspector.cs
@@ -85,6 +85,7 @@ namespace VisualPinball.Unity.Editor
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.SlingShot, DragPointExposure.Texture };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
+		public float ZOffset => MainComponent.HeightTop;
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Surface/SurfaceInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Surface/SurfaceInspector.cs
@@ -80,12 +80,11 @@ namespace VisualPinball.Unity.Editor
 		#region Dragpoint Tooling
 
 		public DragPointData[] DragPoints { get => MainComponent.DragPoints; set => MainComponent.DragPoints = value; }
-		public Vector3 EditableOffset => new Vector3(0.0f, 0.0f, MainComponent.HeightTop + MainComponent.PlayfieldHeight);
 		public bool PointsAreLooping => true;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.SlingShot, DragPointExposure.Texture };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
-		public float ZOffset => MainComponent.HeightTop;
+		public float ZOffset => MainComponent.HeightTop + MainComponent.PlayfieldHeight;
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Surface/SurfaceInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Surface/SurfaceInspector.cs
@@ -17,6 +17,7 @@
 // ReSharper disable AssignmentInConditionalExpression
 
 using System.Collections.Generic;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -81,11 +82,12 @@ namespace VisualPinball.Unity.Editor
 
 		public DragPointData[] DragPoints { get => MainComponent.DragPoints; set => MainComponent.DragPoints = value; }
 		public Vector3 EditableOffset => new Vector3(0.0f, 0.0f, MainComponent.HeightTop + MainComponent.PlayfieldHeight);
-		public Vector3 GetDragPointOffset(float ratio) => Vector3.zero;
+		public Vector3 GetDragPointBaseHeight(float ratio) => Vector3.zero;
 		public bool PointsAreLooping => true;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.SlingShot, DragPointExposure.Texture };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
+		public Dictionary<string, float> GetDragPointBaseHeight(ISet<string> ids, float diffX, float diffY) => DragPoints.Select(dp => dp.AssertId()).ToDictionary(dp => dp.Id, dp => dp.CalcHeight);
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Surface/SurfaceInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Surface/SurfaceInspector.cs
@@ -17,7 +17,6 @@
 // ReSharper disable AssignmentInConditionalExpression
 
 using System.Collections.Generic;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -82,12 +81,10 @@ namespace VisualPinball.Unity.Editor
 
 		public DragPointData[] DragPoints { get => MainComponent.DragPoints; set => MainComponent.DragPoints = value; }
 		public Vector3 EditableOffset => new Vector3(0.0f, 0.0f, MainComponent.HeightTop + MainComponent.PlayfieldHeight);
-		public Vector3 GetDragPointBaseHeight(float ratio) => Vector3.zero;
 		public bool PointsAreLooping => true;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.SlingShot, DragPointExposure.Texture };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
-		public Dictionary<string, float> GetDragPointBaseHeight(ISet<string> ids, float diffX, float diffY) => DragPoints.Select(dp => dp.AssertId()).ToDictionary(dp => dp.Id, dp => dp.CalcHeight);
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Trigger/TriggerInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Trigger/TriggerInspector.cs
@@ -94,6 +94,9 @@ namespace VisualPinball.Unity.Editor
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
 		public float ZOffset => MainComponent.PositionZ;
+		public float[] TopBottomZ => null;
+		public void SetDragPointPosition(DragPointData dragPoint, Vertex3D value, int numSelectedDragPoints,
+			float[] topBottomZ) => dragPoint.Center = value;
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Trigger/TriggerInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Trigger/TriggerInspector.cs
@@ -89,7 +89,6 @@ namespace VisualPinball.Unity.Editor
 		}
 
 		public DragPointData[] DragPoints { get => MainComponent.DragPoints; set => MainComponent.DragPoints = value; }
-		public Vector3 EditableOffset => Vector3.zero;
 		public bool PointsAreLooping => true;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.SlingShot };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Trigger/TriggerInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Trigger/TriggerInspector.cs
@@ -94,7 +94,7 @@ namespace VisualPinball.Unity.Editor
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.SlingShot };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
-		public float ZOffset => 0f;
+		public float ZOffset => MainComponent.PositionZ;
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Trigger/TriggerInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Trigger/TriggerInspector.cs
@@ -17,7 +17,6 @@
 // ReSharper disable AssignmentInConditionalExpression
 
 using System.Collections.Generic;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -91,12 +90,10 @@ namespace VisualPinball.Unity.Editor
 
 		public DragPointData[] DragPoints { get => MainComponent.DragPoints; set => MainComponent.DragPoints = value; }
 		public Vector3 EditableOffset => Vector3.zero;
-		public Vector3 GetDragPointBaseHeight(float ratio) => Vector3.zero;
 		public bool PointsAreLooping => true;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.SlingShot };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
-		public Dictionary<string, float> GetDragPointBaseHeight(ISet<string> ids, float diffX, float diffY) => DragPoints.Select(dp => dp.AssertId()).ToDictionary(dp => dp.Id, dp => dp.CalcHeight);
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Trigger/TriggerInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Trigger/TriggerInspector.cs
@@ -94,6 +94,7 @@ namespace VisualPinball.Unity.Editor
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.SlingShot };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
+		public float ZOffset => 0f;
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Trigger/TriggerInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Trigger/TriggerInspector.cs
@@ -17,6 +17,7 @@
 // ReSharper disable AssignmentInConditionalExpression
 
 using System.Collections.Generic;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VisualPinball.Engine.Math;
@@ -90,11 +91,12 @@ namespace VisualPinball.Unity.Editor
 
 		public DragPointData[] DragPoints { get => MainComponent.DragPoints; set => MainComponent.DragPoints = value; }
 		public Vector3 EditableOffset => Vector3.zero;
-		public Vector3 GetDragPointOffset(float ratio) => Vector3.zero;
+		public Vector3 GetDragPointBaseHeight(float ratio) => Vector3.zero;
 		public bool PointsAreLooping => true;
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth, DragPointExposure.SlingShot };
 		public ItemDataTransformType HandleType => ItemDataTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
+		public Dictionary<string, float> GetDragPointBaseHeight(ISet<string> ids, float diffX, float diffY) => DragPoints.Select(dp => dp.AssertId()).ToDictionary(dp => dp.Id, dp => dp.CalcHeight);
 
 		#endregion
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity/Extensions/MathExtensions.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Extensions/MathExtensions.cs
@@ -73,6 +73,11 @@ namespace VisualPinball.Unity
 			return new Vector3(vertex.X, vertex.Y, vertex.Z);
 		}
 
+		public static Vector3 ToUnityVector2(this Vertex3D vertex)
+		{
+			return new Vector2(vertex.X, vertex.Y);
+		}
+
 		public static Vector3 ToUnityVector3(this RenderVertex3D vertex)
 		{
 			return new Vector3(vertex.X, vertex.Y, vertex.Z);

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/WirePlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/WirePlayer.cs
@@ -364,7 +364,7 @@ namespace VisualPinball.Unity
 				return;
 			}
 			foreach (var wireConfig in _gleDestAssignments[id]) {
-				if (!_wireDevices.ContainsKey(wireConfig.Device)) {
+				if (wireConfig.Device == null || !_wireDevices.ContainsKey(wireConfig.Device)) {
 					continue;
 				}
 				var now = Time.realtimeSinceStartup;


### PR DESCRIPTION
This PR changes how drag points are handled in the editor. This mainly applies to ramps, since they are the only drag-point enabled item where each drag point has an individual height (Z offset).

Before, when a ramp drag point was moved along the XY plane, it would stay on that plane and update the Z-offset accordingly. This is not how VPX behaves (it only updates the XY values and keeping the offset constant, moving it along the Z-curve of the ramp). 

The VPX behavior makes more sense, because the Z-offset is typically only updated once the XY values are correct. In contrast, adding a new drag point would set the absolute height when later moving it in the XY plane, which is less desirable.

https://user-images.githubusercontent.com/70426/230793632-db520f07-7065-4f90-a014-7061771f0378.mp4

TODO:

- [x] Make the drag point positions in the inspector editable
- [x] Fix Undo when moving drag points
- [x] Test functions (flip, etc)
- [x] Modify ramp bottom/top height when changing z-height on start and end drag points.