### PR TITLE
Remove create asset menu for abstract sound base class

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/Sound/SoundAsset.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Sound/SoundAsset.cs
@@ -39,7 +39,6 @@ namespace VisualPinball.Unity
 	/// clips can be assigned for variation. Instances of this class are Unity assets and can
 	/// therefore be stored in the project files or in an asset library for reuse across tables.
 	/// </summary>
-	[CreateAssetMenu(fileName = "Sound", menuName = "Pinball/Sound", order = 102)]
 	[PackWith(typeof(SoundAssetPacker))]
 	public abstract class SoundAsset : ScriptableObject
 	{


### PR DESCRIPTION
The base sound class cannot be instantiated and should not have a menu entry