### PR TITLE
Make kinematic physics velocity-aware.

### DIFF
--- a/VisualPinball.Unity/Documentation~/developer-guide/packaging/materials.md
+++ b/VisualPinball.Unity/Documentation~/developer-guide/packaging/materials.md
@@ -92,7 +92,7 @@ This split is what keeps the schema portable. A profile can record "base color t
 
 ## Supported Material Types
 
-The schema currently defines seven material types:
+The schema currently defines eight material types:
 
 | VPE type | Purpose |
 | --- | --- |
@@ -103,6 +103,7 @@ The schema currently defines seven material types:
 | `vpe.rubber` | VPE rubber shader graph materials. The profile stores a player template key and a `vpe.lit` fallback payload. |
 | `vpe.dmd` | Dot-matrix display materials. The profile stores a player template key, with no `vpe.lit` fallback. |
 | `vpe.fabric.silk` | HDRP fabric/silk materials. The profile carries a `vpe.lit` fallback plus HDRP thread/fuzz hints. |
+| `vpe.insert` | Playfield-insert parts (lens and reflector). The profile carries a part role plus a full `vpe.lit` payload. |
 
 The HDRP translator maps these authoring shaders into those types:
 
@@ -115,6 +116,8 @@ The HDRP translator maps these authoring shaders into those types:
 | VPE metal shader graph | `vpe.metal` |
 | VPE rubber shader graph | `vpe.rubber` |
 | VPE DMD shader graph | `vpe.dmd` |
+
+`vpe.insert` is not selected by shader name. It is a *promotion* of `vpe.lit`: an `HDRP/Lit` material is re-typed as an insert when the translator's scene heuristic identifies it as one (see the `vpe.insert` spec below). The captured data is the same lit payload either way.
 
 Unsupported shaders are not fatal: they produce no VPE profile, and runtime falls back to the imported GLB material for them.
 
@@ -255,6 +258,25 @@ Unlike `vpe.metal`/`vpe.rubber`, `vpe.dmd` carries **no** `vpe.lit` fallback: a 
 | `Fabric.Hdrp` | HDRP fabric/silk hints: optional thread map (with AO/normal/smoothness strengths and UV channel) and fuzz map (with strength and UV scale). |
 
 For HDRP, `HdrpMaterialResolver` clones the fabric/silk template and applies the hints; if no fabric template is configured it returns no material (the imported fallback then stays in place). Other pipelines can render the carried `vpe.lit` fallback.
+
+### `vpe.insert`
+
+`vpe.insert` marks the two physical parts of a playfield insert: the *lens* flush with the playfield surface, and the faceted *reflector* body below it that shapes the lamp light. In HDRP both parts are ordinary translucent Lit materials, so the profile carries no data beyond a plain `vpe.lit` payload — the semantic type exists for pipelines **without** HDRP's translucency, diffusion profiles, and refraction. Knowing "this is an insert lens" lets such a pipeline substitute a purpose-built approximation instead of a generic (and hopeless) translation of a 10%-alpha transmissive surface.
+
+| VPE field | Meaning |
+| --- | --- |
+| `Insert.Part` | `lens` or `reflector`. |
+| `Insert.Lit` | Full portable material intent, identical in shape to a `vpe.lit` payload (transmittance color, thickness map, IOR, refraction model, normal map, surface state, HDRP hints). |
+
+**Classification** happens at export time, by heuristic rather than by shader: a transparent, transmissive `HDRP/Lit` material used by a renderer that sits under a `LightComponent` is an insert part. The part with a refraction model is the reflector; the one without is the lens. Opaque emissive materials under the same light (faux bulbs) are unaffected and stay `vpe.lit`.
+
+**Color identity caveat for readers:** in authored tables, a *reflector's* saturated color is its transmittance tint, while a *lens* usually carries its color in the base color — lens transmittance is often a generic value shared across all insert colors. A renderer approximating inserts should pick its tint source per part accordingly.
+
+**Realization:**
+
+- HDRP resolves `Insert.Lit` through exactly the same path as `vpe.lit` (translucent template plus hints); output is identical to the pre-`vpe.insert` behavior.
+- URP builds both parts as alpha-blended URP/Lit materials: the tint becomes the visible body color (with a per-part opacity floor), and the lamp glow becomes emission whose baseline the runtime lamp system (`LightComponent`) reads at startup, zeroes, and then drives with the live lamp value. Because the parts stay in the transparent render queue, the lamp system treats them as lamp-lit *surfaces* (emission drive only) rather than faux bulbs (which are hidden when the lamp is off).
+- A resolver that does not implement `vpe.insert` should skip it; runtime then keeps the imported GLB material, like any unsupported type.
 
 ### Renderer state
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/KinematicVelocityState.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/KinematicVelocityState.cs
@@ -31,12 +31,17 @@ namespace VisualPinball.Unity
 	internal struct KinematicVelocityState
 	{
 		/// <summary>
-		/// Linear velocity of the transform origin, in VPX units per second, playfield space.
+		/// Linear velocity of the transform origin, in VPX units per
+		/// <see cref="VisualPinball.Engine.Common.PhysicsConstants.DefaultStepTime"/>
+		/// (10 ms — the VP convention, same time base as <see cref="BallState.Velocity"/>),
+		/// playfield space.
 		/// </summary>
 		internal float3 LinearVelocity;
 
 		/// <summary>
-		/// Angular velocity in radians per second, playfield space.
+		/// Angular velocity in radians per
+		/// <see cref="VisualPinball.Engine.Common.PhysicsConstants.DefaultStepTime"/>
+		/// (10 ms), playfield space.
 		/// </summary>
 		internal float3 AngularVelocity;
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/KinematicVelocityState.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/KinematicVelocityState.cs
@@ -57,6 +57,24 @@ namespace VisualPinball.Unity
 		/// </summary>
 		internal ulong LastUpdateUsec;
 
+		/// <summary>
+		/// Instantaneous velocity of the actual pose step this tick (same unit
+		/// as <see cref="LinearVelocity"/>), written by
+		/// <see cref="PhysicsKinematics.StepKinematics"/> — nonzero only while
+		/// the pose catch-up is rate-limited (clamped stepping). During
+		/// catch-up, the true surface velocity is the step rate, which can
+		/// exceed the update-derived velocity; hit tests and contact response
+		/// must see it, or the stepping face outruns the balls it hammers and
+		/// swallows them.
+		/// </summary>
+		internal float3 StepVelocity;
+
+		/// <summary>
+		/// Instantaneous angular velocity of the actual pose step this tick
+		/// (same unit as <see cref="AngularVelocity"/>).
+		/// </summary>
+		internal float3 StepAngularVelocity;
+
 		internal bool IsMoving => math.lengthsq(LinearVelocity) > 1e-8f || math.lengthsq(AngularVelocity) > 1e-8f;
 
 		/// <summary>

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/KinematicVelocityState.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/KinematicVelocityState.cs
@@ -1,0 +1,62 @@
+// Visual Pinball Engine
+// Copyright (C) 2026 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Unity.Mathematics;
+
+namespace VisualPinball.Unity
+{
+	/// <summary>
+	/// The velocity of a kinematic item, derived from its transform updates
+	/// (see <see cref="PhysicsKinematics.DeriveVelocity"/>).
+	/// </summary>
+	/// <remarks>
+	/// Collision and contact resolution use this to compute the surface
+	/// velocity of a kinematic collider at the contact point, so that a
+	/// moving collider imparts momentum and friction to the ball instead of
+	/// acting like a static wall that teleports between poses.
+	/// </remarks>
+	internal struct KinematicVelocityState
+	{
+		/// <summary>
+		/// Linear velocity of the transform origin, in VPX units per second, playfield space.
+		/// </summary>
+		internal float3 LinearVelocity;
+
+		/// <summary>
+		/// Angular velocity in radians per second, playfield space.
+		/// </summary>
+		internal float3 AngularVelocity;
+
+		/// <summary>
+		/// Current position of the transform origin in playfield space, i.e. the point
+		/// that <see cref="LinearVelocity"/> refers to and <see cref="AngularVelocity"/>
+		/// rotates around.
+		/// </summary>
+		internal float3 Pivot;
+
+		/// <summary>
+		/// Physics time at which the velocity was last derived.
+		/// </summary>
+		internal ulong LastUpdateUsec;
+
+		internal bool IsMoving => math.lengthsq(LinearVelocity) > 1e-8f || math.lengthsq(AngularVelocity) > 1e-8f;
+
+		/// <summary>
+		/// Velocity of the item's surface at a given point, in playfield space.
+		/// </summary>
+		internal float3 GetVelocityAt(in float3 position) => LinearVelocity + math.cross(AngularVelocity, position - Pivot);
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/KinematicVelocityState.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/KinematicVelocityState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2e0a7222abee5c04cafd0a36ff118eaf

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsCycle.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsCycle.cs
@@ -37,7 +37,7 @@ namespace VisualPinball.Unity
 			_contacts = new NativeList<ContactBufferElement>(a);
 		}
 
-		internal void Simulate(ref PhysicsState state, ref NativeParallelHashSet<int> overlappingColliders, ref NativeOctree<int> kineticOctree, ref NativeOctree<int> ballOctree, float dTime)
+		internal void Simulate(ref PhysicsState state, ref NativeParallelHashSet<int> overlappingColliders, ref NativeOctree<int> kinematicOctree, ref NativeOctree<int> ballOctree, float dTime)
 		{
 			PerfMarker.Begin();
 			var staticCounts = PhysicsConstants.StaticCnts;
@@ -70,7 +70,7 @@ namespace VisualPinball.Unity
 						PhysicsStaticBroadPhase.FindOverlaps(in state.Octree, in ball, ref overlappingColliders);
 						PhysicsStaticNarrowPhase.FindNextCollision(ref state.Colliders, ref ball, ref overlappingColliders, ref _contacts, ref state);
 
-						PhysicsStaticBroadPhase.FindOverlaps(in kineticOctree, in ball, ref overlappingColliders);
+						PhysicsStaticBroadPhase.FindOverlaps(in kinematicOctree, in ball, ref overlappingColliders);
 						PhysicsStaticNarrowPhase.FindNextCollision(ref state.KinematicColliders, ref ball, ref overlappingColliders, ref _contacts, ref state);
 
 						// no negative time allowed

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngine.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngine.cs
@@ -498,6 +498,32 @@ namespace VisualPinball.Unity
 
 		public BallComponent GetBall(int itemId) => _ctx.BallComponents[itemId];
 
+		/// <summary>
+		/// Returns the current velocity of a kinematic item, derived from its
+		/// transform updates. Values are in VPX playfield space: linear velocity
+		/// of the transform origin in units per second, angular velocity in
+		/// radians per second, and the pivot the angular velocity refers to.
+		/// </summary>
+		/// <remarks>
+		/// Intended for debugging and visualization (e.g. editor gizmos).
+		/// Returns <c>false</c> if the item hasn't moved since the game started.
+		/// </remarks>
+		public bool TryGetKinematicVelocity(int itemId, out float3 linearVelocity, out float3 angularVelocity, out float3 pivot)
+		{
+			lock (_ctx.PhysicsLock) {
+				if (_ctx.KinematicVelocities.Ref.IsCreated && _ctx.KinematicVelocities.Ref.TryGetValue(itemId, out var velocity)) {
+					linearVelocity = velocity.LinearVelocity;
+					angularVelocity = velocity.AngularVelocity;
+					pivot = velocity.Pivot;
+					return true;
+				}
+			}
+			linearVelocity = float3.zero;
+			angularVelocity = float3.zero;
+			pivot = float3.zero;
+			return false;
+		}
+
 		#endregion
 
 		#region Forwarding — Simulation Thread
@@ -615,7 +641,7 @@ namespace VisualPinball.Unity
 			_ctx.Colliders = new NativeColliders(ref colliders, Allocator.Persistent);
 			_ctx.KinematicColliders = new NativeColliders(ref kinematicColliders, Allocator.Persistent);
 
-			// get kinetic collider matrices
+			// get kinematic collider matrices
 			_worldToPlayfield = playfield.transform.worldToLocalMatrix;
 			foreach (var coll in _kinematicColliderComponents) {
 				var matrix = coll.GetLocalToPlayfieldMatrixInVpx(_worldToPlayfield);

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngine.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngine.cs
@@ -500,9 +500,11 @@ namespace VisualPinball.Unity
 
 		/// <summary>
 		/// Returns the current velocity of a kinematic item, derived from its
-		/// transform updates. Values are in VPX playfield space: linear velocity
-		/// of the transform origin in units per second, angular velocity in
-		/// radians per second, and the pivot the angular velocity refers to.
+		/// transform updates. Values are in VPX playfield space and per second
+		/// (converted from the engine's internal per-10ms time base): linear
+		/// velocity of the transform origin in units per second, angular
+		/// velocity in radians per second, and the pivot the angular velocity
+		/// refers to.
 		/// </summary>
 		/// <remarks>
 		/// Intended for debugging and visualization (e.g. editor gizmos).
@@ -510,10 +512,12 @@ namespace VisualPinball.Unity
 		/// </remarks>
 		public bool TryGetKinematicVelocity(int itemId, out float3 linearVelocity, out float3 angularVelocity, out float3 pivot)
 		{
+			// engine time unit (DefaultStepTime, 10 ms) → seconds
+			const float perSecond = (float)(1e6 / PhysicsConstants.DefaultStepTime);
 			lock (_ctx.PhysicsLock) {
 				if (_ctx.KinematicVelocities.Ref.IsCreated && _ctx.KinematicVelocities.Ref.TryGetValue(itemId, out var velocity)) {
-					linearVelocity = velocity.LinearVelocity;
-					angularVelocity = velocity.AngularVelocity;
+					linearVelocity = velocity.LinearVelocity * perSecond;
+					angularVelocity = velocity.AngularVelocity * perSecond;
 					pivot = velocity.Pivot;
 					return true;
 				}

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngineContext.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngineContext.cs
@@ -139,13 +139,15 @@ namespace VisualPinball.Unity
 		public readonly LazyInit<NativeParallelHashMap<int, float4x4>> KinematicTransforms = new(() => new NativeParallelHashMap<int, float4x4>(0, Allocator.Persistent));
 
 		/// <summary>
-		/// The transforms of kinematic items that have changed since the last frame.
+		/// The target transforms of kinematic items that have moved. The physics loop
+		/// steps <see cref="KinematicTransforms"/> toward these per tick (capped, to
+		/// prevent tunneling); entries persist while the item keeps moving.
 		/// </summary>
 		/// <remarks>
 		/// Written by: sim thread (inside <c>PhysicsLock</c>) or main thread
 		/// (single-threaded mode). Read by: physics loop.
 		/// </remarks>
-		public readonly LazyInit<NativeParallelHashMap<int, float4x4>> UpdatedKinematicTransforms = new(() => new NativeParallelHashMap<int, float4x4>(0, Allocator.Persistent));
+		public readonly LazyInit<NativeParallelHashMap<int, float4x4>> KinematicTargetTransforms = new(() => new NativeParallelHashMap<int, float4x4>(0, Allocator.Persistent));
 
 		/// <summary>
 		/// The current velocities of kinematic items, derived from their
@@ -278,7 +280,7 @@ namespace VisualPinball.Unity
 		{
 			var events = EventQueue.Ref.AsParallelWriter();
 			return new PhysicsState(ref PhysicsEnv, ref Octree, ref Colliders, ref KinematicColliders,
-				ref KinematicCollidersAtIdentity, ref KinematicTransforms.Ref, ref UpdatedKinematicTransforms.Ref,
+				ref KinematicCollidersAtIdentity, ref KinematicTransforms.Ref, ref KinematicTargetTransforms.Ref,
 				ref NonTransformableColliderTransforms.Ref, ref KinematicColliderLookups, ref events,
 				ref InsideOfs, ref BallStates.Ref, ref BumperStates.Ref, ref DropTargetStates.Ref, ref FlipperStates.Ref, ref GateStates.Ref,
 				ref HitTargetStates.Ref, ref KickerStates.Ref, ref PlungerStates.Ref, ref SpinnerStates.Ref,
@@ -334,7 +336,7 @@ namespace VisualPinball.Unity
 
 			DisabledCollisionItems.Ref.Dispose();
 			KinematicTransforms.Ref.Dispose();
-			UpdatedKinematicTransforms.Ref.Dispose();
+			KinematicTargetTransforms.Ref.Dispose();
 			KinematicVelocities.Ref.Dispose();
 			PendingKinematicTransforms.Ref.Dispose();
 			NonTransformableColliderTransforms.Ref.Dispose();

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngineContext.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngineContext.cs
@@ -148,6 +148,17 @@ namespace VisualPinball.Unity
 		public readonly LazyInit<NativeParallelHashMap<int, float4x4>> UpdatedKinematicTransforms = new(() => new NativeParallelHashMap<int, float4x4>(0, Allocator.Persistent));
 
 		/// <summary>
+		/// The current velocities of kinematic items, derived from their
+		/// transform updates.
+		/// </summary>
+		/// <remarks>
+		/// Written by: sim thread (via <c>ApplyPendingKinematicTransforms</c>)
+		/// or main thread (single-threaded mode). Read by: physics loop
+		/// (collision and contact resolution).
+		/// </remarks>
+		public readonly LazyInit<NativeParallelHashMap<int, KinematicVelocityState>> KinematicVelocities = new(() => new NativeParallelHashMap<int, KinematicVelocityState>(0, Allocator.Persistent));
+
+		/// <summary>
 		/// The current matrix to which the ball will be transformed to, if
 		/// it collides with a non-transformable collider. This changes as
 		/// the non-transformable collider transforms (it's called
@@ -202,7 +213,16 @@ namespace VisualPinball.Unity
 		public readonly LazyInit<NativeParallelHashMap<int, float4x4>> PendingKinematicTransforms = new(() => new NativeParallelHashMap<int, float4x4>(0, Allocator.Persistent));
 
 		/// <summary>
-		/// Lock protecting <see cref="PendingKinematicTransforms"/>.
+		/// Item IDs of kinematic items that stopped moving, staged by the main
+		/// thread. The sim thread zeroes their velocities when draining. Unlike
+		/// transform updates, a stop neither re-transforms colliders nor dirties
+		/// the octree. Protected by <see cref="PendingKinematicLock"/>.
+		/// </summary>
+		public readonly List<int> PendingKinematicStops = new();
+
+		/// <summary>
+		/// Lock protecting <see cref="PendingKinematicTransforms"/> and
+		/// <see cref="PendingKinematicStops"/>.
 		/// Lock ordering: sim thread may hold <c>PhysicsLock</c> then
 		/// acquire <c>PendingKinematicLock</c>.
 		/// </summary>
@@ -263,7 +283,7 @@ namespace VisualPinball.Unity
 				ref InsideOfs, ref BallStates.Ref, ref BumperStates.Ref, ref DropTargetStates.Ref, ref FlipperStates.Ref, ref GateStates.Ref,
 				ref HitTargetStates.Ref, ref KickerStates.Ref, ref PlungerStates.Ref, ref SpinnerStates.Ref,
 				ref SurfaceStates.Ref, ref TriggerStates.Ref, ref DisabledCollisionItems.Ref, ref SwapBallCollisionHandling,
-				ref ElasticityOverVelocityLUTs, ref FrictionOverVelocityLUTs);
+				ref ElasticityOverVelocityLUTs, ref FrictionOverVelocityLUTs, ref KinematicVelocities.Ref);
 		}
 
 		/// <summary>
@@ -315,6 +335,7 @@ namespace VisualPinball.Unity
 			DisabledCollisionItems.Ref.Dispose();
 			KinematicTransforms.Ref.Dispose();
 			UpdatedKinematicTransforms.Ref.Dispose();
+			KinematicVelocities.Ref.Dispose();
 			PendingKinematicTransforms.Ref.Dispose();
 			NonTransformableColliderTransforms.Ref.Dispose();
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngineThreading.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngineThreading.cs
@@ -58,6 +58,17 @@ namespace VisualPinball.Unity
 		private readonly List<Action> _dueSingleThreadScheduledActions = new();
 		private readonly List<PhysicsEngine.InputAction> _pendingInputActions = new();
 		private readonly List<KeyValuePair<int, float4x4>> _pendingKinematicUpdates = new();
+		private readonly List<int> _pendingKinematicStopUpdates = new();
+
+		/// <summary>
+		/// Kinematic items that moved on the last change-detection scan, so a
+		/// scan without change can zero their velocity ("stop detection").
+		/// Owned by whichever thread runs change detection: the main thread in
+		/// threaded mode (<see cref="UpdateKinematicTransformsFromMainThread"/>),
+		/// the main thread in single-threaded mode (<see cref="ExecutePhysicsUpdate"/>).
+		/// The two modes are mutually exclusive.
+		/// </summary>
+		private readonly HashSet<int> _movedKinematicItems = new();
 		private readonly int[] _snapshotFlipperIds;
 		private readonly int[] _snapshotBumperRingIds;
 		private readonly int[] _snapshotBumperSkirtIds;
@@ -208,12 +219,17 @@ namespace VisualPinball.Unity
 
 		/// <summary>
 		/// Apply kinematic transforms staged by the main thread into the
-		/// physics state maps.
+		/// physics state maps, deriving each item's velocity from the
+		/// transform delta. Also drains staged stop events, zeroing the
+		/// velocity of items that ceased moving.
 		/// </summary>
 		/// <remarks>
 		/// <b>Thread:</b> Simulation thread (inside <c>PhysicsLock</c>).<br/>
 		/// Lock ordering: <c>PhysicsLock</c> (held) then
-		/// <c>PendingKinematicLock</c> (inner).
+		/// <c>PendingKinematicLock</c> (inner).<br/>
+		/// Stops are processed after transforms: when a final move and its
+		/// subsequent stop are drained together, the item must end up with
+		/// zero velocity.
 		/// </remarks>
 		private void ApplyPendingKinematicTransforms()
 		{
@@ -222,20 +238,69 @@ namespace VisualPinball.Unity
 			_ctx.UpdatedKinematicTransforms.Ref.Clear();
 
 			lock (_ctx.PendingKinematicLock) {
-				if (_ctx.PendingKinematicTransforms.Ref.Count() == 0) return;
+				var nowUsec = _ctx.PhysicsEnv.CurPhysicsFrameTime;
 
-				using var enumerator = _ctx.PendingKinematicTransforms.Ref.GetEnumerator();
-				while (enumerator.MoveNext()) {
-					var itemId = enumerator.Current.Key;
-					var matrix = enumerator.Current.Value;
-					_ctx.UpdatedKinematicTransforms.Ref[itemId] = matrix;
-					_ctx.KinematicTransforms.Ref[itemId] = matrix;
+				if (_ctx.PendingKinematicTransforms.Ref.Count() > 0) {
+					using var enumerator = _ctx.PendingKinematicTransforms.Ref.GetEnumerator();
+					while (enumerator.MoveNext()) {
+						var itemId = enumerator.Current.Key;
+						var matrix = enumerator.Current.Value;
 
-					var coll = GetKinematicColliderComponent(itemId);
-					coll?.OnTransformationChanged(matrix);
+						DeriveKinematicVelocity(itemId, in matrix, nowUsec);
+
+						_ctx.UpdatedKinematicTransforms.Ref[itemId] = matrix;
+						_ctx.KinematicTransforms.Ref[itemId] = matrix;
+
+						var coll = GetKinematicColliderComponent(itemId);
+						coll?.OnTransformationChanged(matrix);
+					}
+					_ctx.PendingKinematicTransforms.Ref.Clear();
+					_ctx.KinematicOctreeDirty = true;
 				}
-				_ctx.PendingKinematicTransforms.Ref.Clear();
-				_ctx.KinematicOctreeDirty = true;
+
+				if (_ctx.PendingKinematicStops.Count > 0) {
+					foreach (var itemId in _ctx.PendingKinematicStops) {
+						StopKinematicVelocity(itemId, nowUsec);
+					}
+					_ctx.PendingKinematicStops.Clear();
+				}
+			}
+		}
+
+		/// <summary>
+		/// Derive an item's velocity from its previous and new transform, so
+		/// collision resolution can account for the motion of its colliders.
+		/// </summary>
+		/// <remarks>
+		/// <b>Thread:</b> Simulation thread (inside <c>PhysicsLock</c>), or
+		/// main thread in single-threaded mode.
+		/// </remarks>
+		private void DeriveKinematicVelocity(int itemId, in float4x4 currMatrix, ulong nowUsec)
+		{
+			var prevMatrix = _ctx.KinematicTransforms.Ref[itemId];
+			if (_ctx.KinematicVelocities.Ref.TryGetValue(itemId, out var prevVelocity)) {
+				_ctx.KinematicVelocities.Ref[itemId] = PhysicsKinematics.DeriveVelocity(in prevVelocity, in prevMatrix, in currMatrix, nowUsec);
+
+			} else {
+				// first update: establish a zero-velocity baseline, velocity kicks in with the next update
+				_ctx.KinematicVelocities.Ref[itemId] = new KinematicVelocityState {
+					Pivot = currMatrix.c3.xyz,
+					LastUpdateUsec = nowUsec,
+				};
+			}
+		}
+
+		/// <summary>
+		/// Zero the velocity of a kinematic item that stopped moving, keeping
+		/// its pivot so a later update derives from a valid baseline.
+		/// </summary>
+		private void StopKinematicVelocity(int itemId, ulong nowUsec)
+		{
+			if (_ctx.KinematicVelocities.Ref.TryGetValue(itemId, out var velocity)) {
+				velocity.LinearVelocity = float3.zero;
+				velocity.AngularVelocity = float3.zero;
+				velocity.LastUpdateUsec = nowUsec;
+				_ctx.KinematicVelocities.Ref[itemId] = velocity;
 			}
 		}
 
@@ -525,27 +590,36 @@ namespace VisualPinball.Unity
 			var scanStartTicks = Stopwatch.GetTimestamp();
 
 			_pendingKinematicUpdates.Clear();
+			_pendingKinematicStopUpdates.Clear();
 
 			foreach (var coll in _kinematicColliderComponents) {
 				var currMatrix = coll.GetLocalToPlayfieldMatrixInVpx(_worldToPlayfield);
 
 				// Check against main-thread cache
 				if (_ctx.MainThreadKinematicCache.TryGetValue(coll.ItemId, out var lastMatrix) && lastMatrix.Equals(currMatrix)) {
+					// unchanged — if it moved last frame, it just stopped, so stage a velocity reset
+					if (_movedKinematicItems.Remove(coll.ItemId)) {
+						_pendingKinematicStopUpdates.Add(coll.ItemId);
+					}
 					continue;
 				}
 
 				// Transform changed — update cache
 				_ctx.MainThreadKinematicCache[coll.ItemId] = currMatrix;
+				_movedKinematicItems.Add(coll.ItemId);
 				_pendingKinematicUpdates.Add(new KeyValuePair<int, float4x4>(coll.ItemId, currMatrix));
 			}
 
-			if (_pendingKinematicUpdates.Count == 0) {
+			if (_pendingKinematicUpdates.Count == 0 && _pendingKinematicStopUpdates.Count == 0) {
 				return;
 			}
 
 			lock (_ctx.PendingKinematicLock) {
 				foreach (var update in _pendingKinematicUpdates) {
 					_ctx.PendingKinematicTransforms.Ref[update.Key] = update.Value;
+				}
+				foreach (var itemId in _pendingKinematicStopUpdates) {
+					_ctx.PendingKinematicStops.Add(itemId);
 				}
 			}
 
@@ -578,8 +652,14 @@ namespace VisualPinball.Unity
 				var lastTransformationMatrix = _ctx.KinematicTransforms.Ref[coll.ItemId];
 				var currTransformationMatrix = coll.GetLocalToPlayfieldMatrixInVpx(_worldToPlayfield);
 				if (lastTransformationMatrix.Equals(currTransformationMatrix)) {
+					// unchanged — if it moved last frame, it just stopped, so zero its velocity
+					if (_movedKinematicItems.Remove(coll.ItemId)) {
+						StopKinematicVelocity(coll.ItemId, _ctx.PhysicsEnv.CurPhysicsFrameTime);
+					}
 					continue;
 				}
+				DeriveKinematicVelocity(coll.ItemId, in currTransformationMatrix, _ctx.PhysicsEnv.CurPhysicsFrameTime);
+				_movedKinematicItems.Add(coll.ItemId);
 				_ctx.UpdatedKinematicTransforms.Ref.Add(coll.ItemId, currTransformationMatrix);
 				_ctx.KinematicTransforms.Ref[coll.ItemId] = currTransformationMatrix;
 				coll.OnTransformationChanged(currTransformationMatrix);

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngineThreading.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngineThreading.cs
@@ -69,6 +69,22 @@ namespace VisualPinball.Unity
 		/// The two modes are mutually exclusive.
 		/// </summary>
 		private readonly HashSet<int> _movedKinematicItems = new();
+
+		/// <summary>
+		/// Large isolated transform jumps held for one-frame disambiguation: a
+		/// follow-up update means it was the first frame of continuous motion
+		/// (stream it, with derived velocity); a timeout means it was a genuine
+		/// teleport (snap silently, no impulse). Owned by the thread that stages
+		/// kinematic targets (sim thread, or main thread in single-threaded mode).
+		/// </summary>
+		private readonly Dictionary<int, HeldKinematicPose> _heldIsolatedPoses = new();
+		private readonly List<int> _heldPosesToApply = new();
+
+		private struct HeldKinematicPose
+		{
+			public float4x4 Pose;
+			public ulong HeldAtUsec;
+		}
 		private readonly int[] _snapshotFlipperIds;
 		private readonly int[] _snapshotBumperRingIds;
 		private readonly int[] _snapshotBumperSkirtIds;
@@ -235,27 +251,15 @@ namespace VisualPinball.Unity
 		{
 			if (!_ctx.PendingKinematicTransforms.Ref.IsCreated) return;
 
-			_ctx.UpdatedKinematicTransforms.Ref.Clear();
-
 			lock (_ctx.PendingKinematicLock) {
 				var nowUsec = _ctx.PhysicsEnv.CurPhysicsFrameTime;
 
 				if (_ctx.PendingKinematicTransforms.Ref.Count() > 0) {
 					using var enumerator = _ctx.PendingKinematicTransforms.Ref.GetEnumerator();
 					while (enumerator.MoveNext()) {
-						var itemId = enumerator.Current.Key;
-						var matrix = enumerator.Current.Value;
-
-						DeriveKinematicVelocity(itemId, in matrix, nowUsec);
-
-						_ctx.UpdatedKinematicTransforms.Ref[itemId] = matrix;
-						_ctx.KinematicTransforms.Ref[itemId] = matrix;
-
-						var coll = GetKinematicColliderComponent(itemId);
-						coll?.OnTransformationChanged(matrix);
+						StageKinematicTarget(enumerator.Current.Key, enumerator.Current.Value, nowUsec);
 					}
 					_ctx.PendingKinematicTransforms.Ref.Clear();
-					_ctx.KinematicOctreeDirty = true;
 				}
 
 				if (_ctx.PendingKinematicStops.Count > 0) {
@@ -264,30 +268,114 @@ namespace VisualPinball.Unity
 					}
 					_ctx.PendingKinematicStops.Clear();
 				}
+
+				ProcessHeldKinematicPoses(nowUsec);
+			}
+		}
+
+		/// <summary>
+		/// Stage a kinematic transform update: derive the velocity, then either set
+		/// the streaming target (continuous motion), snap directly (small isolated
+		/// nudge or warp), or hold for one-frame disambiguation (large isolated jump
+		/// — could be a teleport or the first frame of a fast drag; see
+		/// <see cref="PhysicsKinematics.IsolatedHoldDistance"/>).
+		/// </summary>
+		/// <remarks>
+		/// <b>Thread:</b> Simulation thread (inside <c>PhysicsLock</c>), or
+		/// main thread in single-threaded mode.
+		/// </remarks>
+		private void StageKinematicTarget(int itemId, in float4x4 matrix, ulong nowUsec)
+		{
+			var isIsolated = DeriveKinematicVelocity(itemId, in matrix, nowUsec, out var prevMatrix);
+			var wasHeld = _heldIsolatedPoses.Remove(itemId); // a follow-up resolves any hold
+
+			if (isIsolated && !wasHeld) {
+				if (PhysicsKinematics.IsSmallIsolatedDelta(in prevMatrix, in matrix)) {
+					// small isolated nudge / warp: apply as teleport, no impulse
+					SnapKinematicPose(itemId, in matrix);
+				} else {
+					// large isolated jump: hold for disambiguation
+					_heldIsolatedPoses[itemId] = new HeldKinematicPose { Pose = matrix, HeldAtUsec = nowUsec };
+				}
+			} else {
+				// continuous motion (incl. resolving a hold): stream toward the target,
+				// capped per tick, so a fast collider can't skip past a ball
+				_ctx.KinematicTargetTransforms.Ref[itemId] = matrix;
+				_ctx.KinematicOctreeDirty = true;
+			}
+
+			var coll = GetKinematicColliderComponent(itemId);
+			coll?.OnTransformationChanged(matrix);
+		}
+
+		/// <summary>
+		/// Apply a pose directly with teleport semantics: no stepping, no velocity,
+		/// no impulse — the item is just somewhere else now.
+		/// </summary>
+		private void SnapKinematicPose(int itemId, in float4x4 matrix)
+		{
+			_ctx.KinematicTransforms.Ref[itemId] = matrix;
+			_ctx.KinematicTargetTransforms.Ref[itemId] = matrix; // keep in sync, stepping skips equal poses
+
+			var state = _ctx.CreateState();
+			ref var colliderLookups = ref _ctx.KinematicColliderLookups.GetValueByRef(itemId);
+			for (var i = 0; i < colliderLookups.Length; i++) {
+				state.TransformKinematicColliders(colliderLookups[i], matrix);
+			}
+			_ctx.KinematicOctreeDirty = true;
+		}
+
+		/// <summary>
+		/// Apply held isolated poses whose disambiguation window expired without a
+		/// follow-up update: they were genuine teleports.
+		/// </summary>
+		private void ProcessHeldKinematicPoses(ulong nowUsec)
+		{
+			if (_heldIsolatedPoses.Count == 0) {
+				return;
+			}
+			_heldPosesToApply.Clear();
+			foreach (var kvp in _heldIsolatedPoses) {
+				if (nowUsec - kvp.Value.HeldAtUsec >= PhysicsKinematics.IsolatedHoldTimeoutUsec) {
+					_heldPosesToApply.Add(kvp.Key);
+				}
+			}
+			foreach (var itemId in _heldPosesToApply) {
+				SnapKinematicPose(itemId, _heldIsolatedPoses[itemId].Pose);
+				_heldIsolatedPoses.Remove(itemId);
 			}
 		}
 
 		/// <summary>
 		/// Derive an item's velocity from its previous and new transform, so
 		/// collision resolution can account for the motion of its colliders.
+		/// Returns whether the update was isolated (no velocity derived).
 		/// </summary>
 		/// <remarks>
 		/// <b>Thread:</b> Simulation thread (inside <c>PhysicsLock</c>), or
-		/// main thread in single-threaded mode.
+		/// main thread in single-threaded mode.<br/>
+		/// The previous matrix is the held pose if one exists, else the previous
+		/// <i>target</i> (the true motion timeline as staged), not the
+		/// possibly-lagging stepped pose.
 		/// </remarks>
-		private void DeriveKinematicVelocity(int itemId, in float4x4 currMatrix, ulong nowUsec)
+		private bool DeriveKinematicVelocity(int itemId, in float4x4 currMatrix, ulong nowUsec, out float4x4 prevMatrix)
 		{
-			var prevMatrix = _ctx.KinematicTransforms.Ref[itemId];
-			if (_ctx.KinematicVelocities.Ref.TryGetValue(itemId, out var prevVelocity)) {
-				_ctx.KinematicVelocities.Ref[itemId] = PhysicsKinematics.DeriveVelocity(in prevVelocity, in prevMatrix, in currMatrix, nowUsec);
-
-			} else {
-				// first update: establish a zero-velocity baseline, velocity kicks in with the next update
-				_ctx.KinematicVelocities.Ref[itemId] = new KinematicVelocityState {
-					Pivot = currMatrix.c3.xyz,
-					LastUpdateUsec = nowUsec,
-				};
+			if (_heldIsolatedPoses.TryGetValue(itemId, out var held)) {
+				prevMatrix = held.Pose;
+			} else if (!_ctx.KinematicTargetTransforms.Ref.TryGetValue(itemId, out prevMatrix)) {
+				prevMatrix = _ctx.KinematicTransforms.Ref[itemId];
 			}
+			if (_ctx.KinematicVelocities.Ref.TryGetValue(itemId, out var prevVelocity)) {
+				_ctx.KinematicVelocities.Ref[itemId] = PhysicsKinematics.DeriveVelocity(in prevVelocity, in prevMatrix, in currMatrix, nowUsec, out var isIsolated);
+				return isIsolated;
+			}
+
+			// first update: establish a zero-velocity baseline, velocity kicks in with the next update
+			_ctx.KinematicVelocities.Ref[itemId] = new KinematicVelocityState {
+				Pivot = currMatrix.c3.xyz,
+				LastUpdateUsec = nowUsec,
+			};
+			return true;
 		}
 
 		/// <summary>
@@ -646,10 +734,16 @@ namespace VisualPinball.Unity
 		{
 			var sw = Stopwatch.StartNew();
 
-			// check for updated kinematic transforms
-			_ctx.UpdatedKinematicTransforms.Ref.Clear();
+			// check for updated kinematic transforms; compare against the last staged
+			// pose — held or target — not the stepped current pose, which may lag
+			// behind while catching up
 			foreach (var coll in _kinematicColliderComponents) {
-				var lastTransformationMatrix = _ctx.KinematicTransforms.Ref[coll.ItemId];
+				float4x4 lastTransformationMatrix;
+				if (_heldIsolatedPoses.TryGetValue(coll.ItemId, out var held)) {
+					lastTransformationMatrix = held.Pose;
+				} else if (!_ctx.KinematicTargetTransforms.Ref.TryGetValue(coll.ItemId, out lastTransformationMatrix)) {
+					lastTransformationMatrix = _ctx.KinematicTransforms.Ref[coll.ItemId];
+				}
 				var currTransformationMatrix = coll.GetLocalToPlayfieldMatrixInVpx(_worldToPlayfield);
 				if (lastTransformationMatrix.Equals(currTransformationMatrix)) {
 					// unchanged — if it moved last frame, it just stopped, so zero its velocity
@@ -658,13 +752,10 @@ namespace VisualPinball.Unity
 					}
 					continue;
 				}
-				DeriveKinematicVelocity(coll.ItemId, in currTransformationMatrix, _ctx.PhysicsEnv.CurPhysicsFrameTime);
 				_movedKinematicItems.Add(coll.ItemId);
-				_ctx.UpdatedKinematicTransforms.Ref.Add(coll.ItemId, currTransformationMatrix);
-				_ctx.KinematicTransforms.Ref[coll.ItemId] = currTransformationMatrix;
-				coll.OnTransformationChanged(currTransformationMatrix);
-				_ctx.KinematicOctreeDirty = true;
+				StageKinematicTarget(coll.ItemId, in currTransformationMatrix, _ctx.PhysicsEnv.CurPhysicsFrameTime);
 			}
+			ProcessHeldKinematicPoses(_ctx.PhysicsEnv.CurPhysicsFrameTime);
 
 			var state = _ctx.CreateState();
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngineThreading.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngineThreading.cs
@@ -382,6 +382,14 @@ namespace VisualPinball.Unity
 		/// Zero the velocity of a kinematic item that stopped moving, keeping
 		/// its pivot so a later update derives from a valid baseline.
 		/// </summary>
+		/// <remarks>
+		/// The step velocities are deliberately left untouched: the pose may
+		/// still be catching up to its target, and while it does, the collider
+		/// really is still moving — <see cref="PhysicsKinematics.StepKinematics"/>
+		/// re-derives them from the actual step each tick (they carry the
+		/// catch-up pace and keep hit tests honest) and zeroes them the tick
+		/// the pose settles, before any hit test runs.
+		/// </remarks>
 		private void StopKinematicVelocity(int itemId, ulong nowUsec)
 		{
 			if (_ctx.KinematicVelocities.Ref.TryGetValue(itemId, out var velocity)) {

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngineThreading.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsEngineThreading.cs
@@ -383,16 +383,24 @@ namespace VisualPinball.Unity
 		/// its pivot so a later update derives from a valid baseline.
 		/// </summary>
 		/// <remarks>
-		/// The step velocities are deliberately left untouched: the pose may
-		/// still be catching up to its target, and while it does, the collider
-		/// really is still moving — <see cref="PhysicsKinematics.StepKinematics"/>
-		/// re-derives them from the actual step each tick (they carry the
-		/// catch-up pace and keep hit tests honest) and zeroes them the tick
-		/// the pose settles, before any hit test runs.
+		/// The derived velocity is handed over to the step velocities instead of
+		/// just being cleared: the pose may still be catching up to its target,
+		/// and while it does, the collider really is still moving — the step
+		/// velocities keep the catch-up classified as continuous (no teleport
+		/// snap of the remaining gap) and carry its pace. This also covers the
+		/// case where the final transform update and the stop are drained
+		/// together, before <see cref="PhysicsKinematics.StepKinematics"/> ever
+		/// ran for that target — the step velocities would otherwise still be
+		/// zero. From here on, StepKinematics re-derives them from the actual
+		/// step each tick and zeroes them the tick the pose settles, before any
+		/// hit test runs; if the pose is already settled, the seeded values are
+		/// cleared the same way on the next tick.
 		/// </remarks>
 		private void StopKinematicVelocity(int itemId, ulong nowUsec)
 		{
 			if (_ctx.KinematicVelocities.Ref.TryGetValue(itemId, out var velocity)) {
+				velocity.StepVelocity = velocity.LinearVelocity;
+				velocity.StepAngularVelocity = velocity.AngularVelocity;
 				velocity.LinearVelocity = float3.zero;
 				velocity.AngularVelocity = float3.zero;
 				velocity.LastUpdateUsec = nowUsec;

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsKinematics.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsKinematics.cs
@@ -137,8 +137,17 @@ namespace VisualPinball.Unity
 					}
 				}
 
+				// active step motion also counts as continuous: after a stop event, the
+				// derived velocity is already zeroed while the pose may still be
+				// catching up — the remaining gap must keep streaming (paced by
+				// StepVelocity), not get mistaken for an isolated warp and snapped
+				// through balls by the teleport branch of StepTowards
+				var continuous = hasVelocity && (velocity.IsMoving
+					|| math.lengthsq(velocity.StepVelocity) > 0f
+					|| math.lengthsq(velocity.StepAngularVelocity) > 0f);
+
 				var before = current;
-				current = StepTowards(in current, in target, hasVelocity && velocity.IsMoving, maxLinearStep, maxAngularStep, out var jumped);
+				current = StepTowards(in current, in target, continuous, maxLinearStep, maxAngularStep, out var jumped);
 
 				if (hasVelocity) {
 					if (jumped) {
@@ -378,6 +387,12 @@ namespace VisualPinball.Unity
 			PerfMarkerBallOctree.Begin();
 			octree.Clear();
 
+			// the sweep inflation is per item; colliders of the same item are usually
+			// contiguous, so a one-entry memo avoids recomputing it per collider
+			var memoItemId = -1;
+			var memoAngle = 0f;
+			var memoPivot = float3.zero;
+
 			for (var i = 0; i < state.KinematicCollidersAtIdentity.Length; i++) {
 				// while an item steps toward its target pose, cover the whole swept
 				// range: union of the AABBs at the current and at the target pose,
@@ -391,6 +406,32 @@ namespace VisualPinball.Unity
 						math.min(aabb.Top, targetAabb.Top), math.max(aabb.Bottom, targetAabb.Bottom),
 						math.min(aabb.ZLow, targetAabb.ZLow), math.max(aabb.ZHigh, targetAabb.ZHigh)
 					);
+
+					// a rotating collider can swing outside the union of its endpoint
+					// boxes mid-sweep (e.g. a long thin collider rotating 45° bulges
+					// out at 22.5°); inflate by the maximal arc protrusion,
+					// reach × (1 - cos(angle/2)), so intermediate stepped poses stay
+					// inside the broad-phase bounds
+					if (itemId != memoItemId) {
+						memoItemId = itemId;
+						ref var currMatrix = ref state.KinematicTransforms.GetValueByRef(itemId);
+						var targetMatrix = state.KinematicTargetTransforms[itemId];
+						var qDot = math.abs(math.dot(RotationOf(in currMatrix).value, RotationOf(in targetMatrix).value));
+						memoAngle = 2f * math.acos(math.clamp(qDot, -1f, 1f));
+						memoPivot = currMatrix.c3.xyz;
+					}
+					if (memoAngle > 1e-4f) {
+						var dx = math.max(math.abs(aabb.Left - memoPivot.x), math.abs(aabb.Right - memoPivot.x));
+						var dy = math.max(math.abs(aabb.Top - memoPivot.y), math.abs(aabb.Bottom - memoPivot.y));
+						var dz = math.max(math.abs(aabb.ZLow - memoPivot.z), math.abs(aabb.ZHigh - memoPivot.z));
+						var reach = math.length(new float3(dx, dy, dz));
+						var inflate = reach * (1f - math.cos(memoAngle * 0.5f));
+						aabb = new Aabb(
+							aabb.Left - inflate, aabb.Right + inflate,
+							aabb.Top - inflate, aabb.Bottom + inflate,
+							aabb.ZLow - inflate, aabb.ZHigh + inflate
+						);
+					}
 				}
 				octree.Insert(i, aabb);
 			}

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsKinematics.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsKinematics.cs
@@ -411,7 +411,16 @@ namespace VisualPinball.Unity
 					// boxes mid-sweep (e.g. a long thin collider rotating 45° bulges
 					// out at 22.5°); inflate by the maximal arc protrusion,
 					// reach × (1 - cos(angle/2)), so intermediate stepped poses stay
-					// inside the broad-phase bounds
+					// inside the broad-phase bounds.
+					//
+					// This bound is conservative for any shape, including long thin
+					// colliders rotating about one end: every material point's two
+					// endpoint positions lie inside this single (hence convex) box,
+					// which therefore contains the straight chord between them; the
+					// stepped path (lerped translation + slerped rotation) deviates
+					// from that chord only by the rotational arc's sagitta,
+					// r × (1 - cos(angle/2)) with r ≤ reach — exactly the inflation.
+					// The rotate-about-one-end case attains this bound with equality.
 					if (itemId != memoItemId) {
 						memoItemId = itemId;
 						ref var currMatrix = ref state.KinematicTransforms.GetValueByRef(itemId);

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsKinematics.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsKinematics.cs
@@ -17,6 +17,7 @@
 using NativeTrees;
 using Unity.Mathematics;
 using Unity.Profiling;
+using VisualPinball.Engine.Common;
 using VisualPinball.Unity.Collections;
 
 namespace VisualPinball.Unity
@@ -27,11 +28,14 @@ namespace VisualPinball.Unity
 		private static readonly ProfilerMarker PerfMarkerBallOctree = new("CreateKinematicOctree");
 
 		/// <summary>
-		/// Maximal time window used for velocity derivation. When an item starts moving
-		/// after being idle, the elapsed time since its last update can be arbitrarily
-		/// large, which would dilute one frame of motion into a near-zero velocity.
+		/// Maximal gap between two transform updates for them to count as continuous
+		/// motion. The first update after a longer pause imparts no velocity — it's a
+		/// discrete re-position (editor nudge, scripted placement), not motion; velocity
+		/// kicks in from the second update of a motion sequence. The window is generous
+		/// enough that low-cadence updates (e.g. 10 Hz mech events) stay continuous,
+		/// with the actual gap as dt, so the derived velocity is the true average.
 		/// </summary>
-		private const float MaxVelocityDtSec = 0.1f;
+		private const float ContinuityWindowSec = 0.25f;
 
 		/// <summary>
 		/// Per-update displacement above which the update is treated as a teleport,
@@ -92,7 +96,18 @@ namespace VisualPinball.Unity
 				};
 			}
 
-			var dt = math.min((nowUsec - prev.LastUpdateUsec) * 1e-6f, MaxVelocityDtSec);
+			var dtSec = (nowUsec - prev.LastUpdateUsec) * 1e-6f;
+
+			// isolated update after idle: re-baseline without imparting velocity
+			if (dtSec > ContinuityWindowSec) {
+				return new KinematicVelocityState { Pivot = pivot, LastUpdateUsec = nowUsec };
+			}
+
+			// IMPORTANT: physics velocities are VPX units per DefaultStepTime (10 ms) —
+			// the VP convention, same time base as BallState.Velocity. Deriving per
+			// second yields values 100× too large and catapults balls on contact.
+			var dt = (float)((nowUsec - prev.LastUpdateUsec) / PhysicsConstants.DefaultStepTime);
+
 			var deltaPos = pivot - prevMatrix.c3.xyz;
 
 			var q0 = RotationOf(in prevMatrix);

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsKinematics.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsKinematics.cs
@@ -38,31 +38,199 @@ namespace VisualPinball.Unity
 		private const float ContinuityWindowSec = 0.25f;
 
 		/// <summary>
-		/// Per-update displacement above which the update is treated as a teleport,
-		/// i.e. no velocity is imparted. Protects against scripted warps and
-		/// initial placement.
+		/// Per-update displacement above which an update is treated as a teleport,
+		/// i.e. no velocity is imparted. This only guards <i>mid-motion</i> warps —
+		/// isolated jumps are already handled by the continuity window and the
+		/// isolated-hold disambiguation. It must be generous: at 400 units per
+		/// ~16 ms frame it corresponds to ~26,000 u/s (14 m/s) sustained motion,
+		/// so even violent editor drags derive a velocity and stream instead of
+		/// snap-teleporting through balls.
 		/// </summary>
-		private const float TeleportDistance = 100f; // VPX units
+		private const float TeleportDistance = 400f; // VPX units
 
 		/// <summary>
 		/// Per-update rotation above which the update is treated as a teleport.
 		/// </summary>
 		private const float TeleportAngle = math.PI / 3f; // 60°
 
-		internal static void TransformFullyTransformableColliders(ref PhysicsState state)
+		/// <summary>
+		/// Remaining delta up to which the pose is applied as a single jump, in VPX
+		/// units (below a ball radius, with margin). This preserves the classic
+		/// per-frame-jump behavior for all normal speeds: a touching ball ends up
+		/// slightly embedded in the collider skin, where the contact/embedded code
+		/// <i>carries</i> it gently at the surface velocity. Only larger deltas —
+		/// which could skip past a ball entirely — are spread into paced sub-steps
+		/// (where a pushed ball bounces harder; acceptable for rare fast movement).
+		/// </summary>
+		private const float MaxLinearJumpPerTick = 20f;
+
+		/// <summary>
+		/// Rotational analog of <see cref="MaxLinearJumpPerTick"/> (5° per update
+		/// ≈ 300°/s at 60 fps before sub-stepping engages).
+		/// </summary>
+		private const float MaxAngularJumpPerTick = math.PI * 5f / 180f;
+
+		/// <summary>
+		/// Maximal collider pose movement per 1 ms tick during paced sub-stepping,
+		/// in VPX units (half a ball radius). Guarantees no sub-tick step can pass
+		/// a ball. This is only the anti-tunneling ceiling — the actual step size
+		/// is paced at the item's own velocity, so balls feel the true surface
+		/// speed, never the ceiling rate.
+		/// </summary>
+		private const float MaxLinearStepPerTick = 12.5f;
+
+		/// <summary>
+		/// Maximal collider pose rotation per 1 ms tick (3° — 3000°/s, far above
+		/// any mech; caps the sweep of long rotating colliders per tick).
+		/// </summary>
+		private const float MaxAngularStepPerTick = math.PI * 3f / 180f;
+
+		/// <summary>
+		/// Pose steps are paced slightly above the item's measured velocity, so a
+		/// lagging pose (frame hitches, hold resolution) converges back onto its
+		/// target over a few frames instead of bursting at the anti-tunneling
+		/// ceiling — a burst would hammer touching balls at the ceiling rate
+		/// instead of the true surface speed.
+		/// </summary>
+		private const float CatchUpFactor = 1.25f;
+
+		/// <summary>
+		/// Steps every moving kinematic item's current pose toward its target pose
+		/// and re-transforms its colliders. Called once per tick; a no-op for items
+		/// that have reached their target.
+		/// </summary>
+		internal static void StepKinematics(ref PhysicsState state)
 		{
 			PerfMarkerTransform.Begin();
-			using var enumerator = state.UpdatedKinematicTransforms.GetEnumerator();
+			using var enumerator = state.KinematicTargetTransforms.GetEnumerator();
 			while (enumerator.MoveNext()) {
-				ref var matrix = ref enumerator.Current.Value;
+				ref var target = ref enumerator.Current.Value;
 				var itemId = enumerator.Current.Key;
+
+				ref var current = ref state.KinematicTransforms.GetValueByRef(itemId);
+				var hasVelocity = state.KinematicVelocities.TryGetValue(itemId, out var velocity);
+				if (current.Equals(target)) {
+					// pose settled: clear the step-velocity fallback
+					if (hasVelocity && (math.lengthsq(velocity.StepVelocity) > 0f || math.lengthsq(velocity.StepAngularVelocity) > 0f)) {
+						velocity.StepVelocity = float3.zero;
+						velocity.StepAngularVelocity = float3.zero;
+						state.KinematicVelocities[itemId] = velocity;
+					}
+					continue;
+				}
+
+				// pace the step at the item's own speed (per tick), so touching balls
+				// feel the true surface velocity; StepVelocity carries the pace across
+				// the final catch-up after the derived velocity was zeroed by a stop
+				var maxLinearStep = MaxLinearStepPerTick;
+				var maxAngularStep = MaxAngularStepPerTick;
+				if (hasVelocity) {
+					var paceLin = math.max(math.length(velocity.LinearVelocity), math.length(velocity.StepVelocity))
+						* CatchUpFactor * PhysicsConstants.PhysFactor;
+					var paceAng = math.max(math.length(velocity.AngularVelocity), math.length(velocity.StepAngularVelocity))
+						* CatchUpFactor * PhysicsConstants.PhysFactor;
+					if (paceLin > 1e-6f) {
+						maxLinearStep = math.min(paceLin, MaxLinearStepPerTick);
+					}
+					if (paceAng > 1e-8f) {
+						maxAngularStep = math.min(paceAng, MaxAngularStepPerTick);
+					}
+				}
+
+				var before = current;
+				current = StepTowards(in current, in target, hasVelocity && velocity.IsMoving, maxLinearStep, maxAngularStep, out var jumped);
+
+				if (hasVelocity) {
+					if (jumped) {
+						// single-jump application (normal speeds) or teleport snap: the
+						// derived velocity is authoritative for the ball response — the
+						// jump itself must not be reported as velocity
+						velocity.StepVelocity = float3.zero;
+						velocity.StepAngularVelocity = float3.zero;
+
+					} else {
+						// record the actual step rate; paced at the item's velocity, this
+						// stays at (or slightly above) the derived velocity, so the ball
+						// response matches the true surface speed
+						velocity.StepVelocity = (current.c3.xyz - before.c3.xyz) / PhysicsConstants.PhysFactor;
+						var q0 = RotationOf(in before);
+						var q1 = RotationOf(in current);
+						var qd = math.mul(q1, math.inverse(q0));
+						if (qd.value.w < 0f) {
+							qd.value = -qd.value;
+						}
+						var stepAngle = 2f * math.acos(math.clamp(qd.value.w, -1f, 1f));
+						var stepAxisLenSq = math.lengthsq(qd.value.xyz);
+						velocity.StepAngularVelocity = stepAngle > 1e-6f && stepAxisLenSq > 1e-12f
+							? qd.value.xyz * math.rsqrt(stepAxisLenSq) * (stepAngle / PhysicsConstants.PhysFactor)
+							: float3.zero;
+					}
+					state.KinematicVelocities[itemId] = velocity;
+				}
 
 				ref var colliderLookups = ref state.KinematicColliderLookups.GetValueByRef(itemId);
 				for (var i = 0; i < colliderLookups.Length; i++) {
-					state.TransformKinematicColliders(colliderLookups[i], matrix);
+					state.TransformKinematicColliders(colliderLookups[i], current);
 				}
 			}
 			PerfMarkerTransform.End();
+		}
+
+		/// <summary>
+		/// Returns the pose one tick-step closer to the target. Deltas within
+		/// <see cref="MaxLinearJumpPerTick"/> / <see cref="MaxAngularJumpPerTick"/>
+		/// are applied as a single jump (the classic behavior, gentle embedded
+		/// carry); larger ones step at the given paced limits. An <i>isolated</i>
+		/// delta beyond the teleport thresholds snaps to the target directly (a warp
+		/// shouldn't sweep through balls); during continuous motion, large deltas
+		/// keep stepping, so fast drags stream instead of teleporting. Scale is
+		/// taken from the target (scale animation is unsupported, see
+		/// <see cref="RotationOf"/>).
+		/// </summary>
+		private static float4x4 StepTowards(in float4x4 current, in float4x4 target, bool continuous,
+			float maxLinearStep, float maxAngularStep, out bool jumped)
+		{
+			var pC = current.c3.xyz;
+			var pT = target.c3.xyz;
+			var delta = pT - pC;
+			var dist = math.length(delta);
+
+			var qC = RotationOf(in current);
+			var qT = RotationOf(in target);
+			var qDot = math.abs(math.dot(qC.value, qT.value));
+			var angle = 2f * math.acos(math.clamp(qDot, -1f, 1f));
+
+			// within a jump-sized delta: take the target directly
+			if (dist <= MaxLinearJumpPerTick && angle <= MaxAngularJumpPerTick) {
+				jumped = true;
+				return target;
+			}
+
+			// an isolated teleport-sized warp snaps without imparting anything
+			if (!continuous && (dist > TeleportDistance || angle > TeleportAngle)) {
+				jumped = true;
+				return target;
+			}
+			jumped = false;
+
+			var t = 1f;
+			if (dist > maxLinearStep) {
+				t = maxLinearStep / dist;
+			}
+			if (angle > maxAngularStep) {
+				t = math.min(t, maxAngularStep / angle);
+			}
+
+			var p = pC + delta * t;
+			var q = math.slerp(qC, qT, t);
+			var scale = new float3(math.length(target.c0.xyz), math.length(target.c1.xyz), math.length(target.c2.xyz));
+			var r = new float3x3(q);
+			return new float4x4(
+				new float4(r.c0 * scale.x, 0f),
+				new float4(r.c1 * scale.y, 0f),
+				new float4(r.c2 * scale.z, 0f),
+				new float4(p, 1f)
+			);
 		}
 
 		/// <summary>
@@ -81,10 +249,14 @@ namespace VisualPinball.Unity
 		/// <param name="prevMatrix">LocalToPlayfieldMatrixInVpx before this update</param>
 		/// <param name="currMatrix">LocalToPlayfieldMatrixInVpx of this update</param>
 		/// <param name="nowUsec">Current physics time</param>
+		/// <param name="isIsolated">True if this update didn't derive a velocity: first
+		/// update after idle (outside the continuity window) or a teleport-sized jump.
+		/// Isolated updates are applied with teleport semantics (snap, no impulse).</param>
 		internal static KinematicVelocityState DeriveVelocity(in KinematicVelocityState prev, in float4x4 prevMatrix,
-			in float4x4 currMatrix, ulong nowUsec)
+			in float4x4 currMatrix, ulong nowUsec, out bool isIsolated)
 		{
 			var pivot = currMatrix.c3.xyz;
+			isIsolated = false;
 
 			// no time elapsed (e.g. multiple updates within the same tick): keep the current velocity
 			if (nowUsec <= prev.LastUpdateUsec) {
@@ -100,6 +272,7 @@ namespace VisualPinball.Unity
 
 			// isolated update after idle: re-baseline without imparting velocity
 			if (dtSec > ContinuityWindowSec) {
+				isIsolated = true;
 				return new KinematicVelocityState { Pivot = pivot, LastUpdateUsec = nowUsec };
 			}
 
@@ -120,6 +293,7 @@ namespace VisualPinball.Unity
 
 			// teleport guard: a jump this large in a single update imparts no velocity
 			if (math.lengthsq(deltaPos) > TeleportDistance * TeleportDistance || angle > TeleportAngle) {
+				isIsolated = true;
 				return new KinematicVelocityState { Pivot = pivot, LastUpdateUsec = nowUsec };
 			}
 
@@ -135,6 +309,39 @@ namespace VisualPinball.Unity
 				Pivot = pivot,
 				LastUpdateUsec = nowUsec,
 			};
+		}
+
+		/// <summary>
+		/// Distance and angle below which an isolated update is applied immediately
+		/// as a snap. Half a ball radius: a snap this small can never critically
+		/// embed a resting ball (the contact displacement correction recovers it).
+		/// Larger isolated jumps are held for up to <see cref="IsolatedHoldTimeoutUsec"/>:
+		/// if a follow-up update arrives, it was the first frame of continuous motion
+		/// (stream it with derived velocity); if not, it was a genuine teleport (snap
+		/// silently). This is what disambiguates "fast drag" from "teleport" — at the
+		/// first update, they look identical.
+		/// </summary>
+		internal const float IsolatedHoldDistance = MaxLinearJumpPerTick;
+		internal const float IsolatedHoldAngle = MaxAngularJumpPerTick;
+
+		/// <summary>
+		/// Generous enough to survive editor frame hitches — a follow-up update that
+		/// arrives late must still resolve the hold as motion, not misfire a teleport
+		/// through a resting ball. Well below the continuity window, so a resolved
+		/// hold always derives a velocity.
+		/// </summary>
+		internal const ulong IsolatedHoldTimeoutUsec = 120_000;
+
+		/// <summary>
+		/// Returns whether an isolated update's delta is small enough to apply
+		/// immediately (snap) instead of being held for disambiguation.
+		/// </summary>
+		internal static bool IsSmallIsolatedDelta(in float4x4 prevMatrix, in float4x4 currMatrix)
+		{
+			var dist = math.length(currMatrix.c3.xyz - prevMatrix.c3.xyz);
+			var qDot = math.abs(math.dot(RotationOf(in prevMatrix).value, RotationOf(in currMatrix).value));
+			var angle = 2f * math.acos(math.clamp(qDot, -1f, 1f));
+			return dist <= IsolatedHoldDistance && angle <= IsolatedHoldAngle;
 		}
 
 		/// <summary>
@@ -172,7 +379,20 @@ namespace VisualPinball.Unity
 			octree.Clear();
 
 			for (var i = 0; i < state.KinematicCollidersAtIdentity.Length; i++) {
-				octree.Insert(i, state.KinematicCollidersAtIdentity.GetTransformedAabb(i, ref state.KinematicTransforms));
+				// while an item steps toward its target pose, cover the whole swept
+				// range: union of the AABBs at the current and at the target pose,
+				// so the octree stays valid for every sub-tick step of this frame
+				var aabb = state.KinematicCollidersAtIdentity.GetTransformedAabb(i, ref state.KinematicTransforms);
+				var itemId = state.KinematicCollidersAtIdentity.GetItemId(i);
+				if (state.KinematicTargetTransforms.ContainsKey(itemId)) {
+					var targetAabb = state.KinematicCollidersAtIdentity.GetTransformedAabb(i, ref state.KinematicTargetTransforms);
+					aabb = new Aabb(
+						math.min(aabb.Left, targetAabb.Left), math.max(aabb.Right, targetAabb.Right),
+						math.min(aabb.Top, targetAabb.Top), math.max(aabb.Bottom, targetAabb.Bottom),
+						math.min(aabb.ZLow, targetAabb.ZLow), math.max(aabb.ZHigh, targetAabb.ZHigh)
+					);
+				}
+				octree.Insert(i, aabb);
 			}
 
 			PerfMarkerBallOctree.End();

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsKinematics.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsKinematics.cs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using NativeTrees;
+using Unity.Mathematics;
 using Unity.Profiling;
 using VisualPinball.Unity.Collections;
 
@@ -24,6 +25,25 @@ namespace VisualPinball.Unity
 	{
 		private static readonly ProfilerMarker PerfMarkerTransform = new("TransformKinematicColliders");
 		private static readonly ProfilerMarker PerfMarkerBallOctree = new("CreateKinematicOctree");
+
+		/// <summary>
+		/// Maximal time window used for velocity derivation. When an item starts moving
+		/// after being idle, the elapsed time since its last update can be arbitrarily
+		/// large, which would dilute one frame of motion into a near-zero velocity.
+		/// </summary>
+		private const float MaxVelocityDtSec = 0.1f;
+
+		/// <summary>
+		/// Per-update displacement above which the update is treated as a teleport,
+		/// i.e. no velocity is imparted. Protects against scripted warps and
+		/// initial placement.
+		/// </summary>
+		private const float TeleportDistance = 100f; // VPX units
+
+		/// <summary>
+		/// Per-update rotation above which the update is treated as a teleport.
+		/// </summary>
+		private const float TeleportAngle = math.PI / 3f; // 60°
 
 		internal static void TransformFullyTransformableColliders(ref PhysicsState state)
 		{
@@ -39,6 +59,86 @@ namespace VisualPinball.Unity
 				}
 			}
 			PerfMarkerTransform.End();
+		}
+
+		/// <summary>
+		/// Derive an item's velocity from two consecutive transform updates.
+		/// </summary>
+		/// <remarks>
+		/// Same approach as Bullet's <c>btRigidBody::saveKinematicState</c> /
+		/// <c>btTransformUtil::calculateVelocity</c>: linear velocity from the
+		/// translation delta, angular velocity from the axis and angle of the
+		/// delta quaternion. The time base is the physics time elapsed between
+		/// the two transform applications — transforms arrive at Unity frame
+		/// rate, not at tick rate, so dividing by the tick length would
+		/// massively overestimate the velocity.
+		/// </remarks>
+		/// <param name="prev">Velocity state from the previous update (provides the previous timestamp)</param>
+		/// <param name="prevMatrix">LocalToPlayfieldMatrixInVpx before this update</param>
+		/// <param name="currMatrix">LocalToPlayfieldMatrixInVpx of this update</param>
+		/// <param name="nowUsec">Current physics time</param>
+		internal static KinematicVelocityState DeriveVelocity(in KinematicVelocityState prev, in float4x4 prevMatrix,
+			in float4x4 currMatrix, ulong nowUsec)
+		{
+			var pivot = currMatrix.c3.xyz;
+
+			// no time elapsed (e.g. multiple updates within the same tick): keep the current velocity
+			if (nowUsec <= prev.LastUpdateUsec) {
+				return new KinematicVelocityState {
+					LinearVelocity = prev.LinearVelocity,
+					AngularVelocity = prev.AngularVelocity,
+					Pivot = pivot,
+					LastUpdateUsec = prev.LastUpdateUsec,
+				};
+			}
+
+			var dt = math.min((nowUsec - prev.LastUpdateUsec) * 1e-6f, MaxVelocityDtSec);
+			var deltaPos = pivot - prevMatrix.c3.xyz;
+
+			var q0 = RotationOf(in prevMatrix);
+			var q1 = RotationOf(in currMatrix);
+			var qd = math.mul(q1, math.inverse(q0));
+			if (qd.value.w < 0f) { // nearest-neighbor: q and -q are the same rotation
+				qd.value = -qd.value;
+			}
+			var angle = 2f * math.acos(math.clamp(qd.value.w, -1f, 1f));
+
+			// teleport guard: a jump this large in a single update imparts no velocity
+			if (math.lengthsq(deltaPos) > TeleportDistance * TeleportDistance || angle > TeleportAngle) {
+				return new KinematicVelocityState { Pivot = pivot, LastUpdateUsec = nowUsec };
+			}
+
+			var angVel = float3.zero;
+			var axisLenSq = math.lengthsq(qd.value.xyz);
+			if (angle > 1e-6f && axisLenSq > 1e-12f) {
+				angVel = qd.value.xyz * math.rsqrt(axisLenSq) * (angle / dt);
+			}
+
+			return new KinematicVelocityState {
+				LinearVelocity = deltaPos / dt,
+				AngularVelocity = angVel,
+				Pivot = pivot,
+				LastUpdateUsec = nowUsec,
+			};
+		}
+
+		/// <summary>
+		/// Extracts the rotation of a transformation matrix, stripping scale.
+		/// </summary>
+		/// <remarks>
+		/// Full Gram-Schmidt with normalization. Don't replace this with
+		/// <c>math.orthonormalize</c>: that one assumes a near-orthonormal
+		/// input, and LocalToPlayfieldMatrixInVpx matrices can carry a large
+		/// uniform scale (the scene scale vs VPX units), which corrupts its
+		/// result. Scale animation isn't rigid motion and is unsupported here;
+		/// stripping it keeps the derived rotation exact for rigid transforms.
+		/// </remarks>
+		private static quaternion RotationOf(in float4x4 m)
+		{
+			var c0 = math.normalizesafe(m.c0.xyz, new float3(1f, 0f, 0f));
+			var c1 = math.normalizesafe(m.c1.xyz - c0 * math.dot(m.c1.xyz, c0), new float3(0f, 1f, 0f));
+			var c2 = math.cross(c0, c1);
+			return new quaternion(new float3x3(c0, c1, c2));
 		}
 
 		/// <summary>

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsState.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsState.cs
@@ -285,16 +285,28 @@ namespace VisualPinball.Unity
 			if (!collEvent.IsKinematic) {
 				return float3.zero;
 			}
-			var itemId = KinematicColliders.GetItemId(collEvent.ColliderId);
+			return GetKinematicSurfaceVelocity(ref KinematicColliders, collEvent.ColliderId, in contactPoint);
+		}
+
+		/// <summary>
+		/// Same as <see cref="GetKinematicSurfaceVelocity(in CollisionEventData,in float3)"/>,
+		/// but by collider id. Returns zero for non-kinematic collider sets.
+		/// </summary>
+		internal float3 GetKinematicSurfaceVelocity(ref NativeColliders colliders, int colliderId, in float3 position)
+		{
+			if (!colliders.IsKinematic) {
+				return float3.zero;
+			}
+			var itemId = colliders.GetItemId(colliderId);
 			if (!KinematicVelocities.TryGetValue(itemId, out var velocity) || !velocity.IsMoving) {
 				return float3.zero;
 			}
-			if (KinematicColliders.IsTransformed(collEvent.ColliderId)) {
-				return velocity.GetVelocityAt(contactPoint);
+			if (colliders.IsTransformed(colliderId)) {
+				return velocity.GetVelocityAt(position);
 			}
 			ref var matrix = ref KinematicTransforms.GetValueByRef(itemId);
-			var velocityAtContact = velocity.GetVelocityAt(matrix.MultiplyPoint(contactPoint));
-			return math.inverse(matrix).MultiplyVector(velocityAtContact);
+			var velocityAtPosition = velocity.GetVelocityAt(matrix.MultiplyPoint(position));
+			return math.inverse(matrix).MultiplyVector(velocityAtPosition);
 		}
 
 		/// <summary>

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsState.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsState.cs
@@ -63,20 +63,25 @@ namespace VisualPinball.Unity
 		/// It's set in PhysicsEngine.Start() through ColliderReference.TransformToIdentity()
 		///
 		/// This is used for:
-		///   - Transform fully-transformable colliders in PhysicsUpdateJob.Execute() with PhysicsKinematics.TransformFullyTransformableColliders()
+		///   - Transform fully-transformable colliders in PhysicsUpdate.Execute() with PhysicsKinematics.StepKinematics()
 		///   - Computing the AABBs for the octree in PhysicsUpdateJob.Execute()
 		/// </summary>
 		internal NativeColliders KinematicCollidersAtIdentity;
 
 		/// <summary>
-		/// Maps an item ID to the updated transformation matrix since the last frame of all kinematic items.
+		/// Maps an item ID to the target transformation matrix of kinematic items that have moved.
+		/// The current pose (<see cref="KinematicTransforms"/>) is stepped toward this target
+		/// inside the tick loop (<see cref="PhysicsKinematics.StepKinematics"/>), capped per tick,
+		/// so a fast-moving collider can't skip past a ball within one frame.
 		/// <para><c>int</c> is the <see cref="ColliderComponent{TData,TMainComponent}.ItemId"/> of the collider.</para>
-		/// <para><c>float4x4</c> Updated LocalToPlayfieldMatrixInVpx of the item.</para>
+		/// <para><c>float4x4</c> Target LocalToPlayfieldMatrixInVpx of the item.</para>
 		/// </summary>
-		internal NativeParallelHashMap<int, float4x4> UpdatedKinematicTransforms;
+		internal NativeParallelHashMap<int, float4x4> KinematicTargetTransforms;
 
 		/// <summary>
-		/// The LocalToPlayfieldMatrixInVpx of all kinematic colliders, fully transformable or not.
+		/// The current LocalToPlayfieldMatrixInVpx of all kinematic colliders, fully transformable
+		/// or not. While an item moves, this is stepped toward <see cref="KinematicTargetTransforms"/>
+		/// per tick and matches the pose the colliders are actually baked at.
 		/// </summary>
 		/// <remarks>
 		/// <para><c>int</c> is the <see cref="ColliderComponent{TData,TMainComponent}.ItemId"/> of the collider.</para>
@@ -145,7 +150,7 @@ namespace VisualPinball.Unity
 		public PhysicsState(ref PhysicsEnv env, ref NativeOctree<int> octree, ref NativeColliders colliders,
 			ref NativeColliders kinematicColliders, ref NativeColliders kinematicCollidersAtIdentity,
 			ref NativeParallelHashMap<int, float4x4> kinematicTransforms,
-			ref NativeParallelHashMap<int, float4x4> updatedKinematicTransforms,
+			ref NativeParallelHashMap<int, float4x4> kinematicTargetTransforms,
 			ref NativeParallelHashMap<int, float4x4> nonTransformableColliderTransforms,
 			ref NativeParallelHashMap<int, NativeColliderIds> kinematicColliderLookups, ref NativeQueue<EventData>.ParallelWriter eventQueue,
 			ref InsideOfs insideOfs, ref NativeParallelHashMap<int, BallState> balls,
@@ -165,7 +170,7 @@ namespace VisualPinball.Unity
 			KinematicColliders = kinematicColliders;
 			KinematicCollidersAtIdentity = kinematicCollidersAtIdentity;
 			KinematicTransforms = kinematicTransforms;
-			UpdatedKinematicTransforms = updatedKinematicTransforms;
+			KinematicTargetTransforms = kinematicTargetTransforms;
 			_nonTransformableColliderTransforms = nonTransformableColliderTransforms;
 			KinematicColliderLookups = kinematicColliderLookups;
 			EventQueue = eventQueue;
@@ -298,14 +303,28 @@ namespace VisualPinball.Unity
 				return float3.zero;
 			}
 			var itemId = colliders.GetItemId(colliderId);
-			if (!KinematicVelocities.TryGetValue(itemId, out var velocity) || !velocity.IsMoving) {
+			if (!KinematicVelocities.TryGetValue(itemId, out var velocity)) {
 				return float3.zero;
 			}
+
+			// while the pose catch-up is rate-limited (clamped stepping), the actual
+			// step rate is the honest surface velocity and can exceed the derived one
+			var linear = velocity.LinearVelocity;
+			var angular = velocity.AngularVelocity;
+			if (math.lengthsq(velocity.StepVelocity) > math.lengthsq(linear)
+			    || math.lengthsq(velocity.StepAngularVelocity) > math.lengthsq(angular)) {
+				linear = velocity.StepVelocity;
+				angular = velocity.StepAngularVelocity;
+			}
+			if (math.lengthsq(linear) < 1e-8f && math.lengthsq(angular) < 1e-8f) {
+				return float3.zero;
+			}
+
 			if (colliders.IsTransformed(colliderId)) {
-				return velocity.GetVelocityAt(position);
+				return linear + math.cross(angular, position - velocity.Pivot);
 			}
 			ref var matrix = ref KinematicTransforms.GetValueByRef(itemId);
-			var velocityAtPosition = velocity.GetVelocityAt(matrix.MultiplyPoint(position));
+			var velocityAtPosition = linear + math.cross(angular, matrix.MultiplyPoint(position) - velocity.Pivot);
 			return math.inverse(matrix).MultiplyVector(velocityAtPosition);
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsState.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsState.cs
@@ -85,6 +85,15 @@ namespace VisualPinball.Unity
 		internal NativeParallelHashMap<int, float4x4> KinematicTransforms;
 
 		/// <summary>
+		/// The current velocities of all kinematic items that have moved, derived from their transform updates.
+		/// </summary>
+		/// <remarks>
+		/// <para><c>int</c> is the <see cref="ColliderComponent{TData,TMainComponent}.ItemId"/> of the collider.</para>
+		/// <para>Read during collision and contact resolution via <see cref="GetKinematicSurfaceVelocity"/>.</para>
+		/// </remarks>
+		internal NativeParallelHashMap<int, KinematicVelocityState> KinematicVelocities;
+
+		/// <summary>
 		/// The LUT of elasticity over velocity for all colliders where activated. Goes from 0 to 64 velocity units.
 		/// </summary>
 		internal NativeParallelHashMap<int, FixedList512Bytes<float>> ElasticityOverVelocityLUTs;
@@ -147,7 +156,8 @@ namespace VisualPinball.Unity
 			ref NativeParallelHashMap<int, SurfaceState> surfaceStates, ref NativeParallelHashMap<int, TriggerState> triggerStates,
 			ref NativeParallelHashSet<int> disabledCollisionItems, ref bool swapBallCollisionHandling,
 			ref NativeParallelHashMap<int, FixedList512Bytes<float>> elasticityOverVelocityLUTs,
-			ref NativeParallelHashMap<int, FixedList512Bytes<float>> frictionOverVelocityLUTs)
+			ref NativeParallelHashMap<int, FixedList512Bytes<float>> frictionOverVelocityLUTs,
+			ref NativeParallelHashMap<int, KinematicVelocityState> kinematicVelocities)
 		{
 			Env = env;
 			Octree = octree;
@@ -176,6 +186,7 @@ namespace VisualPinball.Unity
 
 			ElasticityOverVelocityLUTs = elasticityOverVelocityLUTs;
 			FrictionOverVelocityLUTs = frictionOverVelocityLUTs;
+			KinematicVelocities = kinematicVelocities;
 		}
 
 		internal ref ColliderHeader GetColliderHeader(ref NativeColliders colliders, int colliderId) => ref colliders.GetHeader(colliderId);
@@ -248,6 +259,42 @@ namespace VisualPinball.Unity
 				return ref KinematicTransforms.GetValueByRef(itemId);
 			}
 			return ref _nonTransformableColliderTransforms.GetValueByRef(itemId);
+		}
+
+		/// <summary>
+		/// Returns the surface velocity of a kinematic collider at a given contact point,
+		/// in the space the ball currently lives in. Returns zero for static colliders and
+		/// for kinematic colliders that aren't currently moving.
+		/// </summary>
+		/// <remarks>
+		/// This is what makes a moving kinematic collider impart momentum and friction to
+		/// the ball: collision and contact resolution compute the ball's velocity relative
+		/// to this velocity instead of treating the surface as static.
+		///
+		/// For non-transformed colliders, the ball (and thus the contact point) has been
+		/// projected into the collider's local space, so the contact point is converted to
+		/// playfield space to evaluate the velocity, and the result is rotated back into
+		/// local space — consistent with <see cref="BallState.Transform"/>, which rotates
+		/// the ball's velocity as well.
+		/// </remarks>
+		/// <param name="collEvent">The collision event, identifying the collider</param>
+		/// <param name="contactPoint">The contact point, in the ball's current space</param>
+		/// <returns>Surface velocity at the contact point, in the ball's current space</returns>
+		internal float3 GetKinematicSurfaceVelocity(in CollisionEventData collEvent, in float3 contactPoint)
+		{
+			if (!collEvent.IsKinematic) {
+				return float3.zero;
+			}
+			var itemId = KinematicColliders.GetItemId(collEvent.ColliderId);
+			if (!KinematicVelocities.TryGetValue(itemId, out var velocity) || !velocity.IsMoving) {
+				return float3.zero;
+			}
+			if (KinematicColliders.IsTransformed(collEvent.ColliderId)) {
+				return velocity.GetVelocityAt(contactPoint);
+			}
+			ref var matrix = ref KinematicTransforms.GetValueByRef(itemId);
+			var velocityAtContact = velocity.GetVelocityAt(matrix.MultiplyPoint(contactPoint));
+			return math.inverse(matrix).MultiplyVector(velocityAtContact);
 		}
 
 		/// <summary>

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsStaticNarrowPhase.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsStaticNarrowPhase.cs
@@ -52,12 +52,23 @@ namespace VisualPinball.Unity
 						var ballTransformed = ball;
 						ballTransformed.Transform(math.inverse(matrix));
 
+						// test in the collider's reference frame: a moving kinematic collider must
+						// see the ball's relative velocity, otherwise a surface gaining on a slower
+						// ball reads as "receding" and generates no events (the ball gets swallowed)
+						ballTransformed.Velocity -= state.GetKinematicSurfaceVelocity(ref colliders, overlappingColliderId, ballTransformed.Position);
+
 						newTime = state.HitTest(ref colliders, overlappingColliderId, ref ballTransformed, ref newCollEvent, ref contacts);
 
 						if (IsValidHit(ref ball, newTime)) {
 							// transform hit normal back to world space
 							newCollEvent.Transform(matrix);
 						}
+
+					} else if (colliders.IsKinematic) {
+						// same as above, for baked (fully transformed) kinematic colliders
+						var ballRelative = ball;
+						ballRelative.Velocity -= state.GetKinematicSurfaceVelocity(ref colliders, overlappingColliderId, ball.Position);
+						newTime = state.HitTest(ref colliders, overlappingColliderId, ref ballRelative, ref newCollEvent, ref contacts);
 
 					} else {
 						newTime = state.HitTest(ref colliders, overlappingColliderId, ref ball, ref newCollEvent, ref contacts);

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsUpdate.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsUpdate.cs
@@ -40,7 +40,7 @@ namespace VisualPinball.Unity
 		// public NativeColliders KinematicColliders;
 		// public NativeColliders KinematicCollidersAtIdentity;
 		// public NativeParallelHashMap<int, float4x4> KinematicTransforms;
-		// public NativeParallelHashMap<int, float4x4> UpdatedKinematicTransforms;
+		// public NativeParallelHashMap<int, float4x4> KinematicTargetTransforms;
 		// public NativeParallelHashMap<int, float4x4> NonTransformableColliderTransforms;
 		//
 		// public NativeParallelHashMap<int, NativeColliderIds> KinematicColliderLookups;
@@ -73,10 +73,6 @@ namespace VisualPinball.Unity
 			// ref var env = ref UnsafeUtility.AsRef<PhysicsEnv>(envPtr.ToPointer());
 			// ref var overlappingColliders = ref UnsafeUtility.AsRef<NativeParallelHashSet<int>>(overlappingCollidersPtr.ToPointer());
 
-			// Transform kinematic colliders that have changed since the last frame.
-			// This is a no-op on ticks where no transforms were staged.
-			PhysicsKinematics.TransformFullyTransformableColliders(ref state);
-
 			var subSteps = 0;
 			while (env.CurPhysicsFrameTime < initialTimeUsec)  // loop here until current (real) time matches the physics (simulated) time
 			{
@@ -88,6 +84,10 @@ namespace VisualPinball.Unity
 					break;
 				}
 				subSteps++;
+
+				// Step kinematic collider poses toward their target transforms, capped
+				// per tick so fast movers can't skip past a ball. No-op when idle.
+				PhysicsKinematics.StepKinematics(ref state);
 
 				env.TimeMsec = (uint)((env.CurPhysicsFrameTime - env.StartTimeUsec) / 1000);
 				var physicsDiffTime = (float)((env.NextPhysicsFrameTime - env.CurPhysicsFrameTime) * (1.0 / PhysicsConstants.DefaultStepTime));

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsUpdate.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/PhysicsUpdate.cs
@@ -67,7 +67,7 @@ namespace VisualPinball.Unity
 		// public bool SwapBallCollisionHandling;
 
 		[BurstCompile]
-		public static void Execute(ref PhysicsState state, ref PhysicsEnv env, ref NativeParallelHashSet<int> overlappingColliders, ref NativeOctree<int> kineticOctree, ref NativeOctree<int> ballOctree, ref PhysicsCycle cycle, ulong initialTimeUsec)
+		public static void Execute(ref PhysicsState state, ref PhysicsEnv env, ref NativeParallelHashSet<int> overlappingColliders, ref NativeOctree<int> kinematicOctree, ref NativeOctree<int> ballOctree, ref PhysicsCycle cycle, ulong initialTimeUsec)
 		{
 			// ref var state = ref UnsafeUtility.AsRef<PhysicsState>(statePtr.ToPointer());
 			// ref var env = ref UnsafeUtility.AsRef<PhysicsEnv>(envPtr.ToPointer());
@@ -132,7 +132,7 @@ namespace VisualPinball.Unity
 				#endregion
 
 				// primary physics loop
-				cycle.Simulate(ref state, ref overlappingColliders, ref kineticOctree, ref ballOctree, physicsDiffTime);
+				cycle.Simulate(ref state, ref overlappingColliders, ref kinematicOctree, ref ballOctree, physicsDiffTime);
 
 				// ball trail, keep old pos of balls
 				using (var enumerator = state.Balls.GetEnumerator()) {

--- a/VisualPinball.Unity/VisualPinball.Unity/Packaging/PackagedFiles.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Packaging/PackagedFiles.cs
@@ -569,37 +569,36 @@ namespace VisualPinball.Unity
 			Directory.CreateDirectory(Application.temporaryCachePath);
 			var extension = Path.GetExtension(fileName);
 			var tempPath = Path.Combine(Application.temporaryCachePath, $"vpe-audio-{Guid.NewGuid():N}{extension}");
-			// try {
-			// 	File.WriteAllBytes(tempPath, bytes);
-			// 	var uri = new Uri(tempPath).AbsoluteUri;
-			// 	using var request = UnityWebRequestMultimedia.GetAudioClip(uri, audioType);
-			// 	var op = request.SendWebRequest();
-			// 	while (!op.isDone) {
-			// 		cancellationToken.ThrowIfCancellationRequested();
-			// 		await Task.Yield();
-			// 	}
-			//
-			// 	if (request.result != UnityWebRequest.Result.Success) {
-			// 		Logger.Warn($"Failed to load audio file {fileName}: {request.error}");
-			// 		return null;
-			// 	}
-			//
-			// 	var clip = DownloadHandlerAudioClip.GetContent(request);
-			// 	if (clip) {
-			// 		clip.name = Path.GetFileNameWithoutExtension(fileName);
-			// 	}
-			// 	return clip;
-			//
-			// } finally {
-			// 	try {
-			// 		if (File.Exists(tempPath)) {
-			// 			File.Delete(tempPath);
-			// 		}
-			// 	} catch (Exception) {
-			// 		// best effort cleanup
-			// 	}
-			// }
-			return null;
+			try {
+				File.WriteAllBytes(tempPath, bytes);
+				var uri = new Uri(tempPath).AbsoluteUri;
+				using var request = UnityWebRequestMultimedia.GetAudioClip(uri, audioType);
+				var op = request.SendWebRequest();
+				while (!op.isDone) {
+					cancellationToken.ThrowIfCancellationRequested();
+					await Task.Yield();
+				}
+
+				if (request.result != UnityWebRequest.Result.Success) {
+					Logger.Warn($"Failed to load audio file {fileName}: {request.error}");
+					return null;
+				}
+
+				var clip = DownloadHandlerAudioClip.GetContent(request);
+				if (clip) {
+					clip.name = Path.GetFileNameWithoutExtension(fileName);
+				}
+				return clip;
+
+			} finally {
+				try {
+					if (File.Exists(tempPath)) {
+						File.Delete(tempPath);
+					}
+				} catch (Exception) {
+					// best effort cleanup
+				}
+			}
 		}
 
 		#endregion

--- a/VisualPinball.Unity/VisualPinball.Unity/Packaging/PackagedFiles.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Packaging/PackagedFiles.cs
@@ -569,36 +569,37 @@ namespace VisualPinball.Unity
 			Directory.CreateDirectory(Application.temporaryCachePath);
 			var extension = Path.GetExtension(fileName);
 			var tempPath = Path.Combine(Application.temporaryCachePath, $"vpe-audio-{Guid.NewGuid():N}{extension}");
-			try {
-				File.WriteAllBytes(tempPath, bytes);
-				var uri = new Uri(tempPath).AbsoluteUri;
-				using var request = UnityWebRequestMultimedia.GetAudioClip(uri, audioType);
-				var op = request.SendWebRequest();
-				while (!op.isDone) {
-					cancellationToken.ThrowIfCancellationRequested();
-					await Task.Yield();
-				}
-
-				if (request.result != UnityWebRequest.Result.Success) {
-					Logger.Warn($"Failed to load audio file {fileName}: {request.error}");
-					return null;
-				}
-
-				var clip = DownloadHandlerAudioClip.GetContent(request);
-				if (clip) {
-					clip.name = Path.GetFileNameWithoutExtension(fileName);
-				}
-				return clip;
-
-			} finally {
-				try {
-					if (File.Exists(tempPath)) {
-						File.Delete(tempPath);
-					}
-				} catch (Exception) {
-					// best effort cleanup
-				}
-			}
+			// try {
+			// 	File.WriteAllBytes(tempPath, bytes);
+			// 	var uri = new Uri(tempPath).AbsoluteUri;
+			// 	using var request = UnityWebRequestMultimedia.GetAudioClip(uri, audioType);
+			// 	var op = request.SendWebRequest();
+			// 	while (!op.isDone) {
+			// 		cancellationToken.ThrowIfCancellationRequested();
+			// 		await Task.Yield();
+			// 	}
+			//
+			// 	if (request.result != UnityWebRequest.Result.Success) {
+			// 		Logger.Warn($"Failed to load audio file {fileName}: {request.error}");
+			// 		return null;
+			// 	}
+			//
+			// 	var clip = DownloadHandlerAudioClip.GetContent(request);
+			// 	if (clip) {
+			// 		clip.name = Path.GetFileNameWithoutExtension(fileName);
+			// 	}
+			// 	return clip;
+			//
+			// } finally {
+			// 	try {
+			// 		if (File.Exists(tempPath)) {
+			// 			File.Delete(tempPath);
+			// 		}
+			// 	} catch (Exception) {
+			// 		// best effort cleanup
+			// 	}
+			// }
+			return null;
 		}
 
 		#endregion

--- a/VisualPinball.Unity/VisualPinball.Unity/Packaging/VpeLightUnitAdjuster.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Packaging/VpeLightUnitAdjuster.cs
@@ -1,0 +1,36 @@
+// Visual Pinball Engine
+// Copyright (C) 2026 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using UnityEngine;
+
+namespace VisualPinball.Unity
+{
+	/// <summary>
+	/// Light values in a .vpe package are authored under HDRP in physical units (candela/lumen/lux)
+	/// and assume HDRP's exposure-based tone mapping. A pipeline without physical light units (URP)
+	/// registers an adjuster here from its bootstrap — the same seam as
+	/// <see cref="VpeMaterialResolver.Register"/> — and <see cref="LightSourcePackable.Apply"/>
+	/// invokes it after a restored light profile has been applied. When nothing is registered
+	/// (HDRP, authoring editor), restored lights keep their authored values.
+	/// </summary>
+	public static class VpeLightUnitAdjuster
+	{
+		public static Action<Light> Active { get; private set; }
+
+		public static void Register(Action<Light> adjuster) => Active = adjuster;
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity/Packaging/VpeLightUnitAdjuster.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity/Packaging/VpeLightUnitAdjuster.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c72d8c6a98c5964988d1e095cd36c46

--- a/VisualPinball.Unity/VisualPinball.Unity/Packaging/VpeMaterial.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Packaging/VpeMaterial.cs
@@ -50,6 +50,15 @@ namespace VisualPinball.Unity
 		public const string Rubber = "vpe.rubber";
 		public const string Dmd = "vpe.dmd";
 		public const string FabricSilk = "vpe.fabric.silk";
+		public const string Insert = "vpe.insert";
+	}
+
+	// The two physical parts of a playfield insert. The lens is the piece flush with the
+	// playfield surface; the reflector is the faceted body below it that shapes the lamp light.
+	public static class VpeInsertParts
+	{
+		public const string Lens = "lens";
+		public const string Reflector = "reflector";
 	}
 
 	public static class VpeColorSpaces
@@ -188,6 +197,22 @@ namespace VisualPinball.Unity
 		public VpeShaderGraphProfile Rubber;
 		public VpeShaderGraphProfile Dmd;
 		public VpeFabricSilkProfile Fabric;
+		public VpeInsertProfile Insert;
+	}
+
+	// A playfield-insert material: translucent plastic lit from below by a lamp. The nested Lit
+	// payload carries the full portable material intent (transmittance color, thickness, IOR,
+	// refraction, normal map, HDRP hints), so HDRP renders it exactly like a vpe.lit profile.
+	// The semantic type exists for pipelines without translucency/refraction (URP): knowing
+	// "this is an insert lens/reflector" lets them substitute a purpose-built approximation
+	// (lamp-driven emissive tinted by the transmittance color) instead of a generic translation.
+	[Serializable]
+	public class VpeInsertProfile
+	{
+		// See VpeInsertParts.
+		public string Part = VpeInsertParts.Lens;
+		// Portable material intent, identical in shape to a vpe.lit payload.
+		public VpeLitProfile Lit = new();
 	}
 
 	[Serializable]

--- a/VisualPinball.Unity/VisualPinball.Unity/Packaging/VpeMaterialReader.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Packaging/VpeMaterialReader.cs
@@ -355,6 +355,11 @@ namespace VisualPinball.Unity
 						payload = PackageApi.Packer.Pack(profile.Fabric);
 					}
 					break;
+				case VpeMaterialTypes.Insert:
+					if (profile.Insert != null) {
+						payload = PackageApi.Packer.Pack(profile.Insert);
+					}
+					break;
 			}
 
 			if (payload == null || payload.Length == 0) {

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/Collider.cs
@@ -101,9 +101,9 @@ namespace VisualPinball.Unity
 			}
 		}
 
-		internal static void Contact(in ColliderHeader collHeader, ref BallState ball, in CollisionEventData collEvent, double hitTime, in float3 gravity)
+		internal static void Contact(in ColliderHeader collHeader, ref BallState ball, in CollisionEventData collEvent, double hitTime, in float3 gravity, in float3 colliderVelocity)
 		{
-			BallCollider.HandleStaticContact(ref ball, in collEvent, collHeader.Material.Friction, (float)hitTime, gravity);
+			BallCollider.HandleStaticContact(ref ball, in collEvent, collHeader.Material.Friction, (float)hitTime, gravity, colliderVelocity);
 		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/ColliderReference.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collider/ColliderReference.cs
@@ -104,7 +104,7 @@ namespace VisualPinball.Unity
 		{
 			#if UNITY_EDITOR
 			if (!IsKinematic) {
-				throw new InvalidOperationException("Cannot transform non-kinetic colliders to identity.");
+				throw new InvalidOperationException("Cannot transform non-kinematic colliders to identity.");
 			}
 			#endif
 			using var enumerator = _itemIdToColliderIds.GetEnumerator();
@@ -123,7 +123,7 @@ namespace VisualPinball.Unity
 							ref var circleCollider = ref CircleColliders.GetElementAsRef(lookup.Index);
 							#if UNITY_EDITOR
 							if (circleCollider.Header.IsTransformed) {
-								throw new InvalidOperationException("A transformed circle collider shouldn't have been added as a kinetic collider.");
+								throw new InvalidOperationException("A transformed circle collider shouldn't have been added as a kinematic collider.");
 							}
 							#endif
 							circleCollider.TransformAabb(math.inverse(matrix));
@@ -163,7 +163,7 @@ namespace VisualPinball.Unity
 							ref var spinnerCollider = ref SpinnerColliders.GetElementAsRef(lookup.Index);
 							#if UNITY_EDITOR
 							if (spinnerCollider.Header.IsTransformed) {
-								throw new InvalidOperationException("A transformed spinner collider shouldn't have been added as a kinetic collider.");
+								throw new InvalidOperationException("A transformed spinner collider shouldn't have been added as a kinematic collider.");
 							}
 							#endif
 							spinnerCollider.TransformAabb(math.inverse(matrix));
@@ -173,7 +173,7 @@ namespace VisualPinball.Unity
 							ref var gateCollider = ref GateColliders.GetElementAsRef(lookup.Index);
 							#if UNITY_EDITOR
 							if (gateCollider.Header.IsTransformed) {
-								throw new InvalidOperationException("A transformed gate collider shouldn't have been added as a kinetic collider.");
+								throw new InvalidOperationException("A transformed gate collider shouldn't have been added as a kinematic collider.");
 							}
 							#endif
 							gateCollider.TransformAabb(math.inverse(matrix));
@@ -183,7 +183,7 @@ namespace VisualPinball.Unity
 							ref var flipperCollider = ref FlipperColliders.GetElementAsRef(lookup.Index);
 							#if UNITY_EDITOR
 							if (flipperCollider.Header.IsTransformed) {
-								throw new InvalidOperationException("A transformed flipper collider shouldn't have been added as a kinetic collider.");
+								throw new InvalidOperationException("A transformed flipper collider shouldn't have been added as a kinematic collider.");
 							}
 							#endif
 							flipperCollider.TransformAabb(math.inverse(matrix));
@@ -193,7 +193,7 @@ namespace VisualPinball.Unity
 							ref var slingshotCollider = ref LineSlingshotColliders.GetElementAsRef(lookup.Index);
 							#if UNITY_EDITOR
 							if (slingshotCollider.Header.IsTransformed) {
-								throw new InvalidOperationException("A transformed slingshot collider shouldn't have been added as a kinetic collider.");
+								throw new InvalidOperationException("A transformed slingshot collider shouldn't have been added as a kinematic collider.");
 							}
 							#endif
 							slingshotCollider.TransformAabb(math.inverse(matrix));
@@ -203,7 +203,7 @@ namespace VisualPinball.Unity
 							ref var plungerCollider = ref PlungerColliders.GetElementAsRef(lookup.Index);
 							#if UNITY_EDITOR
 							if (plungerCollider.Header.IsTransformed) {
-								throw new InvalidOperationException("A transformed plunger collider shouldn't have been added as a kinetic collider.");
+								throw new InvalidOperationException("A transformed plunger collider shouldn't have been added as a kinematic collider.");
 							}
 							#endif
 							plungerCollider.TransformAabb(math.inverse(matrix));
@@ -211,11 +211,11 @@ namespace VisualPinball.Unity
 
 						case ColliderType.Line:
 							#if UNITY_EDITOR
-							throw new InvalidOperationException("Line colliders shouldn't exist as kinetic colliders, but converted to line 3D colliders.");
+							throw new InvalidOperationException("Line colliders shouldn't exist as kinematic colliders, but converted to line 3D colliders.");
 							#endif
 						case ColliderType.LineZ:
 							#if UNITY_EDITOR
-							throw new InvalidOperationException("Line-Z colliders shouldn't exist as kinetic colliders, but converted to line 3D colliders.");
+							throw new InvalidOperationException("Line-Z colliders shouldn't exist as kinematic colliders, but converted to line 3D colliders.");
 							#endif
 						case ColliderType.Plane:
 							#if UNITY_EDITOR

--- a/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/ContactPhysics.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Physics/Collision/ContactPhysics.cs
@@ -40,7 +40,9 @@ namespace VisualPinball.Unity
 					ref var flipperState = ref state.GetFlipperState(collEvent.ColliderId, ref colliders);
 					flipperCollider.Contact(ref ball, ref flipperState.Movement, in collEvent, in flipperState.Static, in flipperState.Velocity, hitTime, in gravity);
 				} else {
-					Collider.Contact(in collHeader, ref ball, in collEvent, hitTime, in gravity);
+					// surface velocity of the collider at the contact point (zero unless kinematic and moving)
+					var colliderVelocity = state.GetKinematicSurfaceVelocity(in collEvent, ball.Position - ball.Radius * collEvent.HitNormal);
+					Collider.Contact(in collHeader, ref ball, in collEvent, hitTime, in gravity, in colliderVelocity);
 				}
 
 				if (!colliders.IsTransformed(collEvent.ColliderId)) {
@@ -53,7 +55,7 @@ namespace VisualPinball.Unity
 				var collHeader = collEvent.IsKinematic
 					? ref state.GetColliderHeader(ref state.KinematicColliders, contact.CollEvent.ColliderId)
 					: ref state.GetColliderHeader(ref state.Colliders, contact.CollEvent.ColliderId);
-				BallCollider.HandleStaticContact(ref ball, in collEvent, collHeader.Material.Friction, hitTime, state.Env.Gravity);
+				BallCollider.HandleStaticContact(ref ball, in collEvent, collHeader.Material.Friction, hitTime, state.Env.Gravity, float3.zero);
 			}
 		}
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity/Sound/SoundComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Sound/SoundComponent.cs
@@ -79,10 +79,10 @@ namespace VisualPinball.Unity
 			base.OnEnableAfterAfterAwake();
 			_calloutCoordinator = GetComponentInParent<CalloutCoordinator>();
 			if (_calloutCoordinator == null)
-				Logger.Error("No callout coordinator found in parents. Callouts will not work!");
+				Logger.Warn("No callout coordinator found in parents. Callouts will not work!");
 			_musicCoordinator = GetComponentInParent<MusicCoordinator>();
 			if (_musicCoordinator == null)
-				Logger.Error("No music coordinator found in parents. Music will not work!");
+				Logger.Warn("No music coordinator found in parents. Music will not work!");
 		}
 
 		protected void Update()

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallCollider.cs
@@ -153,12 +153,11 @@ namespace VisualPinball.Unity
 				var fe = gravity * ball.Mass;
 				var dot = math.dot(fe, collEvent.HitNormal);
 
-				// HitOrgNormalVelocity was captured against a static surface in the hit test,
-				// so correct it by the surface's own normal velocity
-				var orgNormVel = collEvent.HitOrgNormalVelocity - math.dot(colliderVelocity, collEvent.HitNormal);
+				// note: for kinematic colliders, HitOrgNormalVelocity is already relative to the
+				// surface — the narrow phase hit-tests in the collider's reference frame
 
 				// normal force is always nonnegative
-				var normalForce = math.max(0.0f, -(dot * dTime + orgNormVel));
+				var normalForce = math.max(0.0f, -(dot * dTime + collEvent.HitOrgNormalVelocity));
 
 				// Add just enough to kill original normal velocity and counteract the external forces.
 				ball.Velocity += collEvent.HitNormal * normalForce;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallCollider.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallCollider.cs
@@ -26,8 +26,11 @@ namespace VisualPinball.Unity
 
 		public static void Collide3DWall(ref BallState ball, in PhysicsMaterialData material, in CollisionEventData collEvent, in float3 hitNormal, ref PhysicsState state)
 		{
-			// speed normal to wall
-			var dot = math.dot(ball.Velocity, hitNormal);
+			// surface velocity of the collider at the contact point (zero unless kinematic and moving)
+			var colliderVelocity = state.GetKinematicSurfaceVelocity(in collEvent, ball.Position - ball.Radius * hitNormal);
+
+			// speed normal to wall, relative to the (possibly moving) surface
+			var dot = math.dot(ball.Velocity - colliderVelocity, hitNormal);
 
 			if (dot >= -PhysicsConstants.LowNormVel) {
 				// nearly receding ... make sure of conditions
@@ -78,7 +81,7 @@ namespace VisualPinball.Unity
 
 			// compute friction impulse
 			var surfP = -ball.Radius * hitNormal;                        // surface contact point relative to center of mass
-			var surfVel = BallState.SurfaceVelocity(in ball, in surfP);                              // velocity at impact point
+			var surfVel = BallState.SurfaceVelocity(in ball, in surfP) - colliderVelocity;           // velocity at impact point, relative to the surface
 			var tangent = surfVel - hitNormal * math.dot(surfVel, hitNormal);  // calc the tangential velocity
 
 			var tangentSpSq = math.lengthsq(tangent);
@@ -94,7 +97,7 @@ namespace VisualPinball.Unity
 				// get friction based on normal Velocity  
 				float friction;
 				if (material.UseFrictionOverVelocity) {
-					var normalVelocity = math.dot(ball.Velocity, hitNormal);
+					var normalVelocity = math.dot(ball.Velocity - colliderVelocity, hitNormal);
 					var colliders = collEvent.IsKinematic ? state.KinematicColliders : state.Colliders;
 					var itemId = colliders.GetItemId(collEvent.ColliderId);
 					var lut = state.FrictionOverVelocityLUTs[itemId];
@@ -137,10 +140,11 @@ namespace VisualPinball.Unity
 			}
 		}
 
-		public static void HandleStaticContact(ref BallState ball, in CollisionEventData collEvent, float friction, float dTime, in float3 gravity)
+		public static void HandleStaticContact(ref BallState ball, in CollisionEventData collEvent, float friction, float dTime, in float3 gravity, in float3 colliderVelocity)
 		{
 			// this should be zero, but only up to +/- PhysicsConstants.ContactVel
-			var normVel = math.dot(ball.Velocity, collEvent.HitNormal);
+			// (relative to the surface, which may be moving if the collider is kinematic)
+			var normVel = math.dot(ball.Velocity - colliderVelocity, collEvent.HitNormal);
 
 			// If some collision has changed the ball's velocity, we may not have to do anything.
 			if (normVel <= PhysicsConstants.ContactVel) {
@@ -149,21 +153,29 @@ namespace VisualPinball.Unity
 				var fe = gravity * ball.Mass;
 				var dot = math.dot(fe, collEvent.HitNormal);
 
+				// HitOrgNormalVelocity was captured against a static surface in the hit test,
+				// so correct it by the surface's own normal velocity
+				var orgNormVel = collEvent.HitOrgNormalVelocity - math.dot(colliderVelocity, collEvent.HitNormal);
+
 				// normal force is always nonnegative
-				var normalForce = math.max(0.0f, -(dot * dTime + collEvent.HitOrgNormalVelocity));
+				var normalForce = math.max(0.0f, -(dot * dTime + orgNormVel));
 
 				// Add just enough to kill original normal velocity and counteract the external forces.
 				ball.Velocity += collEvent.HitNormal * normalForce;
 
-				ApplyFriction(ref ball, collEvent.HitNormal, dTime, friction, gravity);
+				ApplyFriction(ref ball, collEvent.HitNormal, dTime, friction, gravity, colliderVelocity);
 			}
 		}
 
-		private static void ApplyFriction(ref BallState ball, in float3 hitNormal, float dTime, float frictionCoeff, in float3 gravity)
+		private static void ApplyFriction(ref BallState ball, in float3 hitNormal, float dTime, float frictionCoeff, in float3 gravity, in float3 colliderVelocity)
 		{
 			// surface contact point relative to center of mass
 			var surfP = -ball.Radius * hitNormal;
-			var surfVel = BallState.SurfaceVelocity(in ball, in surfP);
+
+			// velocity of the ball's surface relative to the (possibly moving) collider surface:
+			// once the ball rides along with a moving surface, slip goes to zero and static
+			// friction keeps it locked to the surface
+			var surfVel = BallState.SurfaceVelocity(in ball, in surfP) - colliderVelocity;
 
 			// calc the tangential slip velocity
 			var slip = surfVel - hitNormal * math.dot(surfVel, hitNormal);
@@ -174,7 +186,7 @@ namespace VisualPinball.Unity
 			float3 slipDir;
 			float numer;
 
-			var normVel = math.dot(ball.Velocity, hitNormal);
+			var normVel = math.dot(ball.Velocity - colliderVelocity, hitNormal);
 			if (normVel <= 0.025 || slipSpeed < PhysicsConstants.Precision) {
 				// check for <=0.025 originated from ball<->rubber collisions pushing the ball upwards, but this is still not enough, some could even use <=0.2
 				// slip speed zero - static friction case

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallSpinHackPhysics.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallSpinHackPhysics.cs
@@ -23,6 +23,21 @@ namespace VisualPinball.Unity
 {
 	internal static class BallSpinHackPhysics
 	{
+		/// <summary>
+		/// Squared positional drift (x/y, VPX units) over the ~100 ms position ring
+		/// buffer window below which the ball counts as being at rest.
+		/// </summary>
+		private const float RestPositionEpsSq = 0.01f; // 0.1 units per 100 ms
+
+		/// <summary>
+		/// Squared linear velocity below which the ball counts as being at rest.
+		/// Generous on purpose: the contact solver's per-tick gravity-cancel cycle
+		/// makes a resting ball's instantaneous velocity oscillate by more than the
+		/// true drift. The positional gate above is what discriminates actual
+		/// motion — a ball moving this fast for real fails it immediately.
+		/// </summary>
+		private const float RestVelocityEpsSq = 0.04f; // 0.2 units per 10 ms = 20 u/s
+
 		internal static void Update(ref BallState ball)
 		{
 			var p0 = (ball.RingCounterOldPos / (10000 / PhysicsConstants.PhysicsStepTime) + 1) % BallPositions.Count;
@@ -40,6 +55,18 @@ namespace VisualPinball.Unity
 					var damp = math.clamp(1.0f - (threshold - 666) / 10000, 0.23f, 1); // do not kill spin completely, otherwise stuck balls will happen during regular gameplay
 					ball.AngularMomentum *= damp;
 				}
+
+				// Rest detection: in contact, no positional drift over the ring-buffer
+				// window (~100 ms) and no linear velocity. While at rest, the angular
+				// momentum is nulled before integration (see BallVelocityPhysics) —
+				// the point-contact model has no drilling friction and the per-contact
+				// friction impulses holding the ball re-inject a bit of spin every
+				// tick, so without this a cradled ball keeps rotating forever.
+				ball.IsAtRest = mag < RestPositionEpsSq && mag2 < RestPositionEpsSq
+					&& math.lengthsq(ball.Velocity) < RestVelocityEpsSq;
+
+			} else {
+				ball.IsAtRest = false;
 			}
 		}
 	}

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallState.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallState.cs
@@ -51,6 +51,15 @@ namespace VisualPinball.Unity
 		public float Radius;
 		public float Mass;
 		public bool IsFrozen;
+
+		/// <summary>
+		/// Whether the ball is macroscopically at rest: in contact, no positional
+		/// drift over the last ~100 ms and no linear velocity. Detected at the end
+		/// of each cycle (see <see cref="BallSpinHackPhysics"/>); while set, the
+		/// angular momentum is nulled before integration, so the per-tick contact
+		/// impulses holding the ball in place can't keep it visibly spinning.
+		/// </summary>
+		public bool IsAtRest;
 		public int RingCounterOldPos;
 
 		public bool ManualControl;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallVelocityPhysics.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Ball/BallVelocityPhysics.cs
@@ -29,6 +29,24 @@ namespace VisualPinball.Unity
 				return;
 			}
 
+			// A resting ball must stop rotating. The point-contact model has no
+			// drilling friction, and the per-contact friction impulses that hold the
+			// ball in place re-inject a little angular momentum every tick (their
+			// torques don't cancel across sequentially solved contacts) — without
+			// this, a ball cradled on a raised flipper keeps spinning forever.
+			// Applied here, before displacement integrates it: a firm spin-down for
+			// visible spin, and a hard stop below ~30°/s (the per-tick injection is
+			// far below that band, so the flutter dies instantly). Any real impulse
+			// breaks the rest state (see BallSpinHackPhysics), so gameplay spin is
+			// unaffected.
+			if (ball.IsAtRest) {
+				ball.AngularMomentum *= 0.988f; // half-life ~60 ms
+				var restSpinEps = 0.005f * ball.Inertia; // ~30°/s
+				if (math.lengthsq(ball.AngularMomentum) < restSpinEps * restSpinEps) {
+					ball.AngularMomentum = float3.zero;
+				}
+			}
+
 			if (ball.ManualControl) {
 				ball.Velocity *= 0.5f; // Null out most of the X/Y velocity, want a little bit so the ball can sort of find its way out of obstacles.
 				ball.Velocity += new float3(

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/ColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/ColliderComponent.cs
@@ -230,13 +230,13 @@ namespace VisualPinball.Unity
 					Gizmos.matrix = playfieldToWorld * (Matrix4x4)Physics.VpxToWorld * (Matrix4x4)unmodifiedLocalToPlayfieldMatrixInVpx;
 					if (_untransformedColliderMesh) {
 						if (IsKinematic) {
-							Gizmos.color = colliderEnabled ? ColliderColor.UntransformedKineticColliderSelected : ColliderColor.DisabledColliderSelected;
+							Gizmos.color = colliderEnabled ? ColliderColor.UntransformedKinematicColliderSelected : ColliderColor.DisabledColliderSelected;
 						} else {
 							Gizmos.color = colliderEnabled ? ColliderColor.UntransformedColliderSelected : ColliderColor.DisabledColliderSelected;
 						}
 						Gizmos.DrawMesh(_untransformedColliderMesh);
 						if (IsKinematic) {
-							Gizmos.color = Application.isPlaying ? ColliderColor.UntransformedKineticCollider : white;
+							Gizmos.color = Application.isPlaying ? ColliderColor.UntransformedKinematicCollider : white;
 						} else {
 							Gizmos.color = Application.isPlaying ? ColliderColor.UntransformedCollider : white;
 						}
@@ -251,13 +251,13 @@ namespace VisualPinball.Unity
 					//Gizmos.matrix = MainComponent.transform.localToWorldMatrix * playfieldToWorld * (Matrix4x4)Physics.VpxToWorld;
 					if (_transformedColliderMesh) {
 						if (IsKinematic) {
-							Gizmos.color = colliderEnabled ? ColliderColor.TransformedKineticColliderSelected : ColliderColor.DisabledColliderSelected;
+							Gizmos.color = colliderEnabled ? ColliderColor.TransformedKinematicColliderSelected : ColliderColor.DisabledColliderSelected;
 						} else {
 							Gizmos.color = colliderEnabled ? ColliderColor.TransformedColliderSelected : ColliderColor.DisabledColliderSelected;
 						}
 						Gizmos.DrawMesh(_transformedColliderMesh);
 						if (IsKinematic) {
-							Gizmos.color = Application.isPlaying ? ColliderColor.TransformedKineticCollider : white;
+							Gizmos.color = Application.isPlaying ? ColliderColor.TransformedKinematicCollider : white;
 						} else {
 							Gizmos.color = Application.isPlaying ? ColliderColor.TransformedCollider : white;
 						}
@@ -780,12 +780,12 @@ namespace VisualPinball.Unity
 		internal static readonly Color SelectedAabb = new Color32(255, 255, 255, 128);
 		internal static readonly Color TransformedCollider = new Color32(0, 255, 75, 50);
 		internal static readonly Color TransformedColliderSelected = new Color32(0, 255, 75, 128);
-		internal static readonly Color TransformedKineticCollider = new Color32(255, 255, 0, 50);
-		internal static readonly Color TransformedKineticColliderSelected = new Color32(255, 255, 0, 128);
+		internal static readonly Color TransformedKinematicCollider = new Color32(255, 255, 0, 50);
+		internal static readonly Color TransformedKinematicColliderSelected = new Color32(255, 255, 0, 128);
 		internal static readonly Color UntransformedCollider = new Color32(0, 255, 255, 50);
 		internal static readonly Color UntransformedColliderSelected = new Color32(0, 255, 255, 128);
-		internal static readonly Color UntransformedKineticCollider = new Color32(255, 50, 50, 50);
-		internal static readonly Color UntransformedKineticColliderSelected = new Color32(255, 50, 50, 128);
+		internal static readonly Color UntransformedKinematicCollider = new Color32(255, 50, 50, 50);
+		internal static readonly Color UntransformedKinematicColliderSelected = new Color32(255, 50, 50, 128);
 		internal static readonly Color DisabledColliderSelected = new Color32(255, 0, 255, 128);
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/ColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/ColliderComponent.cs
@@ -160,7 +160,8 @@ namespace VisualPinball.Unity
 
 		public virtual void OnTransformationChanged(float4x4 currTransformationMatrix)
 		{
-			// do nothing per default.
+			// invalidate cached collider gizmo meshes, so they're redrawn at the new pose
+			_collidersDirty = true;
 		}
 
 		#endregion
@@ -171,6 +172,66 @@ namespace VisualPinball.Unity
 
 		private Player _player;
 		private NativeOctree<int> _octree;
+
+		/// <summary>
+		/// Arrow length per VPX unit/sec of linear velocity, in VPX units.
+		/// </summary>
+		private const float LinearVelocityGizmoScale = 1f;
+
+		/// <summary>
+		/// Axis-arrow length per rad/sec of angular velocity, in VPX units.
+		/// </summary>
+		private const float AngularVelocityGizmoScale = 50f;
+
+		/// <summary>
+		/// Draws the current kinematic velocity while playing: a yellow arrow for
+		/// linear velocity, a cyan arrow along the rotation axis for angular
+		/// velocity, plus a numeric label. Only visible while the item is moving.
+		/// </summary>
+		private void OnDrawGizmos()
+		{
+			if (!Application.isPlaying || !_isKinematic) {
+				return;
+			}
+			if (!PhysicsEngine) {
+				PhysicsEngine = GetComponentInParent<PhysicsEngine>();
+				if (!PhysicsEngine) {
+					return;
+				}
+			}
+			if (!PhysicsEngine.TryGetKinematicVelocity(ItemId, out var linearVelocity, out var angularVelocity, out var pivot)) {
+				return;
+			}
+			var linSq = math.lengthsq(linearVelocity);
+			var angSq = math.lengthsq(angularVelocity);
+			if (linSq < 1e-6f && angSq < 1e-6f) {
+				return;
+			}
+			var playfieldComponent = GetComponentInParent<PlayfieldComponent>();
+			if (!playfieldComponent) {
+				return;
+			}
+			var vpxToWorld = playfieldComponent.transform.localToWorldMatrix * (Matrix4x4)Physics.VpxToWorld;
+			var origin = vpxToWorld.MultiplyPoint3x4(pivot);
+
+			if (linSq >= 1e-6f) {
+				var tip = vpxToWorld.MultiplyPoint3x4(pivot + linearVelocity * LinearVelocityGizmoScale);
+				DrawVelocityArrow(origin, tip, Color.yellow);
+			}
+			if (angSq >= 1e-6f) {
+				var tip = vpxToWorld.MultiplyPoint3x4(pivot + angularVelocity * AngularVelocityGizmoScale);
+				DrawVelocityArrow(origin, tip, Color.cyan);
+			}
+			Handles.Label(origin, $"v = {math.sqrt(linSq):F1} u/s   ω = {math.degrees(math.sqrt(angSq)):F1} °/s");
+		}
+
+		private static void DrawVelocityArrow(Vector3 from, Vector3 to, Color color)
+		{
+			Gizmos.color = color;
+			Gizmos.matrix = Matrix4x4.identity;
+			Gizmos.DrawLine(from, to);
+			Gizmos.DrawSphere(to, (to - from).magnitude * 0.05f);
+		}
 
 		private void OnDrawGizmosSelected()
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerColliderComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Kicker/KickerColliderComponent.cs
@@ -109,6 +109,8 @@ namespace VisualPinball.Unity
 
 		public override void OnTransformationChanged(float4x4 currTransformationMatrix)
 		{
+			base.OnTransformationChanged(currTransformationMatrix);
+
 			// update kicker center, so the internal collision shape is correct
 			ref var kickerData = ref PhysicsEngine.KickerState(_itemId);
 			kickerData.Static.Center = currTransformationMatrix.c3.xy;

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Light/LightComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Light/LightComponent.cs
@@ -253,8 +253,14 @@ namespace VisualPinball.Unity
 				if (emissiveIntensity > 0) {
 					_materials.Add((mr, emissiveIntensity));
 
-					// Treat any emissive renderer as a faux-bulb style visual that should
-					// dim/hide with lamp intensity, independent of object naming.
+					// Transparent emissive renderers are lamp-lit *surfaces* (e.g. insert lens
+					// materials on pipelines that fake transmission with emission): they get the
+					// emissive drive above, but must stay visible when the lamp is off. Only
+					// opaque emissive renderers are faux-bulb visuals that dim/hide with lamp
+					// intensity, independent of object naming.
+					if (mr.sharedMaterial.renderQueue > (int)UnityEngine.Rendering.RenderQueue.GeometryLast) {
+						continue;
+					}
 					var hasBaseColor = mr.sharedMaterial.HasProperty(BaseColor);
 					var hasColor = mr.sharedMaterial.HasProperty(ColorProperty);
 					var baseColor = hasBaseColor

--- a/VisualPinball.Unity/VisualPinball.Unity/VPT/Light/LightPackable.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/VPT/Light/LightPackable.cs
@@ -163,6 +163,8 @@ namespace VisualPinball.Unity
 			light.intensity = Intensity;
 			light.enabled = Enabled;
 			Hdrp.Apply(light);
+			// Values applied above are HDRP-physical; a non-HDRP pipeline converts them here.
+			VpeLightUnitAdjuster.Active?.Invoke(light);
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "com.unity.cloud.gltfast": "6.10.1",
     "com.unity.formats.fbx": "4.1.2",
     "com.unity.inputsystem": "1.19.0",
+    "com.unity.modules.audio": "1.0.0",
+    "com.unity.modules.unitywebrequest": "1.0.0",
+    "com.unity.modules.unitywebrequestaudio": "1.0.0",
     "com.unity.nuget.newtonsoft-json": "3.2.1",
     "com.unity.ugui": "2.5.0",
     "com.unity.test-framework": "1.7.0"


### PR DESCRIPTION
This PR adds kinematic collider velocity handling so moving colliders can properly impart momentum and friction to balls, including paced per-tick pose stepping to reduce tunneling during fast motion. Also stops resting balls from spinning indefinitely.

https://github.com/user-attachments/assets/73d9eaea-fac7-4b19-b97f-304d3a706bf0

Includes a few related runtime/package updates:
- Adds `vpe.insert` material profile support for playfield inserts.
- Enables packaged audio clip loading through `UnityWebRequest`.
- Adds a light unit adjuster hook for non-HDRP pipelines.