### PR TITLE
Fix bumper skirt animation

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperComponent.cs
@@ -332,7 +332,7 @@ namespace VisualPinball.Unity
 				} : default;
 
 			// skirt animation data
-			var skirtAnimComponent = GetComponentInChildren<BumperRingAnimationComponent>();
+			var skirtAnimComponent = GetComponentInChildren<BumperSkirtAnimationComponent>();
 			var skirtAnimation = skirtAnimComponent
 				? new BumperSkirtAnimationState {
 					BallPosition = default,


### PR DESCRIPTION
The bumper skirt animation is currently incorrectly applied to the bumper ring, because the type used in the `GetComponent` call for the skirt animation component is wrong.