### PR TITLE
Add serialized subclasses

### DIFF
--- a/VisualPinball.Engine/Game/Engines/GamelogicEngineCoil.cs
+++ b/VisualPinball.Engine/Game/Engines/GamelogicEngineCoil.cs
@@ -36,11 +36,11 @@ namespace VisualPinball.Engine.Game.Engines
 		/// </summary>
 		public bool IsUnused;
 
-		private string _description;
-		private string _id;
-		private string _deviceHint;
-		private string _deviceItemHint;
-		private int _numMatches = 1;
+		protected string _description;
+		protected string _id;
+		protected string _deviceHint;
+		protected string _deviceItemHint;
+		protected int _numMatches = 1;
 
 		public GamelogicEngineCoil(string id)
 		{

--- a/VisualPinball.Engine/Game/Engines/GamelogicEngineLamp.cs
+++ b/VisualPinball.Engine/Game/Engines/GamelogicEngineLamp.cs
@@ -70,11 +70,11 @@ namespace VisualPinball.Engine.Game.Engines
 
 		public int NumMatches { get => _numMatches; set => _numMatches = value; }
 
-		private string _description;
-		private string _id;
-		private string _deviceHint;
-		private string _deviceItemHint;
-		private int _numMatches = 1;
+		protected string _description;
+		protected string _id;
+		protected string _deviceHint;
+		protected string _deviceItemHint;
+		protected int _numMatches = 1;
 
 		public GamelogicEngineLamp(string id)
 		{

--- a/VisualPinball.Engine/Game/Engines/GamelogicEngineSwitch.cs
+++ b/VisualPinball.Engine/Game/Engines/GamelogicEngineSwitch.cs
@@ -61,11 +61,11 @@ namespace VisualPinball.Engine.Game.Engines
 		public int NumMatches { get => _numMatches; set => _numMatches = value; }
 		public SwitchConstantHint ConstantHint = SwitchConstantHint.None;
 
-		private string _description;
-		private string _id;
-		private string _deviceHint;
-		private string _deviceItemHint;
-		private int _numMatches = 1;
+		protected string _description;
+		protected string _id;
+		protected string _deviceHint;
+		protected string _deviceItemHint;
+		protected int _numMatches = 1;
 
 		public GamelogicEngineSwitch(string id)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/SerializedGamelogicEngineCoil.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/SerializedGamelogicEngineCoil.cs
@@ -1,0 +1,55 @@
+﻿// Visual Pinball Engine
+// Copyright (C) 2023 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// ReSharper disable InconsistentNaming
+
+using System;
+using UnityEngine;
+using VisualPinball.Engine.Game.Engines;
+
+namespace VisualPinball.Unity
+{
+	[Serializable]
+	public class SerializedGamelogicEngineCoil : GamelogicEngineCoil, ISerializationCallbackReceiver
+	{
+		public SerializedGamelogicEngineCoil(string id) : base(id) { }
+		public SerializedGamelogicEngineCoil(int id) : base(id) { }
+
+		[SerializeField] private string _serializedDescription;
+		[SerializeField] private string _serializedId;
+		[SerializeField] private string _serializedDeviceHint;
+		[SerializeField] private string _serializedDeviceItemHint;
+		[SerializeField] private int _serializedNumMatches = 1;
+
+		public void OnBeforeSerialize()
+		{
+			_serializedDescription = _description;
+			_serializedId = _id;
+			_serializedDeviceHint = _deviceHint;
+			_serializedDeviceItemHint = _deviceItemHint;
+			_serializedNumMatches = _numMatches;
+		}
+
+		public void OnAfterDeserialize()
+		{
+			_description = _serializedDescription;
+			_id = _serializedId;
+			_deviceHint = _serializedDeviceHint;
+			_deviceItemHint = _serializedDeviceItemHint;
+			_numMatches = _serializedNumMatches;			
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/SerializedGamelogicEngineCoil.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/SerializedGamelogicEngineCoil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 379cb814f2063284ea0725442e281d71
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/SerializedGamelogicEngineLamp.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/SerializedGamelogicEngineLamp.cs
@@ -1,0 +1,55 @@
+// Visual Pinball Engine
+// Copyright (C) 2023 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// ReSharper disable InconsistentNaming
+
+using System;
+using UnityEngine;
+using VisualPinball.Engine.Game.Engines;
+
+namespace VisualPinball.Unity
+{
+    [Serializable]
+    public class SerializedGamelogicEngineLamp : GamelogicEngineLamp, ISerializationCallbackReceiver
+    {
+        public SerializedGamelogicEngineLamp(string id) : base(id) { }
+        public SerializedGamelogicEngineLamp(int id) : base(id) { }
+
+        [SerializeField] private string _serializedDescription;
+        [SerializeField] private string _serializedId;
+        [SerializeField] private string _serializedDeviceHint;
+        [SerializeField] private string _serializedDeviceItemHint;
+        [SerializeField] private int _serializedNumMatches = 1;
+
+        public void OnBeforeSerialize()
+        {
+            _serializedDescription = _description;
+            _serializedId = _id;
+            _serializedDeviceHint = _deviceHint;
+            _serializedDeviceItemHint = _deviceItemHint;
+            _serializedNumMatches = _numMatches;
+        }
+
+        public void OnAfterDeserialize()
+        {
+            _description = _serializedDescription;
+            _id = _serializedId;
+            _deviceHint = _serializedDeviceHint;
+            _deviceItemHint = _serializedDeviceItemHint;
+            _numMatches = _serializedNumMatches;
+        }
+    }
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/SerializedGamelogicEngineLamp.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/SerializedGamelogicEngineLamp.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ebb7ab30f064f2840a5809dc35129c3f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/SerializedGamelogicEngineSwitch.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/SerializedGamelogicEngineSwitch.cs
@@ -1,0 +1,55 @@
+// Visual Pinball Engine
+// Copyright (C) 2023 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// ReSharper disable InconsistentNaming
+
+using System;
+using UnityEngine;
+using VisualPinball.Engine.Game.Engines;
+
+namespace VisualPinball.Unity
+{
+    [Serializable]
+    public class SerializedGamelogicEngineSwitch : GamelogicEngineSwitch, ISerializationCallbackReceiver
+    {
+        public SerializedGamelogicEngineSwitch(string id) : base(id) { }
+        public SerializedGamelogicEngineSwitch(int id) : base(id) { }
+
+        [SerializeField] private string _serializedDescription;
+        [SerializeField] private string _serializedId;
+        [SerializeField] private string _serializedDeviceHint;
+        [SerializeField] private string _serializedDeviceItemHint;
+        [SerializeField] private int _serializedNumMatches = 1;
+
+        public void OnBeforeSerialize()
+        {
+            _serializedDescription = _description;
+            _serializedId = _id;
+            _serializedDeviceHint = _deviceHint;
+            _serializedDeviceItemHint = _deviceItemHint;
+            _serializedNumMatches = _numMatches;
+        }
+
+        public void OnAfterDeserialize()
+        {
+            _description = _serializedDescription;
+            _id = _serializedId;
+            _deviceHint = _serializedDeviceHint;
+            _deviceItemHint = _serializedDeviceItemHint;
+            _numMatches = _serializedNumMatches;
+        }
+    }
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/SerializedGamelogicEngineSwitch.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/SerializedGamelogicEngineSwitch.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b2550960502086439463190e733defa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
[This commit](https://github.com/freezy/VisualPinball.Engine/commit/494bb36e0ed689a7b86db206649bebc55f90eda7) caused `_id` and some other properties of the classes `GameLogicEngineCoil`, `GameLogicEngineSwitch` and `GameLogicEngineLamp` to not be serialized by Unity, which led to [this issue](https://github.com/VisualPinball/VisualPinball.Engine.Mpf/issues/19) in the [VisualPinball.Engine.Mpf repository](https://github.com/VisualPinball/VisualPinball.Engine.Mpf). This pull request adds new subclasses of the classes in question which implement Unity's [ISerializationCallbackReceiver](https://docs.unity3d.com/ScriptReference/ISerializationCallbackReceiver.html) interface to serialize their properties without making them public again and without introducing a dependency on Unity to the core VisualPinball.Engine project. These new classes are used in [this pull request](https://github.com/VisualPinball/VisualPinball.Engine.Mpf/pull/20) to fix the aforementioned issue.