### PR TITLE
debug: Fix GetComponent for ball roller

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/Game/BallDebugComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/BallDebugComponent.cs
@@ -18,9 +18,9 @@ namespace VisualPinball.Unity
 
 		private void Awake()
 		{
-			_physicsEngine = GetComponentInParent<PhysicsEngine>();
-			_playfield = GetComponentInParent<PlayfieldComponent>();
-			_player = GetComponentInParent<Player>();
+			_physicsEngine = GetComponentInChildren<PhysicsEngine>();
+			_playfield = GetComponentInChildren<PlayfieldComponent>();
+			_player = GetComponentInChildren<Player>();
 
 			_ltw = Physics.VpxToWorld;
 			_wtl = Physics.WorldToVpx;


### PR DESCRIPTION
https://github.com/freezy/VisualPinball.Engine/commit/3325d6fbf5f76679d101c98cf8e6e2854abdd61b#diff-bfeeb83ebdbd31489ea3437b468e1f011ecff70ff6f29cd6bc2f04daf36c9df3R21 Changed `GetComponentInChildren` calls on the ball roller to `GetComponentInParent`. This breaks the ball roller since the ball roller component is (by default) on the root object of the table and the playfield and physics engine are one layer below. 