### PR TITLE
Hardwire bumpers by default

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Bumper/BumperInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Bumper/BumperInspector.cs
@@ -29,6 +29,7 @@ namespace VisualPinball.Unity.Editor
 		private SerializedProperty _heightScaleProperty;
 		private SerializedProperty _orientationProperty;
 		private SerializedProperty _surfaceProperty;
+		private SerializedProperty _isHardwiredProperty;
 
 		protected override void OnEnable()
 		{
@@ -39,6 +40,7 @@ namespace VisualPinball.Unity.Editor
 			_heightScaleProperty = serializedObject.FindProperty(nameof(BumperComponent.HeightScale));
 			_orientationProperty = serializedObject.FindProperty(nameof(BumperComponent.Orientation));
 			_surfaceProperty = serializedObject.FindProperty(nameof(BumperComponent._surface));
+			_isHardwiredProperty = serializedObject.FindProperty(nameof(BumperComponent.IsHardwired));
 		}
 
 		public override void OnInspectorGUI()
@@ -56,6 +58,7 @@ namespace VisualPinball.Unity.Editor
 			PropertyField(_heightScaleProperty, updateTransforms: true);
 			PropertyField(_orientationProperty, updateTransforms: true);
 			PropertyField(_surfaceProperty, updateTransforms: true);
+			PropertyField(_isHardwiredProperty, updateTransforms: false);
 
 			base.OnInspectorGUI();
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperComponent.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Unity.Mathematics;
 using UnityEngine;
 using VisualPinball.Engine.Game.Engines;
@@ -52,6 +53,9 @@ namespace VisualPinball.Unity
 		[Range(-180f, 180f)]
 		[Tooltip("Orientation angle. Updates z rotation.")]
 		public float Orientation;
+
+		[Tooltip("Should the bumper coil always activate when touched by a ball? Disable to give game logic engine full control")]
+		public bool IsHardwired = true;
 
 		public ISurfaceComponent Surface { get => _surface as ISurfaceComponent; set => _surface = value as MonoBehaviour; }
 
@@ -97,6 +101,23 @@ namespace VisualPinball.Unity
 			player.Register(BumperApi, this);
 			if (GetComponentInChildren<BumperColliderComponent>()) {
 				RegisterPhysics(physicsEngine);
+			}
+		}
+
+		private void Start()
+		{
+			if (IsHardwired) {
+				WireMapping wireMapping = new() {
+					Description = $"Hardwired bumper '{name}'",
+					Source = SwitchSource.Playfield,
+					SourceDevice = this,
+					SourceDeviceItem = AvailableSwitches.FirstOrDefault().Id,
+					DestinationDevice = this,
+					DestinationDeviceItem = AvailableCoils.FirstOrDefault().Id,
+					IsDynamic = false,
+				};
+				WireDestConfig wireDestConfig = new(wireMapping.WithId());
+				BumperApi.AddWireDest(wireDestConfig);
 			}
 		}
 


### PR DESCRIPTION
Makes bumpers 'just work' by default so users who don't want any special game logic for their bumpers don't have to wire them manually. Adds the option to disable the wire to the `BumperComponent` inspector.