### PR TITLE
Log object name if sound event not found

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/Sound/EventSoundComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Sound/EventSoundComponent.cs
@@ -34,8 +34,10 @@ namespace VisualPinball.Unity
 			if (TryFindEventSource(out _eventSource)) {
 				Subscribe(_eventSource);
 			} else {
-				Logger.Warn($"Could not find sound event source of type {typeof(TEventSource).Name}. " +
-				            $"Make sure an appropriate component is attached");
+				Logger.Warn(
+					$"Could not find sound event source of type {typeof(TEventSource).Name} on "
+						+ $"game object '{name}.' Make sure an appropriate component is attached."
+				);
 			}
 		}
 


### PR DESCRIPTION
Makes it easier to figure out which object is misconfigured.