### PR TITLE
Rewrite bumper hit detection

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/Game/InsideOfs.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/InsideOfs.cs
@@ -44,6 +44,24 @@ namespace VisualPinball.Unity
 		
 		internal bool IsOutsideOf(int itemId, int ballId) => !IsInsideOf(itemId, ballId);
 
+		internal int GetInsideCount(int itemId)
+		{
+			if (!_insideOfs.ContainsKey(itemId)) {
+				return 0;
+			}
+
+			return _insideOfs[itemId].CountBits();
+		}
+
+		internal bool IsEmpty(int itemId)
+		{
+			if (!_insideOfs.ContainsKey(itemId)) {
+				return true;
+			}
+
+			return !_insideOfs[itemId].TestAny(0, 64);
+		}
+
 		private void ClearItems(int itemId)
 		{
 			if (_insideOfs[itemId].GetBits(0, 64) == 0L) {

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngine.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngine.cs
@@ -27,6 +27,7 @@ using VisualPinball.Engine.Common;
 using VisualPinball.Unity.Collections;
 using AABB = NativeTrees.AABB;
 using Debug = UnityEngine.Debug;
+using Random = Unity.Mathematics.Random;
 
 namespace VisualPinball.Unity
 {
@@ -115,6 +116,7 @@ namespace VisualPinball.Unity
 		internal ref TriggerState TriggerState(int itemId) => ref _triggerStates.GetValueByRef(itemId);
 		internal void SetBallInsideOf(int ballId, int itemId) => _insideOfs.SetInsideOf(itemId, ballId);
 		internal uint TimeMsec => _physicsEnv[0].TimeMsec;
+		internal Random Random => _physicsEnv[0].Random;
 		internal void Register<T>(T item) where T : MonoBehaviour
 		{
 			var go = item.gameObject;

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsState.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsState.cs
@@ -151,7 +151,7 @@ namespace VisualPinball.Unity
 			switch (GetColliderType(ref colliders, colliderId)) {
 				case ColliderType.Bumper:
 					return colliders.Circle(colliderId).HitTestBasicRadius(ref newCollEvent, ref InsideOfs, in ball,
-						ball.CollisionEvent.HitTime, false, false, false);
+						ball.CollisionEvent.HitTime, direction:false, lateral:true, rigid:false);
 
 				case ColliderType.Circle:
 					return colliders.Circle(colliderId).HitTest(ref newCollEvent, ref InsideOfs, in ball,

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsState.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsState.cs
@@ -150,6 +150,9 @@ namespace VisualPinball.Unity
 			}
 			switch (GetColliderType(ref colliders, colliderId)) {
 				case ColliderType.Bumper:
+					return colliders.Circle(colliderId).HitTestBasicRadius(ref newCollEvent, ref InsideOfs, in ball,
+						ball.CollisionEvent.HitTime, false, false, false);
+
 				case ColliderType.Circle:
 					return colliders.Circle(colliderId).HitTest(ref newCollEvent, ref InsideOfs, in ball,
 						ball.CollisionEvent.HitTime);

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsStaticCollision.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsStaticCollision.cs
@@ -84,7 +84,7 @@ namespace VisualPinball.Unity
 				case ColliderType.Bumper:
 					ref var bumperState = ref state.GetBumperState(colliderId, ref colliders);
 					BumperCollider.Collide(ref ball, ref state.EventQueue, ref ball.CollisionEvent, ref bumperState.RingAnimation, ref bumperState.SkirtAnimation,
-						in collHeader, in bumperState.Static, ref state.Env.Random);
+						in collHeader, in bumperState.Static, ref state.Env.Random, ref state.InsideOfs);
 					break;
 
 				case ColliderType.Flipper:

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperApi.cs
@@ -75,30 +75,28 @@ namespace VisualPinball.Unity
 			}
 			ref var bumperState = ref PhysicsEngine.BumperState(ItemId);
 			bumperState.RingAnimation.IsHit = true;
-			bumperState.SkirtAnimation.HitEvent = true;
 			ref var insideOfs = ref PhysicsEngine.InsideOfs;
 			List<int> idsOfBallsInColl = insideOfs.GetIdsOfBallsInsideItem(ItemId);
 			foreach (var ballId in idsOfBallsInColl) {
 				if (PhysicsEngine.Balls.ContainsKey(ballId)) {
 					ref var ballState = ref PhysicsEngine.BallState(ballId);
-					bumperState.SkirtAnimation.BallPosition = ballState.Position;
 					float3 bumperPos = new(MainComponent.Position.x, MainComponent.Position.y, MainComponent.PositionZ);
 					float3 ballPos = ballState.Position;
 					var bumpDirection = ballPos - bumperPos;
 					bumpDirection.z = 0f;
 					bumpDirection = math.normalize(bumpDirection);
-					var collEvent = new CollisionEventData();
-					collEvent.HitTime = 0f;
-					collEvent.HitNormal = bumpDirection;
-					collEvent.HitVelocity.x = bumpDirection.x * ColliderComponent.Force;
-					collEvent.HitVelocity.y = bumpDirection.y * ColliderComponent.Force;
-					collEvent.HitDistance = 0f;
-					collEvent.HitFlag = false;
-					collEvent.HitOrgNormalVelocity = math.dot(bumpDirection, math.normalize(ballState.Velocity));
-					collEvent.IsContact = true;
-					collEvent.ColliderId = switchColliderId;
-					collEvent.IsKinematic = false;
-					collEvent.BallId = ballId;
+					var collEvent = new CollisionEventData {
+						HitTime = 0f,
+						HitNormal = bumpDirection,
+						HitVelocity = new float2(bumpDirection.x, bumpDirection.y) * ColliderComponent.Force,
+						HitDistance = 0f,
+						HitFlag = false,
+						HitOrgNormalVelocity = math.dot(bumpDirection, math.normalize(ballState.Velocity)),
+						IsContact = true,
+						ColliderId = switchColliderId,
+						IsKinematic = false,
+						BallId = ballId
+					};
 					var physicsMaterialData = ColliderComponent.PhysicsMaterialData;
 					var random = PhysicsEngine.Random;
 					BallCollider.Collide3DWall(ref ballState, in physicsMaterialData, in collEvent, in bumpDirection, ref random);
@@ -159,6 +157,10 @@ namespace VisualPinball.Unity
 			} else {
 				Hit?.Invoke(this, new HitEventArgs(ballId));
 				if (insideOfs.GetInsideCount(ItemId) == 1) { // Must've been empty before
+					ref var bumperState = ref PhysicsEngine.BumperState(ItemId);
+					bumperState.SkirtAnimation.HitEvent = true;
+					ref var ballState = ref PhysicsEngine.BallState(ballId);
+					bumperState.SkirtAnimation.BallPosition = ballState.Position;
 					Switch?.Invoke(this, new SwitchEventArgs(true, ballId));
 					OnSwitch(true);
 				}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperApi.cs
@@ -50,7 +50,7 @@ namespace VisualPinball.Unity
 		public event EventHandler<SwitchEventArgs> Switch;
 
 		private readonly PhysicsEngine _physicsEngine;
-		private int colliderId;
+		private int switchColliderId;
 
 		public BumperApi(GameObject go, Player player, PhysicsEngine physicsEngine) : base(go, player, physicsEngine)
 		{
@@ -96,7 +96,7 @@ namespace VisualPinball.Unity
 					collEvent.HitFlag = false;
 					collEvent.HitOrgNormalVelocity = math.dot(bumpDirection, math.normalize(ballState.Velocity));
 					collEvent.IsContact = true;
-					collEvent.ColliderId = colliderId;
+					collEvent.ColliderId = switchColliderId;
 					collEvent.IsKinematic = false;
 					collEvent.BallId = ballId;
 					var physicsMaterialData = ColliderComponent.PhysicsMaterialData;
@@ -120,12 +120,16 @@ namespace VisualPinball.Unity
 			ref ColliderReference kinematicColliders, float margin)
 		{
 			var height = MainComponent.PositionZ;
+			var switchCollider = new CircleCollider(MainComponent.Position, MainComponent.Radius, height,
+					height + MainComponent.HeightScale, GetColliderInfo(), ColliderType.Bumper);			
+			var rigidCollider = new CircleCollider(MainComponent.Position, MainComponent.Radius * 0.5f, height,
+					height + MainComponent.HeightScale, GetColliderInfo(), ColliderType.Circle);
 			if (ColliderComponent.IsKinematic) {
-				colliderId = kinematicColliders.Add(new CircleCollider(MainComponent.Position, MainComponent.Radius, height,
-					height + MainComponent.HeightScale, GetColliderInfo(), ColliderType.Bumper));
+				switchColliderId = kinematicColliders.Add(switchCollider);
+				kinematicColliders.Add(rigidCollider);
 			} else {
-				colliderId = colliders.Add(new CircleCollider(MainComponent.Position, MainComponent.Radius, height,
-					height + MainComponent.HeightScale, GetColliderInfo(), ColliderType.Bumper));
+				switchColliderId = colliders.Add(switchCollider);
+				colliders.Add(rigidCollider);
 			}
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperComponent.cs
@@ -107,7 +107,6 @@ namespace VisualPinball.Unity
 		public IEnumerable<GamelogicEngineSwitch> AvailableSwitches => new[] {
 			new GamelogicEngineSwitch(SocketSwitchItem) {
 				Description = "Socket Switch",
-				IsPulseSwitch = true,
 			}
 		};
 


### PR DESCRIPTION
Fixes #482

Bumpers now have two colliders:
- An outer non-rigid collider to detect balls near the bumper. 
- An inner rigid collider so balls cannot pass through the bumper if the coil is not triggered by the switch

These balls are pushed away in `IApiCoil.OnCoil`. `BallCollider.Collide3DWall` is also called there to make sure the velocity of the ball towards the bumper is removed regardless of how weak the push force of the bumper is. I'm not sure if it's appropriate to do that outside the physics loop, but without it, the pushes of two bumpers (e.g. in a bumper cluster) would cancel each other out like this: 

[output.webm](https://github.com/user-attachments/assets/0561aff7-8087-4fb9-9995-6c8f3310a2d5)

This is the same test scenario with collision:

[fixed.webm](https://github.com/user-attachments/assets/09c6ea98-97b1-4124-b0b4-5d3a1d441c47)

A simpler solution would to simply zero out the ball's velocity, but that would lead to strange interactions when the ball grazes the bumper from the side.