### PR TITLE
Display seam for external DMD output (real / virtual / colorized)

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DisplayComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DisplayComponent.cs
@@ -30,6 +30,8 @@ namespace VisualPinball.Unity
 		public abstract Color LitColor { get; set; }
 		public abstract Color UnlitColor { get; set; }
 
+		public bool ReceiveGamelogicFrames { get; set; } = true;
+
 		public EventHandler<DisplayFrameData> OnDisplayChanged;
 
 		private static readonly int DataProp = Shader.PropertyToID("__Data");

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DisplayComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DisplayComponent.cs
@@ -124,7 +124,6 @@ namespace VisualPinball.Unity
 
 			Vector2[] uvs;
 			if (flipX) {
-				Logger.Error("FLIPX");
 				uvs = new [] {
 					uv00, uv00, uv00, uv00, // Bottom
 					uv00, uv00, uv00, uv00, // Left

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayComponent.cs
@@ -190,7 +190,7 @@ namespace VisualPinball.Unity
 						for (var y = 0; y < _height; y++) {
 							for (var x = 0; x < _width; x++) {
 								var pixel = frame[(_height - y - 1) * _width + x];
-								_colorBuffer[y * _width + x] = map.ContainsKey(pixel) ? map[pixel] : (Color32)Color.magenta;
+								_colorBuffer[y * _width + x] = map.TryGetValue(pixel, out var mapped) ? mapped : (Color32)Color.magenta;
 							}
 						}
 						_texture.SetPixels32(_colorBuffer);

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayComponent.cs
@@ -203,11 +203,7 @@ namespace VisualPinball.Unity
 
 				case DisplayFrameFormat.Dmd24:
 					if (frame.Length == _width * _height * 3) {
-
-						// the texture has RGB24 format, so we can just copy all into the texture directly.
-						CopyData(frame, 0, frame.Length, _texture.GetRawTextureData<byte>());
-
-						// still need to apply it.
+						CopyRgb24FrameToTexture(frame, _texture.GetRawTextureData<byte>());
 						_texture.Apply();
 
 					} else {
@@ -224,11 +220,19 @@ namespace VisualPinball.Unity
 			}
 		}
 
-		private static unsafe void CopyData<T>(T[] array, int offset, int count, NativeArray<T> dst) where T : unmanaged
+		private void CopyRgb24FrameToTexture(byte[] frame, NativeArray<byte> textureData)
+		{
+			var rowLength = _width * 3;
+			for (var y = 0; y < _height; y++) {
+				CopyData(frame, (_height - y - 1) * rowLength, rowLength, textureData, y * rowLength);
+			}
+		}
+
+		private static unsafe void CopyData<T>(T[] array, int offset, int count, NativeArray<T> dst, int dstOffset = 0) where T : unmanaged
 		{
 			fixed (T * srcPtr = array) {
-				var dstPtr = dst.GetUnsafePtr();
-				UnsafeUtility.MemCpy(dstPtr,srcPtr + offset, sizeof(T) * count);
+				var dstPtr = (T*)dst.GetUnsafePtr();
+				UnsafeUtility.MemCpy(dstPtr + dstOffset, srcPtr + offset, sizeof(T) * count);
 			}
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/DisplayPlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/DisplayPlayer.cs
@@ -69,15 +69,15 @@ namespace VisualPinball.Unity
 
 		private void HandleDisplayClear(object sender, string id)
 		{
-			if (_displayGameObjects.ContainsKey(id)) {
-				_displayGameObjects[id].Clear();
+			if (_displayGameObjects.TryGetValue(id, out var display) && display.ReceiveGamelogicFrames) {
+				display.Clear();
 			}
 		}
 
 		private void HandleDisplayUpdateFrame(object sender, DisplayFrameData e)
 		{
-			if (_displayGameObjects.ContainsKey(e.Id)) {
-				_displayGameObjects[e.Id].UpdateFrame(e.Format, e.Data);
+			if (_displayGameObjects.TryGetValue(e.Id, out var display) && display.ReceiveGamelogicFrames) {
+				display.UpdateFrame(e.Format, e.Data);
 			}
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/DisplayPlayer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/DisplayPlayer.cs
@@ -50,9 +50,14 @@ namespace VisualPinball.Unity
 		private void HandleDisplaysRequested(object sender, RequestedDisplays requestedDisplays)
 		{
 			foreach (var display in requestedDisplays.Displays) {
-				if (_displayGameObjects.ContainsKey(display.Id)) {
+				if (_displayGameObjects.TryGetValue(display.Id, out var displayGameObject)) {
+					// When another subscriber (e.g. the DMD bridge's in-scene destination) owns this
+					// display, it reconfigures and feeds the component itself. Touching it here would
+					// resize the texture and blank it via Clear(), causing a flicker — so skip it.
+					if (!displayGameObject.ReceiveGamelogicFrames) {
+						continue;
+					}
 					Logger.Info($"Updating display \"{display.Id}\" to {display.Width}x{display.Height}");
-					var displayGameObject = _displayGameObjects[display.Id];
 					displayGameObject.UpdateDimensions(display.Width, display.Height, display.FlipX);
 					if (display.LitColor.HasValue) {
 						displayGameObject.UpdateColor(display.LitColor.Value);

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/IGamelogicEngine.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/IGamelogicEngine.cs
@@ -155,6 +155,11 @@ namespace VisualPinball.Unity
 		// todo displays
 	}
 
+	public interface IDisplayFrameFormatPreference
+	{
+		void RequestDisplayFrameFormat(string displayId, DisplayFrameFormat format);
+	}
+
 	public enum GamelogicInputDispatchMode
 	{
 		MainThread = 0,

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/IGamelogicEngine.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/IGamelogicEngine.cs
@@ -58,6 +58,18 @@ namespace VisualPinball.Unity
 		/// <summary>
 		/// Emitted by the display player when a display frame update is requested.
 		/// </summary>
+		///
+		/// <remarks>
+		/// CONTRACT for implementers and subscribers:
+		/// <list type="bullet">
+		/// <item>This event MUST be raised on the Unity main thread. Subscribers touch Unity objects
+		/// (textures) and/or marshal to their own worker threads assuming a single, known origin thread.</item>
+		/// <item>The <see cref="DisplayFrameData.Data"/> buffer is only guaranteed valid for the duration
+		/// of the synchronous invocation. A subscriber that retains the frame beyond the call (e.g. hands
+		/// it to a worker thread) MUST copy the bytes; the producer may reuse or overwrite the buffer
+		/// afterwards. Producers that cannot guarantee this should hand out a fresh array per frame.</item>
+		/// </list>
+		/// </remarks>
 		event EventHandler<DisplayFrameData> OnDisplayUpdateFrame;
 
 		/// <summary>

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/IGamelogicEngine.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/IGamelogicEngine.cs
@@ -160,6 +160,16 @@ namespace VisualPinball.Unity
 		void RequestDisplayFrameFormat(string displayId, DisplayFrameFormat format);
 	}
 
+	/// <summary>
+	/// Optional capability interface for gamelogic engines that know the ROM they are running.
+	/// Consumers (e.g. the DMD bridge resolving colorization) use this instead of reflecting
+	/// over the concrete engine type.
+	/// </summary>
+	public interface IRomNameProvider
+	{
+		string RomName { get; }
+	}
+
 	public enum GamelogicInputDispatchMode
 	{
 		MainThread = 0,


### PR DESCRIPTION
Small, additive changes to the GLE **display seam** so an external package
([`VisualPinball.Engine.DMD`](https://github.com/VisualPinball/VisualPinball.Engine.DMD)) can fan display frames out to real DMD hardware, an on-screen virtual DMD, and a colorization stage without touching the in-scene rendering path. Also includes two small correctness/perf fixes in the in-scene DMD.

No behavior changes for existing setups. Every addition is opt-in and `ReceiveGamelogicFrames`
defaults to the current behavior.

**`Game/Engine/IGamelogicEngine.cs`** - two optional capability interfaces + a documented contract:
- `IRomNameProvider { string RomName }` - lets a consumer resolve the active ROM (for colorization
  lookup) without reflection.
- `IDisplayFrameFormatPreference { void RequestDisplayFrameFormat(string displayId, DisplayFrameFormat format) }` - lets a consumer request a frame format per display (e.g. `Dmd4` for colorization vs `Dmd8`).
- Documented the threading / buffer-ownership **contract** on `OnDisplayUpdateFrame`: it must be
  raised on the Unity main thread, and `DisplayFrameData.Data` is only valid for the duration of the
  call (a subscriber that hands it to a worker thread must copy it).

Gamelogic engines opt in by implementing the interfaces (PinMAME does so in its own repo); engines
that don't are unaffected.

**`Display/DisplayComponent.cs`** - adds `bool ReceiveGamelogicFrames` (default `true`). When an
external owner (e.g. the DMD bridge's in-scene destination) takes over a display, it flips this off
so the built-in `DisplayPlayer` stops writing that display's texture.

**`Game/DisplayPlayer.cs`** - honors `ReceiveGamelogicFrames` on frame-update, clear, **and**
display-requested events (the last one prevents a blank-frame flicker and a redundant `Texture2D`
reallocation when an externally-owned display is re-requested mid-game). Minor `TryGetValue` cleanups.

**`Display/DotMatrixDisplayComponent.cs`**
- RGB24 frames are now copied to the texture with a vertical row flip, matching the orientation of
  the gray (`Dmd2/4/8`) path (`CopyData` gained a destination offset so it can copy row-by-row).
- The gray palette lookup uses a single `TryGetValue` instead of `ContainsKey` + indexer (two
  dictionary lookups per pixel → one).
- Removed a stray `FLIPX` debug log.