### PR TITLE
Remove null audio clips in inspector

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Sound/SoundAssetInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Sound/SoundAssetInspector.cs
@@ -20,6 +20,7 @@ using UnityEditor;
 using UnityEngine.UIElements;
 using UnityEngine;
 using UnityEditor.UIElements;
+using System.Collections.Generic;
 
 namespace VisualPinball.Unity.Editor
 {
@@ -59,11 +60,22 @@ namespace VisualPinball.Unity.Editor
 
 		private void OnDisable()
 		{
+			RemoveNullClips();
 			_instantCts.Cancel();
 			_instantCts.Dispose();
 			_instantCts = null;
 			_allowFadeCts.Dispose();
 			_allowFadeCts = null;
+		}
+
+		private void RemoveNullClips()
+		{
+			var clipsProp = serializedObject.FindProperty("_clips");
+			for (var i = clipsProp.arraySize -1; i >= 0; i--) {
+				if (clipsProp.GetArrayElementAtIndex(i).objectReferenceValue == null)
+					clipsProp.DeleteArrayElementAtIndex(i);
+			}
+			serializedObject.ApplyModifiedPropertiesWithoutUndo();
 		}
 
 		private async void OnPlayButtonClicked()

--- a/VisualPinball.Unity/VisualPinball.Unity/Sound/SoundAsset.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Sound/SoundAsset.cs
@@ -101,7 +101,6 @@ namespace VisualPinball.Unity
 
 		private AudioClip GetClip()
 		{
-			_clips.ToList().RemoveAll(clip => clip == null);
 			if (_clips.Length == 0) {
 				throw new InvalidOperationException($"The sound asset '{name}' has no audio clips to play.");
 			}


### PR DESCRIPTION
Delete the line that was supposed to remove audio clips at runtime, because it didn't work and didn't belong there anyways. Instead, ensure that there are no null clips in the asset to begin with by removing when the inspector window is closed.