### PR TITLE
Fix bumper animations

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsUpdateJob.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsUpdateJob.cs
@@ -19,6 +19,7 @@ using Unity.Collections;
 using Unity.Jobs;
 using Unity.Mathematics;
 using VisualPinball.Engine.Common;
+using UnityEngine;
 
 namespace VisualPinball.Unity
 {
@@ -128,10 +129,10 @@ namespace VisualPinball.Unity
 					while (enumerator.MoveNext()) {
 						ref var bumperState = ref enumerator.Current.Value;
 						if (bumperState.RingItemId != 0) {
-							BumperRingAnimation.Update(ref bumperState.RingAnimation, DeltaTimeMs);
+							BumperRingAnimation.Update(ref bumperState.RingAnimation, PhysicsConstants.PhysicsStepTime / 1000f);
 						}
 						if (bumperState.SkirtItemId != 0) {
-							BumperSkirtAnimation.Update(ref bumperState.SkirtAnimation, DeltaTimeMs);
+							BumperSkirtAnimation.Update(ref bumperState.SkirtAnimation, PhysicsConstants.PhysicsStepTime / 1000f);
 						}
 					}
 				}
@@ -164,7 +165,7 @@ namespace VisualPinball.Unity
 				using (var enumerator = TriggerStates.GetEnumerator()) {
 					while (enumerator.MoveNext()) {
 						ref var triggerState = ref enumerator.Current.Value;
-						TriggerAnimation.Update(ref triggerState.Animation, ref triggerState.Movement, in triggerState.Static, DeltaTimeMs);
+						TriggerAnimation.Update(ref triggerState.Animation, ref triggerState.Movement, in triggerState.Static, PhysicsConstants.PhysicsStepTime / 1000f);
 					}
 				}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperComponent.cs
@@ -340,7 +340,8 @@ namespace VisualPinball.Unity
 					DoUpdate = false,
 					EnableAnimation = true,
 					Rotation = new float2(0, 0),
-					Center = Position
+					Center = Position,
+					Duration = skirtAnimComponent.duration,
 				} : default;
 
 			// ring animation data

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimation.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimation.cs
@@ -18,7 +18,7 @@ namespace VisualPinball.Unity
 {
 	internal static class BumperRingAnimation
 	{
-		internal static void Update(ref BumperRingAnimationState state, float dTime)
+		internal static void Update(ref BumperRingAnimationState state, float dTimeMs)
 		{
 			// todo visibility - skip if invisible
 
@@ -33,7 +33,7 @@ namespace VisualPinball.Unity
 				if (state.AnimateDown) {
 					step = -step;
 				}
-				state.Offset += step * dTime;
+				state.Offset += step * dTimeMs;
 				if (state.AnimateDown) {
 					if (state.Offset <= -limit) {
 						state.Offset = -limit;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperRingAnimationComponent.cs
@@ -27,7 +27,7 @@ namespace VisualPinball.Unity
 		#region Data
 
 		[Tooltip("How quick the ring moves down when the ball is hit.")]
-		public float RingSpeed = 0.5f;
+		public float RingSpeed = 1.0f;
 
 		[Tooltip("How low the ring drops. 0 = bottom")]
 		public float RingDropOffset;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimation.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimation.cs
@@ -20,7 +20,7 @@ namespace VisualPinball.Unity
 {
 	internal static class BumperSkirtAnimation
 	{
-		internal static void Update(ref BumperSkirtAnimationState state, float dTime)
+		internal static void Update(ref BumperSkirtAnimationState state, float dTimeMs)
 		{
 			// todo visibility - skip if invisible
 
@@ -34,8 +34,8 @@ namespace VisualPinball.Unity
 					state.AnimationCounter = 0.0f;
 				}
 				if (state.DoAnimate) {
-					state.AnimationCounter += dTime;
-					if (state.AnimationCounter > 160.0f) {
+					state.AnimationCounter += dTimeMs;
+					if (state.AnimationCounter > state.Duration * 1000) {
 						state.DoAnimate = false;
 						ResetSkirt(ref state);
 					}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationComponent.cs
@@ -22,5 +22,9 @@ namespace VisualPinball.Unity
 	[AddComponentMenu("Visual Pinball/Animation/Bumper Skirt Animation")]
 	public class BumperSkirtAnimationComponent : AnimationComponent<BumperData, BumperComponent>
 	{
+		#region Data
+		[Tooltip("How long the skirt is pushed down when hit by a ball in seconds")]
+		public float duration = 0.1f;
+		#endregion
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationState.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperSkirtAnimationState.cs
@@ -31,5 +31,6 @@ namespace VisualPinball.Unity
 
 		// static
 		public float2 Center;
+		public float Duration;
 	}
 }


### PR DESCRIPTION
Fixes the bumper animations broken in #483 . To be honest, I don't understand how this was working before. The delta time passed into the animation `Update` functions was the Unity frame time in milliseconds. But this was done in a loop that runs once for every millisecond of frame time. So the animations were just over before they could ever appear on screen. I also found it confusing how the physics engine uses seconds, milliseconds, and microseconds, often without the variable name indicating the unit used. (See #488)