### PR TITLE
Fix exception on ball drain

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngine.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngine.cs
@@ -145,6 +145,7 @@ namespace VisualPinball.Unity
 		internal NativeQueue<EventData>.ParallelWriter EventQueue => _eventQueue.Ref.AsParallelWriter();
 
 		internal void Schedule(InputAction action) => _inputActions.Enqueue(action);
+		internal bool BallExists(int ballId) => _ballStates.Ref.ContainsKey(ballId);
 		internal ref BallState BallState(int ballId) => ref _ballStates.Ref.GetValueByRef(ballId);
 		internal ref BumperState BumperState(int itemId) => ref _bumperStates.Ref.GetValueByRef(itemId);
 		internal ref FlipperState FlipperState(int itemId) => ref _flipperStates.Ref.GetValueByRef(itemId);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallMovementPhysics.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallMovementPhysics.cs
@@ -36,6 +36,11 @@ namespace VisualPinball.Unity
 
 		public static void Move(BallState ball, Transform ballTransform)
 		{
+			// if ball was destroyed, don't do anything.
+			if (!ballTransform || !ballTransform.gameObject) {
+				return;
+			}
+
 			// calculate/adapt height of ball
 			var zHeight = !ball.IsFrozen ? ball.Position.z : ball.Position.z - ball.Radius;
 			ballTransform.localPosition = Physics.TranslateToWorld(ball.Position.x, ball.Position.y, zHeight);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerApi.cs
@@ -250,8 +250,11 @@ namespace VisualPinball.Unity
 				Hit?.Invoke(this, new HitEventArgs(ballId));
 				Switch?.Invoke(this, new SwitchEventArgs(true, ballId));
 				OnSwitch(true);
-				BallMovementPhysics.Move(PhysicsEngine.BallState(ballId), ballTransform); // do the last update, since frozen balls don't get updated
-				ballTransform.SetParent(MainComponent.transform, true);
+				// check if ball is destroyed
+				if (PhysicsEngine.BallExists(ballId)) {
+					BallMovementPhysics.Move(PhysicsEngine.BallState(ballId), ballTransform); // do the last update, since frozen balls don't get updated
+					ballTransform.SetParent(MainComponent.transform, true);
+				}
 			}
 		}
 


### PR DESCRIPTION
We've recently introduced parenting, and if a ball is frozen by a kicker, it's re-parented to the kicker so it follows its movement. There was no check whether the ball wasn't actually destroyed (which is far more likely, heh).

Fixes #512.