### PR TITLE
Lazy init Player.TableApi

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
@@ -31,7 +31,8 @@ namespace VisualPinball.Unity
 {
 	public class Player : MonoBehaviour
 	{
-		public TableApi TableApi { get; }
+		private TableApi _tableApi;
+		public TableApi TableApi => _tableApi ??= new(this);
 		public PlayfieldApi PlayfieldApi { get; private set; }
 
 		// shortcuts
@@ -131,11 +132,6 @@ namespace VisualPinball.Unity
 		#endregion
 
 		#region Lifecycle
-
-		public Player()
-		{
-			TableApi = new TableApi(this);
-		}
 
 		private void Awake()
 		{


### PR DESCRIPTION
The `Player` class is derived from `MonoBehaviour` and has a constructor:
```
public Player()
{
  	TableApi = new TableApi(this);
}
```
According to [Unity docs](https://docs.unity3d.com/2022.3/Documentation/Manual/class-MonoBehaviour.html), this is very bad:

> Note: Experienced programmers may be surprised that initialization of an object is not done using a constructor function. This is because the construction of objects is handled by the Unity Editor and does not take place at the start of gameplay as you might expect. If you attempt to define a constructor for a MonoBehaviour, it will interfere with the normal operation of Unity and can cause major problems with the project.

VPE initialization has three phases that each depend on the completion of the previous one:
1. The `TableApi` is created
2. Playfield items (flippers, bumpers, etc.) register with the `TableApi` by calling `Player.Register` in their `Awake` methods. The `TableApi` must exist at this point.
3. The `OnInit` methods of the game items is called in `Player.Start`. In these functions, the game items access other items, so they must be registered at this point.

Since Unity only provides two steps in the form of `Awake` and `Start`, I assume the constructor was used to make sure the `TableApi` is initialized by the time the first `Awake` method runs. With this PR, `TableApi` is lazy initialized instead.