### PR TITLE
Fix hit events

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Gate/GateApi.cs
@@ -96,7 +96,7 @@ namespace VisualPinball.Unity
 		#endregion
 
 		#region Collider Generation
-
+		protected override bool FireHitEvents => true;
 		protected override void CreateColliders(ref ColliderReference colliders,
 			ref ColliderReference kinematicColliders, float margin)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceApi.cs
@@ -45,7 +45,7 @@ namespace VisualPinball.Unity
 
 		#region Collider Generation
 
-		protected override bool FireHitEvents => true;
+		protected override bool FireHitEvents => ColliderComponent.HitEvent;
 		protected override float HitThreshold => ColliderComponent.Threshold;
 		protected override void CreateColliders(ref ColliderReference colliders,
 			ref ColliderReference kinematicColliders, float margin)


### PR DESCRIPTION
Fixes #499 and fixes the ColliderComponent.HitEvent setting. It was previously ignored.