### PR TITLE
Bumper fixes

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/Sound/CoilSoundComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Sound/CoilSoundComponent.cs
@@ -29,7 +29,6 @@ namespace VisualPinball.Unity
 	[AddComponentMenu("Pinball/Sound/Coil Sound")]
 	public class CoilSoundComponent : BinaryEventSoundComponent<IApiCoil, NoIdCoilEventArgs>, IPackable
 	{
-		[HideInInspector]
 		public string CoilName;
 
 		public override Type GetRequiredType() => typeof(ICoilDeviceComponent);

--- a/VisualPinball.Unity/VisualPinball.Unity/Sound/SwitchSoundComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Sound/SwitchSoundComponent.cs
@@ -29,7 +29,6 @@ namespace VisualPinball.Unity
 	[AddComponentMenu("Pinball/Sound/Switch Sound")]
 	public class SwitchSoundComponent : BinaryEventSoundComponent<IApiSwitch, SwitchEventArgs>, IPackable
 	{
-		[HideInInspector]
 		public string SwitchName;
 
 		public override Type GetRequiredType() => typeof(ISwitchDeviceComponent);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperApi.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperApi.cs
@@ -102,6 +102,8 @@ namespace VisualPinball.Unity
 					BumperCollider.PushBallAway(ref ballState, in bumperState.Static, ref collEvent, in physicsMaterialData, ref state);
 				}
 			}
+			
+			CoilStatusChanged?.Invoke(this, new NoIdCoilEventArgs(enabled));
 		}
 
 		void IApiWireDest.OnChange(bool enabled) => (this as IApiCoil).OnCoil(enabled);

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Bumper/BumperComponent.cs
@@ -95,6 +95,7 @@ namespace VisualPinball.Unity
 		public const float DataMeshScale = 100f;
 
 		public const string SocketSwitchItem = "socket_switch";
+		public const string RingCoilItem = "ring_coil";
 
 		#endregion
 
@@ -144,7 +145,7 @@ namespace VisualPinball.Unity
 		public SwitchDefault SwitchDefault => SwitchDefault.Configurable;
 
 		public IEnumerable<GamelogicEngineCoil> AvailableCoils =>  new[] {
-			new GamelogicEngineCoil(name) {
+			new GamelogicEngineCoil(RingCoilItem) {
 				Description = "Ring Coil"
 			}
 		};

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceColliderGenerator.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Surface/SurfaceColliderGenerator.cs
@@ -17,6 +17,7 @@
 // ReSharper disable CompareOfFloatsByEqualityOperator
 
 using Unity.Mathematics;
+using VisualPinball.Engine.Math;
 using VisualPinball.Engine.VPT.Surface;
 
 namespace VisualPinball.Unity
@@ -34,7 +35,8 @@ namespace VisualPinball.Unity
 
 			var data = new SurfaceData();
 			component.CopyDataTo(data, null, null, false);
-			_meshGen = new SurfaceMeshGenerator(data);
+			var pos = new Vertex3D(matrix.c3.x, matrix.c3.y, matrix.c3.z);
+			_meshGen = new SurfaceMeshGenerator(data, pos);
 		}
 
 		internal void GenerateColliders(ref ColliderReference colliders)


### PR DESCRIPTION


- Remove unneccessary HideInInspector attributes from `CoilSoundComponent` and `SwitchSoundComponent`. These classes have custom inspectors anyways and the HideInInspector attribute makes it impossible to debug those using the Debug view in the inspector.
- Fix: Bumper coil was not  triggering status events. This was broken in https://github.com/freezy/VisualPinball.Engine/commit/b890c47341c82e10ba6ebafc6deab58e6e8ca7e5. It caused the bumper sound effect to not play.
- Fix: Bumper coil is named after bumper game object. This didn't really break anything because the bumper API ignores the ID of the requested coil, but it did cause the coil sound inspector to stop showing the "Ring Coil" text whenever the name of the bumper prefab was changed. The bumper coil now always has the id "ring_coil" just like the switch always has the id "socket_switch".