### PR TITLE
Fix null error with code-created input actions

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
@@ -404,7 +404,7 @@ namespace VisualPinball.Unity
 
 		private static void HandleInput(object obj, InputActionChange change)
 		{
-			if (obj is InputAction action && action.actionMap.name == InputConstants.MapDebug) {
+			if (obj is InputAction action && action.actionMap != null && action.actionMap.name == InputConstants.MapDebug) {
 				var value = action.ReadValue<float>();
 				switch (action.name) {
 					case InputConstants.ActionSlowMotion: {


### PR DESCRIPTION
If other code in the Unity project creates input actions that are not part of an action map, a null error is raised every time the associated key binds are pressed by the user.