### PR TITLE
Correctly set isHardwareRule in AddHardwareRule

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Player.cs
@@ -361,7 +361,7 @@ namespace VisualPinball.Unity
 			}
 
 			var wireMapping = new WireMapping($"Hardware rule: {switchId} -> {coilId}", switchMapping, coilMapping).WithId();
-			_wirePlayer.AddWire(wireMapping);
+			_wirePlayer.AddWire(wireMapping, isHardwareRule: true);
 
 			// this is for showing it in the editor during runtime only
 			_tableComponent.MappingConfig.AddWire(wireMapping);


### PR DESCRIPTION
When adding hardware rules via `Player.AddHardwareRules` the argument `isHardwareRule` must explicitly be set to true, because it is false by default. This argument is stored in `WireDestConfig.IsHardwareRule` and checked when the hardware rule is removed. If it is not true, the rule is not removed using `Player.RemoveHardwareRule` and when using something like MPF that removes and adds the same rules whenever the ball drains, hardware rules will start piling up. With this PR, hardware rules can be removed.