### PR TITLE
Log info instead of warning when adding wire

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/Game/WirePlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/WirePlayer.cs
@@ -178,7 +178,7 @@ namespace VisualPinball.Unity
 				}
 				_gleDestAssignments[destId].Add(wireDest);
 
-				Logger.Warn($"Added dynamic wire \"{wireMapping.Description}\" ({srcId} -> {destId}).");
+				Logger.Info($"Added dynamic wire \"{wireMapping.Description}\" ({srcId} -> {destId}).");
 
 			} else {
 				Logger.Warn($"GLE IDs not found for dynamic wire {wireMapping.Description} ({srcId} -> {destId}).");


### PR DESCRIPTION
Adding a dynamic wire should not cause a warning, or at least I don't see why.