### PR TITLE
Fix rubber transformation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,9 +27,9 @@ jobs:
             rid: osx
           - os: macos-latest
             rid: ios-arm64
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             rid: linux-x64
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             rid: android-arm64-v8a
     steps:
       - uses: actions/checkout@v4

--- a/VisualPinball.Engine.Test/VPT/Primitive/PrimitiveMeshTests.cs
+++ b/VisualPinball.Engine.Test/VPT/Primitive/PrimitiveMeshTests.cs
@@ -71,7 +71,7 @@ namespace VisualPinball.Engine.Test.VPT.Primitive
 
 			m.GetTranslation().X.Should().Be(505f);
 			m.GetTranslation().Y.Should().Be(1305f);
-			m.GetTranslation().Z.Should().Be(_tc.Table.TableHeight);
+			m.GetTranslation().Z.Should().Be(0);
 		}
 
 		[Test]

--- a/VisualPinball.Engine/VPT/HitTarget/HitTargetMeshGenerator.cs
+++ b/VisualPinball.Engine/VPT/HitTarget/HitTargetMeshGenerator.cs
@@ -54,10 +54,7 @@ namespace VisualPinball.Engine.VPT.HitTarget
 			return new PbrMaterial(_table.GetMaterial(_data.Material), _table.GetTexture(_data.Image));
 		}
 
-		protected override float BaseHeight(Table.Table table)
-		{
-			return table?.TableHeight ?? 0f;
-		}
+		protected override float BaseHeight(Table.Table table) => 0;
 
 		private Mesh GetBaseMesh()
 		{

--- a/VisualPinball.Engine/VPT/MetalWireGuide/MetalWireGuideMeshGenerator.cs
+++ b/VisualPinball.Engine/VPT/MetalWireGuide/MetalWireGuideMeshGenerator.cs
@@ -42,7 +42,7 @@ namespace VisualPinball.Engine.VPT.MetalWireGuide
 
 		public Mesh GetMesh(Table.Table table, MetalWireGuideData metalWireGuideData)
 		{
-			var mesh = GetTransformedMesh(table.TableHeight, _data.Height, table.GetDetailLevel(), _data.Bendradius);
+			var mesh = GetTransformedMesh(0, _data.Height, table.GetDetailLevel(), _data.Bendradius);
 			mesh.Name = metalWireGuideData.Name;
 			var preMatrix = new Matrix3D();
 			preMatrix.SetTranslation(0, 0, -_data.Height);

--- a/VisualPinball.Engine/VPT/Primitive/PrimitiveMeshGenerator.cs
+++ b/VisualPinball.Engine/VPT/Primitive/PrimitiveMeshGenerator.cs
@@ -61,14 +61,12 @@ namespace VisualPinball.Engine.VPT.Primitive
 
 		public Mesh GetTransformedMesh(float height, Mesh originalMesh, Origin origin, bool asRightHanded = true)
 		{
+			// todo remove height, it should always be 0
 			var (preVertexMatrix, preNormalsMatrix) = GetPreMatrix(height, origin, asRightHanded);
 			return GetMesh(originalMesh)?.Transform(preVertexMatrix, preNormalsMatrix);
 		}
 
-		protected override float BaseHeight(Table.Table table)
-		{
-			return table?.TableHeight ?? 0f;
-		}
+		protected override float BaseHeight(Table.Table table) => 0;
 
 		public Matrix3D TransformationMatrix(float height)
 		{

--- a/VisualPinball.Engine/VPT/Ramp/Ramp.cs
+++ b/VisualPinball.Engine/VPT/Ramp/Ramp.cs
@@ -88,8 +88,8 @@ namespace VisualPinball.Engine.VPT.Ramp
 			var len = MathF.Sqrt(dx * dx + dy * dy);
 			startLength += len; // Add the distance the object is between the two closest polyline segments.  Matters mostly for straight edges. Z does not respect that yet!
 
-			var topHeight = Data.HeightTop + table.TableHeight;
-			var bottomHeight = Data.HeightBottom + table.TableHeight;
+			var topHeight = Data.HeightTop;
+			var bottomHeight = Data.HeightBottom;
 
 			return vVertex[iSeg].Z + startLength / totalLength * (topHeight - bottomHeight) + bottomHeight;
 		}

--- a/VisualPinball.Engine/VPT/Ramp/RampMeshGenerator.cs
+++ b/VisualPinball.Engine/VPT/Ramp/RampMeshGenerator.cs
@@ -83,7 +83,7 @@ namespace VisualPinball.Engine.VPT.Ramp
 
 		public Mesh GetMesh(string id, Table.Table table, bool asRightHanded)
 		{
-			var meshes = GenerateMeshes(table.Width, table.Height, table.TableHeight);
+			var meshes = GenerateMeshes(table.Width, table.Height, 0);
 			if (meshes.ContainsKey(id)) {
 				return asRightHanded ? meshes[id].Transform(Matrix3D.RightHanded) : meshes[id];
 			}

--- a/VisualPinball.Engine/VPT/Rubber/IRubberData.cs
+++ b/VisualPinball.Engine/VPT/Rubber/IRubberData.cs
@@ -20,12 +20,9 @@ namespace VisualPinball.Engine.VPT.Rubber
 {
 	public interface IRubberData
 	{
+		string name { get; }
 		DragPointData[] DragPoints { get; }
 		int Thickness { get; }
 		float Height { get; }
-
-		float RotX { get; }
-		float RotY { get; }
-		float RotZ { get; }
 	}
 }

--- a/VisualPinball.Engine/VPT/Rubber/Rubber.cs
+++ b/VisualPinball.Engine/VPT/Rubber/Rubber.cs
@@ -60,7 +60,7 @@ namespace VisualPinball.Engine.VPT.Rubber
 		Matrix3D IRenderable.TransformationMatrix(Table.Table table, Origin origin) => Matrix3D.Identity;
 		public Mesh GetMesh(string id, Table.Table table, Origin origin = Origin.Global, bool asRightHanded = true)
 		{
-			return MeshGenerator.GetMesh(table, Data);
+			return MeshGenerator.GetMesh(0, table);
 		}
 
 		public PbrMaterial GetMaterial(string id, Table.Table table) => MeshGenerator.GetMaterial(table, Data);

--- a/VisualPinball.Engine/VPT/Rubber/RubberData.cs
+++ b/VisualPinball.Engine/VPT/Rubber/RubberData.cs
@@ -35,6 +35,7 @@ namespace VisualPinball.Engine.VPT.Rubber
 	{
 		public override string GetName() => Name;
 		public override void SetName(string name) { Name = name; }
+		public string name => Name;
 
 		[BiffString("NAME", IsWideString = true, Pos = 8)]
 		public string Name = string.Empty;

--- a/VisualPinball.Engine/VPT/Surface/Surface.cs
+++ b/VisualPinball.Engine/VPT/Surface/Surface.cs
@@ -54,7 +54,7 @@ namespace VisualPinball.Engine.VPT.Surface
 		Matrix3D IRenderable.TransformationMatrix(Table.Table table, Origin origin) => Matrix3D.Identity;
 
 		public Mesh GetMesh(string id, Table.Table table, Origin origin = Origin.Global, bool asRightHanded = true)
-			=> _meshGenerator.GetMesh(id, table.Width, table.Height, table.TableHeight, asRightHanded);
+			=> _meshGenerator.GetMesh(id, table.Width, table.Height, 0, asRightHanded);
 
 		public PbrMaterial GetMaterial(string id, Table.Table table) => _meshGenerator.GetMaterial(id, table, Data);
 

--- a/VisualPinball.Engine/VPT/Table/Table.cs
+++ b/VisualPinball.Engine/VPT/Table/Table.cs
@@ -32,10 +32,7 @@ namespace VisualPinball.Engine.VPT.Table
 		public float Width => Data.Right - Data.Left;
 		public float Height => Data.Bottom - Data.Top;
 
-		public float TableHeight => Data.TableHeight;
-
 		public float GlassHeight => Data.GlassHeight;
-		public Rect3D BoundingBox => new Rect3D(Data.Left, Data.Right, Data.Top, Data.Bottom, TableHeight, GlassHeight);
 
 		private readonly TableContainer _tableContainer;
 		private readonly TableMeshGenerator _meshGenerator;
@@ -49,24 +46,17 @@ namespace VisualPinball.Engine.VPT.Table
 		public float GetSurfaceHeight(string surfaceName, float x, float y)
 		{
 			if (string.IsNullOrEmpty(surfaceName)) {
-				return TableHeight;
+				return 0;
 			}
 
 			if (_tableContainer.Has<Surface.Surface>(surfaceName)) {
-				return TableHeight + _tableContainer.Get<Surface.Surface>(surfaceName).Data.HeightTop;
+				return _tableContainer.Get<Surface.Surface>(surfaceName).Data.HeightTop;
 			}
 
 			if (_tableContainer.Has<Ramp.Ramp>(surfaceName)) {
-				return TableHeight + _tableContainer.Get<Ramp.Ramp>(surfaceName).GetSurfaceHeight(x, y, this);
+				return _tableContainer.Get<Ramp.Ramp>(surfaceName).GetSurfaceHeight(x, y, this);
 			}
-
-			// Logger.Warn(
-			// 	"[Table.getSurfaceHeight] Unknown surface {0}.\nAvailable surfaces: [ {1} ]\nAvailable ramps: [ {2} ]",
-			// 	surfaceName,
-			// 	string.Join(", ", _surfaces.Keys),
-			// 	string.Join(", ", _ramps.Keys)
-			// );
-			return TableHeight;
+			return 0;
 		}
 
 		public int GetDetailLevel()
@@ -93,4 +83,3 @@ namespace VisualPinball.Engine.VPT.Table
 		#endregion
 	}
 }
-

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsSceneViewHandler.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/DragPoint/DragPointsSceneViewHandler.cs
@@ -216,7 +216,6 @@ namespace VisualPinball.Unity.Editor
 		/// </remarks>
 		private void DisplayControlPoints()
 		{
-			var matrix = math.mul(math.mul(Physics.WorldToVpx,math.inverse(_handler.MainComponent.gameObject.transform.worldToLocalMatrix)), Physics.VpxToWorld);
 			Profiler.BeginSample("DisplayControlPoints");
 			// Render Control Points and check traveler distance from CP
 			var distToControlPoint = Mathf.Infinity;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Import/VpeMenuImporter.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Import/VpeMenuImporter.cs
@@ -27,7 +27,7 @@ namespace VisualPinball.Unity.Editor
 {
 	public static class VpeMenuImporter
 	{
-		[MenuItem("Visual Pinball/Import VPE", false, 1)]
+		[MenuItem("Visual Pinball/Import .vpe File", false, 1)]
 		public static async void ImportVpeIntoScene(MenuCommand menuCommand)
 		{
 			// if it's an untitled scene, save first.
@@ -36,7 +36,7 @@ namespace VisualPinball.Unity.Editor
 			}
 			
 			// open file dialog
-			var vpePath = EditorUtility.OpenFilePanelWithFilters("Import .VPE File", null, new[] { "VPE Table Files", "vpe" });
+			var vpePath = EditorUtility.OpenFilePanelWithFilters("Import .vpe File", null, new[] { "VPE Table Files", "vpe" });
 			if (vpePath.Length == 0) {
 				return;
 			}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Import/VpxImportWizard.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Import/VpxImportWizard.cs
@@ -117,7 +117,7 @@ namespace VisualPinball.Unity.Editor
 					}
 
 					// open file dialog
-					var vpxPath = EditorUtility.OpenFilePanelWithFilters("Import .VPX File", initialDirectory, new[] { "Visual Pinball Table Files", "vpx" });
+					var vpxPath = EditorUtility.OpenFilePanelWithFilters("Import .vpx File", initialDirectory, new[] { "Visual Pinball Table Files", "vpx" });
 					if (vpxPath.Length != 0 && File.Exists(vpxPath))
 					{
 						VpxImportWizardSettings.VpxPath = vpxPath;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/Import/VpxMenuImporter.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/Import/VpxMenuImporter.cs
@@ -27,7 +27,7 @@ namespace VisualPinball.Unity.Editor
 {
 	public static class VpxMenuImporter
 	{
-		[MenuItem("Visual Pinball/Import VPX", false, 2)]
+		[MenuItem("Visual Pinball/Import .vpx File", false, 2)]
 		public static void ImportVpxIntoScene(MenuCommand menuCommand)
 		{
 			// if it's an untitled scene, save first.
@@ -36,7 +36,7 @@ namespace VisualPinball.Unity.Editor
 			}
 			
 			// open file dialog
-			var vpxPath = EditorUtility.OpenFilePanelWithFilters("Import .VPX File", null, new[] { "Visual Pinball Table Files", "vpx" });
+			var vpxPath = EditorUtility.OpenFilePanelWithFilters("Import .vpx File", null, new[] { "Visual Pinball Table Files", "vpx" });
 			if (vpxPath.Length == 0) {
 				return;
 			}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Rubber/RubberInspector.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/VPT/Rubber/RubberInspector.cs
@@ -30,9 +30,7 @@ namespace VisualPinball.Unity.Editor
 
 		public Transform Transform => MainComponent.transform;
 
-		private SerializedProperty _heightProperty;
 		private SerializedProperty _thicknessProperty;
-		private SerializedProperty _rotationProperty;
 
 		protected override void OnEnable()
 		{
@@ -41,9 +39,7 @@ namespace VisualPinball.Unity.Editor
 			DragPointsHelper = new DragPointsInspectorHelper(MainComponent, this);
 			DragPointsHelper.OnEnable();
 
-			_heightProperty = serializedObject.FindProperty(nameof(RubberComponent._height));
 			_thicknessProperty = serializedObject.FindProperty(nameof(RubberComponent._thickness));
-			_rotationProperty = serializedObject.FindProperty(nameof(RubberComponent.Rotation));
 		}
 
 		protected override void OnDisable()
@@ -62,8 +58,13 @@ namespace VisualPinball.Unity.Editor
 
 			OnPreInspectorGUI();
 
-			PropertyField(_rotationProperty, rebuildMesh: true);
-			PropertyField(_heightProperty, rebuildMesh: true);
+			// height
+			EditorGUI.BeginChangeCheck();
+			var newHeight = EditorGUILayout.FloatField(new GUIContent("Height", "Height of the rubber (in VPX units."), MainComponent.Height);
+			if (EditorGUI.EndChangeCheck()) {
+				Undo.RecordObject(MainComponent.transform, "Change Rubber Height");
+				MainComponent.Height = newHeight;
+			}
 			PropertyField(_thicknessProperty, rebuildMesh: true);
 
 			DragPointsHelper.OnInspectorGUI(this);
@@ -86,7 +87,7 @@ namespace VisualPinball.Unity.Editor
 		public IEnumerable<DragPointExposure> DragPointExposition => new[] { DragPointExposure.Smooth };
 		public DragPointTransformType HandleType => DragPointTransformType.TwoD;
 		public DragPointsInspectorHelper DragPointsHelper { get; private set; }
-		public float ZOffset => MainComponent.Height;
+		public float ZOffset => 0;
 		public float[] TopBottomZ => null;
 		public void SetDragPointPosition(DragPointData dragPoint, Vertex3D value, int numSelectedDragPoints,
 			float[] topBottomZ) => dragPoint.Center = value;

--- a/VisualPinball.Unity/VisualPinball.Unity/Extensions/MathExtensions.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Extensions/MathExtensions.cs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-using System.ComponentModel;
 using Unity.Collections;
 using Unity.Mathematics;
 using UnityEngine;

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Physics.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Physics.cs
@@ -67,7 +67,7 @@ namespace VisualPinball.Unity
 		/// <param name="m">VPX-space matrix that is supposed to be applied to a VPX-space mesh</param>
 		/// <returns>Matrix that with the same transformation to be applied to a mesh converted to world-space.</returns>
 		public static Matrix4x4 TransformVpxInWorld(this Matrix4x4 m) => math.mul(math.mul(VpxToWorld, m), WorldToVpx);
-		public static Matrix4x4 TransformWorldInVpx(this Matrix4x4 m) => math.mul(math.mul(WorldToVpx, m), VpxToWorld);
+		public static float4x4 TransformVpxInWorld(this float4x4 m) => math.mul(math.mul(VpxToWorld, m), WorldToVpx);
 
 		//public static float3 MultiplyPoint(this float4x4 matrix, float3 p) => math.mul(matrix, new float4(p, 1f)).xyz;
 		public static float3 MultiplyPoint(this float4x4 matrix, float3 p) => math.transform(matrix, p);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Playfield/PlayfieldComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Playfield/PlayfieldComponent.cs
@@ -172,7 +172,7 @@ namespace VisualPinball.Unity
 			var updatedComponents = new List<MonoBehaviour> { this };
 			var mg = new PrimitiveMeshGenerator(primitiveData);
 			var mesh = mg
-				.GetTransformedMesh(table?.TableHeight ?? 0f, primitiveData.Mesh, Origin.Original, false)
+				.GetTransformedMesh(0, primitiveData.Mesh, Origin.Original, false)
 				.Transform(mg.TransformationMatrix(0)) // apply transformation to mesh, because this is the playfield
 				.TransformToWorld(); // also, transform this to world space.
 			var material = new PbrMaterial(

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Plunger/PlungerCollider.cs
@@ -85,11 +85,15 @@ namespace VisualPinball.Unity
 			LineSegEnd = new LineCollider(new float2(x2, position), new float2(x, position), zHeight, zHeight + Plunger.PlungerHeight, info);
 			JointEnd0 = new LineZCollider(new float2(x, position), zHeight, zHeight + Plunger.PlungerHeight, info);
 			JointEnd1 = new LineZCollider(new float2(x2, position), zHeight, zHeight + Plunger.PlungerHeight, info);
-
 			PosY = 0;
+
 			Bounds = new ColliderBounds(Header.ItemId, Header.Id, new Aabb(
-				new float3(-comp.Width - 10, comp.Height, 0),
-				new float3(comp.Width + 10, -100, 50)
+				x - 0.1f,
+				x2 + 0.1f,
+				frameTop - 0.1f,
+				y + 0.1f,
+				0,
+				50
 			));
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Primitive/PrimitiveComponent.cs
@@ -78,11 +78,11 @@ namespace VisualPinball.Unity
 			var updatedComponents = new List<MonoBehaviour> { this };
 
 			// transforms
-			var position = data.Position.ToUnityVector3();
+			var position = data.Position.ToUnityFloat3();
 			var size = data.Size.ToUnityFloat3();
-			var rotation = new Vector3(data.RotAndTra[0], data.RotAndTra[1], data.RotAndTra[2]);
-			var translation = new Vector3(data.RotAndTra[3], data.RotAndTra[4], data.RotAndTra[5]);
-			var objectRotation = new Vector3(data.RotAndTra[6], data.RotAndTra[7], data.RotAndTra[8]);
+			var rotation = new float3(data.RotAndTra[0], data.RotAndTra[1], data.RotAndTra[2]);
+			var translation = new float3(data.RotAndTra[3], data.RotAndTra[4], data.RotAndTra[5]);
+			var objectRotation = new float3(data.RotAndTra[6], data.RotAndTra[7], data.RotAndTra[8]);
 
 			var scaleMatrix = float4x4.Scale(size);
 			var transMatrix = float4x4.Translate(position);
@@ -93,7 +93,7 @@ namespace VisualPinball.Unity
 					float4x4.Translate(translation)
 				));
 			var transformationWithinPlayfieldMatrix = math.mul(transMatrix, math.mul(rotTransMatrix, scaleMatrix));
-			transform.SetFromMatrix(((Matrix4x4)transformationWithinPlayfieldMatrix).TransformVpxInWorld());
+			transform.SetFromMatrix(transformationWithinPlayfieldMatrix.TransformVpxInWorld());
 
 			// mesh
 			var meshComponent = GetComponent<PrimitiveMeshComponent>();

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberApi.cs
@@ -51,7 +51,7 @@ namespace VisualPinball.Unity
 				new RubberMeshGenerator(MainComponent),
 				translateWithinPlayfieldMatrix
 			);
-			colliderGenerator.GenerateColliders(0, ColliderComponent.HitHeight, MainComponent.PlayfieldDetailLevel, ref colliders, margin);
+			colliderGenerator.GenerateColliders(MainComponent.Height - ColliderComponent.HitHeight, MainComponent.PlayfieldDetailLevel, ref colliders, margin);
 		}
 
 		#endregion

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberColliderGenerator.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberColliderGenerator.cs
@@ -34,9 +34,9 @@ namespace VisualPinball.Unity
 			_matrix = matrix;
 		}
 
-		internal void GenerateColliders(float playfieldHeight, float hitHeight, int detailLevel, ref ColliderReference colliders, float margin)
+		internal void GenerateColliders(float zOffset, int detailLevel, ref ColliderReference colliders, float margin)
 		{
-			var mesh = _meshGenerator.GetTransformedMesh(playfieldHeight, hitHeight, detailLevel, 6, true, margin); //!! adapt hacky code in the function if changing the "6" here
+			var mesh = _meshGenerator.GetTransformedMesh(zOffset, detailLevel, 6, margin); //!! adapt hacky code in the function if changing the "6" here
 			var addedEdges = EdgeSet.Get(Allocator.TempJob);
 
 			// add collision triangles and edges

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberMeshComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberMeshComponent.cs
@@ -29,7 +29,7 @@ namespace VisualPinball.Unity
 	{
 		protected override Mesh GetMesh(RubberData data)
 			=> new RubberMeshGenerator(MainComponent)
-				.GetTransformedMesh(0, MainComponent.Height, MainComponent.PlayfieldDetailLevel)
+				.GetTransformedMesh(0, MainComponent.PlayfieldDetailLevel)
 				.TransformToWorld();
 
 		protected override PbrMaterial GetMaterial(RubberData data, Table table)

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberPackable.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Rubber/RubberPackable.cs
@@ -23,14 +23,12 @@ namespace VisualPinball.Unity
 {
 	public struct RubberPackable
 	{
-		public float Height;
 		public int Thickness;
 		public IEnumerable<DragPointPackable> DragPoints;
 
 		public static byte[] Pack(RubberComponent comp)
 		{
 			return PackageApi.Packer.Pack(new RubberPackable {
-				Height = comp.Height,
 				Thickness = comp.Thickness,
 				DragPoints = comp.DragPoints.Select(DragPointPackable.From)
 			});
@@ -39,7 +37,6 @@ namespace VisualPinball.Unity
 		public static void Unpack(byte[] bytes, RubberComponent comp)
 		{
 			var data = PackageApi.Packer.Unpack<RubberPackable>(bytes);
-			comp._height = data.Height;
 			comp._thickness = data.Thickness;
 			comp.DragPoints = data.DragPoints.Select(c => c.ToDragPoint()).ToArray();
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SlingshotComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SlingshotComponent.cs
@@ -158,9 +158,6 @@ namespace VisualPinball.Unity
 		public DragPointData[] DragPoints => DragPointsAt(Position);
 		public int Thickness => RubberOff.GetComponent<RubberComponent>()?.Thickness ?? 8;
 		public float Height => RubberOff.GetComponent<RubberComponent>()?.Height ?? 25f;
-		public float RotX => RubberOff.GetComponent<RubberComponent>()?.RotX ?? 0;
-		public float RotY => RubberOff.GetComponent<RubberComponent>()?.RotY ?? 0;
-		public float RotZ => RubberOff.GetComponent<RubberComponent>()?.RotZ ?? 0;
 
 		#endregion
 
@@ -227,7 +224,7 @@ namespace VisualPinball.Unity
 			Debug.Log($"Generating new mesh at {pos}");
 
 			var mesh = MeshGenerator
-				.GetTransformedMesh(0, r0.Height, pf.PlayfieldDetailLevel)
+				.GetTransformedMesh(0, pf.PlayfieldDetailLevel)
 				.TransformToWorld()
 				.ToUnityMesh();
 


### PR DESCRIPTION
Use a matrix like the rest of the transformations instead of transforming the actual mesh.

The mesh generator now takes in a z-offset instead of height so we can generate meshes at different height for collision.