### PR TITLE
Modernize Asset Browser

### DIFF
--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.cs
@@ -211,9 +211,8 @@ namespace VisualPinball.Unity.Editor
 						foreach (var assetResult in _selectedResults.Where(a => lib.HasAsset(a.Asset.GUID)).ToList()) {
 							_selectedResults.Remove(assetResult);
 							lib.DeleteAsset(assetResult.Asset);
-							if (libs.Length == 1 && _thumbCache.ContainsKey(assetResult.Asset.GUID)) {
-								DestroyImmediate(_thumbCache[assetResult.Asset.GUID]);
-								_thumbCache.Remove(assetResult.Asset.GUID);
+							if (libs.Length == 1) {
+								RemoveCachedThumbnails(assetResult.Asset.GUID);
 							}
 							numRemovedAssets++;
 						}
@@ -568,10 +567,7 @@ namespace VisualPinball.Unity.Editor
 
 		public void RefreshThumb(Asset asset)
 		{
-			if (_thumbCache.ContainsKey(asset.GUID)) {
-				DestroyImmediate(_thumbCache[asset.GUID]);
-				_thumbCache.Remove(asset.GUID);
-			}
+			RemoveCachedThumbnails(asset.GUID);
 			var visibleResult = _visibleElements.Keys.FirstOrDefault(result => result.Asset == asset);
 			if (visibleResult != null) {
 				LoadThumb(_visibleElements[visibleResult], asset);

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.cs
@@ -57,8 +57,9 @@ namespace VisualPinball.Unity.Editor
 		private AssetResult _firstSelectedResult;
 		private readonly HashSet<AssetResult> _selectedResults = new();
 
-		private readonly Dictionary<Asset, VisualElement> _elementByAsset = new();
-		private readonly Dictionary<VisualElement, AssetResult> _resultByElement = new();
+		private readonly Dictionary<AssetResult, VisualElement> _visibleElements = new();
+		private readonly List<int> _gridRowStarts = new();
+		private int _gridColumnCount = 1;
 
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
@@ -175,20 +176,10 @@ namespace VisualPinball.Unity.Editor
 		private void UpdateQueryResults(List<AssetResult> results, long duration)
 		{
 			_assetResults = results;
-			_gridContent.Clear();
-			_elementByAsset.Clear();
-			_resultByElement.Clear();
 			_selectedResults.Clear();
 
 			LastSelectedResult = null;
-			foreach (var row in results) {
-				var element = NewItem(row);
-				_elementByAsset[row.Asset] = element;
-				_resultByElement[element] = row;
-				_gridContent.Add(element);
-			}
-
-			_gridContent.MarkDirtyRepaint(); // todo doesn't work, scrolling is still screwed.
+			RebuildGridRows(true);
 
 			if (!results.Contains(_firstSelectedResult)) {
 				_firstSelectedResult = null;
@@ -201,6 +192,9 @@ namespace VisualPinball.Unity.Editor
 
 			private void AddAssetContextMenu(ContextualMenuPopulateEvent evt, AssetResult clickedAsset)
 			{
+				if (clickedAsset == null) {
+					return;
+				}
 				var libs = clickedAsset.Asset.Libraries;
 				if (libs.All(l => l.IsLocked)) {
 					Debug.Log("Early out in AddAssetContextMenu, all libraries are locked.");
@@ -211,7 +205,7 @@ namespace VisualPinball.Unity.Editor
 				foreach (var lib in libs.Where(l => !l.IsLocked)) {
 					evt.menu.AppendAction($"Remove from {lib.Name}", _ => {
 						if (_selectedResults.Add(clickedAsset)) {
-							ToggleSelectionClass(_elementByAsset[clickedAsset.Asset]);
+							UpdateSelectionClass(clickedAsset);
 						}
 						var numRemovedAssets = 0;
 						foreach (var assetResult in _selectedResults.Where(a => lib.HasAsset(a.Asset.GUID)).ToList()) {
@@ -322,7 +316,9 @@ namespace VisualPinball.Unity.Editor
 			if (evt.button != 0) {
 				return;
 			}
-			var clickedAsset = _resultByElement[element];
+			if (element.userData is not AssetResult clickedAsset) {
+				return;
+			}
 
 			// no modifier pressed
 			if (!evt.shiftKey && !evt.ctrlKey) {
@@ -438,11 +434,11 @@ namespace VisualPinball.Unity.Editor
 				if (i >= start && i <= end) {
 					if (!_selectedResults.Contains(asset)) {
 						_selectedResults.Add(asset);
-						ToggleSelectionClass(_elementByAsset[asset.Asset]);
+						UpdateSelectionClass(asset);
 					}
 				} else if (_selectedResults.Contains(asset)) {
 					_selectedResults.Remove(asset);
-					ToggleSelectionClass(_elementByAsset[asset.Asset]);
+					UpdateSelectionClass(asset);
 				}
 			}
 		}
@@ -450,7 +446,7 @@ namespace VisualPinball.Unity.Editor
 		private void SelectNone()
 		{
 			foreach (var selectedAsset in _selectedResults) {
-				ToggleSelectionClass(_elementByAsset[selectedAsset.Asset]);
+				UpdateSelectionClass(selectedAsset, false);
 			}
 			_selectedResults.Clear();
 			_firstSelectedResult = null;
@@ -462,7 +458,7 @@ namespace VisualPinball.Unity.Editor
 			var wasAlreadySelected = false;
 			foreach (var selectedAsset in _selectedResults) {
 				if (selectedAsset != result) {
-					ToggleSelectionClass(_elementByAsset[selectedAsset.Asset]);
+					UpdateSelectionClass(selectedAsset, false);
 				} else {
 					wasAlreadySelected = true;
 				}
@@ -470,7 +466,7 @@ namespace VisualPinball.Unity.Editor
 			_selectedResults.Clear();
 			_selectedResults.Add(result);
 			if (!wasAlreadySelected) {
-				ToggleSelectionClass(_elementByAsset[result.Asset]);
+				UpdateSelectionClass(result, true);
 			}
 			_firstSelectedResult = result;
 			LastSelectedResult = result;
@@ -479,7 +475,7 @@ namespace VisualPinball.Unity.Editor
 		private void UnSelect(AssetResult result)
 		{
 			_selectedResults.Remove(result);
-			ToggleSelectionClass(_elementByAsset[result.Asset]);
+			UpdateSelectionClass(result, false);
 			_firstSelectedResult = _selectedResults.Count > 0 ? _selectedResults.FirstOrDefault() : null;
 			LastSelectedResult = _selectedResults.Count > 0 ? _selectedResults.LastOrDefault() : null;
 		}
@@ -488,11 +484,16 @@ namespace VisualPinball.Unity.Editor
 		private void Select(AssetResult result)
 		{
 			_selectedResults.Add(result);
-			ToggleSelectionClass(_elementByAsset[result.Asset]);
+			UpdateSelectionClass(result, true);
 			LastSelectedResult = result;
 		}
 
-		private static void ToggleSelectionClass(VisualElement element) => element.ToggleInClassList("selected");
+		private void UpdateSelectionClass(AssetResult result, bool? selected = null)
+		{
+			if (_visibleElements.TryGetValue(result, out var element)) {
+				element.EnableInClassList("selected", selected ?? _selectedResults.Contains(result));
+			}
+		}
 
 		#endregion Selection
 
@@ -571,22 +572,22 @@ namespace VisualPinball.Unity.Editor
 				DestroyImmediate(_thumbCache[asset.GUID]);
 				_thumbCache.Remove(asset.GUID);
 			}
-			if (_elementByAsset.ContainsKey(asset)) {
-				LoadThumb(_elementByAsset[asset], asset);
+			var visibleResult = _visibleElements.Keys.FirstOrDefault(result => result.Asset == asset);
+			if (visibleResult != null) {
+				LoadThumb(_visibleElements[visibleResult], asset);
 			}
 		}
 
 		private void OnThumbSizeChanged(ChangeEvent<float> evt)
 		{
 			_thumbnailSize = (int)evt.newValue;
-			foreach (var e in _elementByAsset.Values) {
-				e.Q<LibraryAssetElement>().SetSize(_thumbnailSize);
-			}
+			RebuildGridRows();
 		}
 
 		public void AttachData(AssetResult clickedResult)
 		{
 			_selectedResults.Add(clickedResult);
+			UpdateSelectionClass(clickedResult, true);
 			DragAndDrop.objectReferences = _selectedResults.Select(result => result.Asset.Object).ToArray();
 			StartDraggingAssets(_selectedResults);
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.cs
@@ -106,6 +106,9 @@ namespace VisualPinball.Unity.Editor
 			}
 
 			// setup query
+			if (Query != null) {
+				Query.OnQueryUpdated -= OnQueryUpdated;
+			}
 			Query = new AssetQuery(Libraries.Where(lib => lib.IsActive).ToList());
 			Query.OnQueryUpdated += OnQueryUpdated;
 
@@ -196,19 +199,8 @@ namespace VisualPinball.Unity.Editor
 			_statusLabel.text = $"Found {results.Count} asset" + (results.Count == 1 ? "" : "s") + $" in {duration}ms.";
 		}
 
-			private void AddAssetContextMenu(ContextualMenuPopulateEvent evt)
+			private void AddAssetContextMenu(ContextualMenuPopulateEvent evt, AssetResult clickedAsset)
 			{
-				if (evt.target is not VisualElement target) {
-					Debug.Log("Early out in AddAssetContextMenu, target is no VisualElement.");
-					return;
-				}
-
-				if (!_resultByElement.ContainsKey(target.parent.parent)) {
-					Debug.Log($"Early out in AddAssetContextMenu, {target.parent.parent} not in resultByElement.");
-					return;
-				}
-
-				var clickedAsset = _resultByElement[target.parent.parent];
 				var libs = clickedAsset.Asset.Libraries;
 				if (libs.All(l => l.IsLocked)) {
 					Debug.Log("Early out in AddAssetContextMenu, all libraries are locked.");
@@ -300,7 +292,7 @@ namespace VisualPinball.Unity.Editor
 							foreach (var attr in srcAsset.Attributes) {
 								destAsset.AddAttribute(attr.Key, attr.Value);
 							}
-							foreach (var link in srcAsset.Links.Where(link => destAsset.Links.FirstOrDefault(l => l.Name == link.Name) != null)) {
+							foreach (var link in srcAsset.Links.Where(link => destAsset.Links.All(l => l.Name != link.Name))) {
 								destAsset.Links.Add(new AssetLink(link.Name, link.Url));
 							}
 
@@ -370,7 +362,12 @@ namespace VisualPinball.Unity.Editor
 		}
 
 		public void OnCategoriesUpdated(Dictionary<AssetLibrary, List<AssetCategory>> categories) => Query.Filter(categories);
-		private void OnSearchQueryChanged(ChangeEvent<string> evt) => Query.Search(evt.newValue);
+		private void OnSearchQueryChanged(ChangeEvent<string> evt)
+		{
+			_pendingSearch = evt.newValue;
+			_searchScheduledItem?.Pause();
+			_searchScheduledItem = _queryInput.schedule.Execute(() => Query?.Search(_pendingSearch)).StartingIn(200);
+		}
 		private void OnLibraryToggled(AssetLibrary lib, bool enabled)
 		{
 			lib.IsActive = enabled;
@@ -381,11 +378,14 @@ namespace VisualPinball.Unity.Editor
 
 		public AssetLibrary GetLibraryByPath(string pathToCheck)
 		{
-			pathToCheck = pathToCheck.Replace('\\', '/');
-			return Libraries.FirstOrDefault(assetLibrary => {
-				var libraryPath = assetLibrary.LibraryRoot.Replace('\\', '/');
-				return pathToCheck.StartsWith(libraryPath);
-			});
+			pathToCheck = pathToCheck.Replace('\\', '/').TrimEnd('/');
+			return Libraries
+				.OrderByDescending(assetLibrary => assetLibrary.LibraryRoot.Length)
+				.FirstOrDefault(assetLibrary => {
+					var libraryPath = assetLibrary.LibraryRoot.Replace('\\', '/').TrimEnd('/');
+					return string.Equals(pathToCheck, libraryPath, StringComparison.Ordinal)
+					       || pathToCheck.StartsWith(libraryPath + "/", StringComparison.Ordinal);
+				});
 		}
 
 		public void AddAssets(IEnumerable<string> paths, Func<AssetLibrary, AssetCategory> getCategory)

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.cs
@@ -43,6 +43,9 @@ namespace VisualPinball.Unity.Editor
 
 		[SerializeField]
 		private List<string> _selectedLibraries;
+		private readonly Dictionary<AssetLibrary, string> _libraryAssetPaths = new();
+		private readonly HashSet<AssetLibrary> _pendingLibraryReindexes = new();
+		private bool _fullLibraryRefreshPending;
 
 		[NonSerialized]
 		private List<AssetResult> _assetResults;
@@ -98,6 +101,11 @@ namespace VisualPinball.Unity.Editor
 				.Select(AssetDatabase.GUIDToAssetPath)
 				.Select(AssetDatabase.LoadAssetAtPath<AssetLibrary>)
 				.Where(lib => lib != null).ToList();
+			_libraryAssetPaths.Clear();
+			foreach (var lib in Libraries) {
+				lib.IsActive = selectedLibraries?.Contains(lib.Id) ?? true;
+				_libraryAssetPaths[lib] = NormalizeAssetPath(AssetDatabase.GetAssetPath(lib));
+			}
 
 			// toggle label
 			if (Libraries.Count == 0) {
@@ -116,7 +124,6 @@ namespace VisualPinball.Unity.Editor
 			// update left column and subscribe
 			_libraryList.Clear();
 			foreach (var lib in Libraries) {
-				lib.IsActive = selectedLibraries?.Contains(lib.Id) ?? true;
 				_libraryList.Add(NewAssetLibrary(lib));
 				lib.OnChange += OnLibraryChanged;
 			}
@@ -124,9 +131,75 @@ namespace VisualPinball.Unity.Editor
 
 		private void OnLibraryChanged(object sender, EventArgs e)
 		{
-			RefreshLibraries();
+			if (sender is AssetLibrary library) {
+				ScheduleLibraryReindex(library);
+			} else {
+				ScheduleFullLibraryRefresh();
+			}
+		}
+
+		private void OnAssetFilesChanged(string[] paths)
+		{
+			var normalizedPaths = paths.Select(NormalizeAssetPath).ToArray();
+			var libraries = (Libraries ?? Enumerable.Empty<AssetLibrary>()).ToArray();
+			var databaseRoots = libraries.ToDictionary(library => library, library => NormalizeAssetPath(library.DatabaseRoot));
+			if (normalizedPaths.Any(path => _libraryAssetPaths.Values.Contains(path))) {
+				ScheduleFullLibraryRefresh();
+				return;
+			}
+			var pathsOutsideDatabases = normalizedPaths
+				.Where(path => databaseRoots.Values.All(root => !IsPathWithin(path, root)));
+			if (pathsOutsideDatabases.Any(path => AssetDatabase.GetMainAssetTypeAtPath(path) == typeof(AssetLibrary))) {
+				ScheduleFullLibraryRefresh();
+				return;
+			}
+			foreach (var library in libraries) {
+				if (normalizedPaths.Any(path => IsPathWithin(path, databaseRoots[library]))) {
+					ScheduleLibraryReindex(library);
+				}
+			}
+		}
+
+		private void ScheduleLibraryReindex(AssetLibrary library)
+		{
+			if (library != null) {
+				_pendingLibraryReindexes.Add(library);
+			}
+			ScheduleLibraryRefresh();
+		}
+
+		private void ScheduleFullLibraryRefresh()
+		{
+			_fullLibraryRefreshPending = true;
+			ScheduleLibraryRefresh();
+		}
+
+		private void ScheduleLibraryRefresh()
+		{
+			_libraryRefreshScheduledItem?.Pause();
+			_libraryRefreshScheduledItem = rootVisualElement.schedule.Execute(ApplyPendingLibraryChanges).StartingIn(50);
+		}
+
+		private void ApplyPendingLibraryChanges()
+		{
+			if (_fullLibraryRefreshPending) {
+				_fullLibraryRefreshPending = false;
+				_pendingLibraryReindexes.Clear();
+				Refresh();
+				return;
+			}
+			var libraries = _pendingLibraryReindexes.ToArray();
+			_pendingLibraryReindexes.Clear();
+			foreach (var library in libraries.Where(library => Libraries.Contains(library))) {
+				Query.Reindex(library);
+			}
 			RefreshCategories();
 		}
+
+		private static string NormalizeAssetPath(string path) => (path ?? string.Empty).Replace('\\', '/').TrimEnd('/');
+
+		private static bool IsPathWithin(string path, string root) => root.Length > 0
+			&& (string.Equals(path, root, StringComparison.Ordinal) || path.StartsWith(root + "/", StringComparison.Ordinal));
 
 		public void FilterByAttribute(string attributeKey, string value, bool remove = false)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.cs
@@ -194,6 +194,7 @@ namespace VisualPinball.Unity.Editor
 				Query.Reindex(library);
 			}
 			RefreshCategories();
+			RefreshAssets();
 		}
 
 		private static string NormalizeAssetPath(string path) => (path ?? string.Empty).Replace('\\', '/').TrimEnd('/');

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.uss
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.uss
@@ -55,10 +55,14 @@ LibraryCategoryView {
 	background-color: #333333; /* sampled from project window */
 }
 
-#gridContent .unity-scroll-view__content-container {
+#gridContent .unity-collection-view__item {
+	padding: 0;
+}
+
+.asset-grid-row {
 	flex-direction: row;
-	flex-wrap: wrap;
-	padding: 10px;
+	padding-left: 10px;
+	padding-right: 10px;
 }
 
 #gridContent .unity-image {

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.uxml
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser.uxml
@@ -32,7 +32,7 @@
 			<ui:VisualElement>
 
 				<!-- CONTENT -->
-				<ui:ScrollView name="gridContent" focusable="true"/>
+				<ui:ListView name="gridContent" focusable="true"/>
 
 				<!-- ERROR PANEL -->
 				<ui:VisualElement name="dragErrorContainer" class="hidden">

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowserPostprocessor.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowserPostprocessor.cs
@@ -1,0 +1,41 @@
+// Visual Pinball Engine
+// Copyright (C) 2026 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Linq;
+using UnityEditor;
+
+namespace VisualPinball.Unity.Editor
+{
+	internal sealed class AssetBrowserPostprocessor : AssetPostprocessor
+	{
+		public static event Action<string[]> AssetFilesChanged;
+
+		private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
+		{
+			var changedPaths = importedAssets
+				.Concat(deletedAssets)
+				.Concat(movedAssets)
+				.Concat(movedFromAssetPaths)
+				.Where(path => path.EndsWith(".asset", StringComparison.OrdinalIgnoreCase))
+				.Distinct(StringComparer.Ordinal)
+				.ToArray();
+			if (changedPaths.Length > 0) {
+				AssetFilesChanged?.Invoke(changedPaths);
+			}
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowserPostprocessor.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowserPostprocessor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 29de95b8e05440ea9c91a3076154f568

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser_Init.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser_Init.cs
@@ -31,7 +31,7 @@ namespace VisualPinball.Unity.Editor
 		private VisualElement _libraryList;
 		private Label _noLibrariesLabel;
 
-		private VisualElement _gridContent;
+		private ListView _gridContent;
 		private Label _dragErrorLabelLeft;
 		private VisualElement _dragErrorContainerLeft;
 		private Label _dragErrorLabel;
@@ -101,8 +101,15 @@ namespace VisualPinball.Unity.Editor
 			_noLibrariesLabel = ui.Q<Label>("noLibraries");
 
 			_categoryView = ui.Q<LibraryCategoryView>();
-			_gridContent = ui.Q<VisualElement>("gridContent");
+			_gridContent = ui.Q<ListView>("gridContent");
 			_gridContent.styleSheets.Add(_assetStyle);
+			_gridContent.makeItem = MakeGridRow;
+			_gridContent.bindItem = BindGridRow;
+			_gridContent.unbindItem = UnbindGridRow;
+			_gridContent.itemsSource = _gridRowStarts;
+			_gridContent.selectionType = SelectionType.None;
+			_gridContent.virtualizationMethod = CollectionVirtualizationMethod.FixedHeight;
+			UpdateGridMetrics();
 			_detailsElement = ui.Q<AssetDetails>();
 
 			_statusLabel = ui.Q<Label>("bottomLabel");
@@ -127,6 +134,8 @@ namespace VisualPinball.Unity.Editor
 			_gridContent.RegisterCallback<DragEnterEvent>(OnDragEnterEvent);
 			_gridContent.RegisterCallback<DragLeaveEvent>(OnDragLeaveEvent);
 			_gridContent.RegisterCallback<PointerUpEvent>(OnEmptyClicked);
+			_gridContent.RegisterCallback<KeyDownEvent>(OnGridKeyDown);
+			_gridContent.RegisterCallback<GeometryChangedEvent>(OnGridGeometryChanged);
 
 			ui.panel.visualTree.userData = this; // children need access to this. if there's another way of getting the panel's owner object, let me know!
 
@@ -140,6 +149,8 @@ namespace VisualPinball.Unity.Editor
 			_queryInput?.UnregisterValueChangedCallback(OnSearchQueryChanged);
 
 			_gridContent?.UnregisterCallback<PointerUpEvent>(OnEmptyClicked);
+			_gridContent?.UnregisterCallback<KeyDownEvent>(OnGridKeyDown);
+			_gridContent?.UnregisterCallback<GeometryChangedEvent>(OnGridGeometryChanged);
 			_gridContent?.UnregisterCallback<DragLeaveEvent>(OnDragLeaveEvent);
 			_gridContent?.UnregisterCallback<DragEnterEvent>(OnDragEnterEvent);
 			_gridContent?.UnregisterCallback<DragPerformEvent>(OnDragPerformEvent);
@@ -162,26 +173,157 @@ namespace VisualPinball.Unity.Editor
 			_thumbCache.Clear();
 		}
 
-		private VisualElement NewItem(AssetResult result)
+		private VisualElement MakeGridRow()
 		{
-			var item = new VisualElement();
-			_assetTree.CloneTree(item);
-			var assetElement = item.Q<LibraryAssetElement>();
-			assetElement.Result = result;
+			var row = new VisualElement();
+			row.AddToClassList("asset-grid-row");
+			return row;
+		}
 
-			LoadThumb(item, result.Asset);
-			var img = item.Q<VisualElement>("thumbnail-mask");
-			assetElement.SetSize(_thumbnailSize);
+		private void BindGridRow(VisualElement row, int rowIndex)
+		{
+			EnsureGridCells(row);
+			var rowStart = _gridRowStarts[rowIndex];
+			for (var column = 0; column < _gridColumnCount; column++) {
+				var cell = row[column];
+				var resultIndex = rowStart + column;
+				if (resultIndex < _assetResults.Count) {
+					BindGridCell(cell, _assetResults[resultIndex]);
+				} else {
+					UnbindGridCell(cell);
+				}
+			}
+		}
 
-			var label = item.Q<Label>("label");
-			label.text = result.Asset.Name;
+		private void UnbindGridRow(VisualElement row, int rowIndex)
+		{
+			foreach (var cell in row.Children()) {
+				UnbindGridCell(cell);
+			}
+		}
+
+		private void EnsureGridCells(VisualElement row)
+		{
+			while (row.childCount > _gridColumnCount) {
+				var lastCell = row[row.childCount - 1];
+				UnbindGridCell(lastCell);
+				lastCell.RemoveFromHierarchy();
+			}
+			while (row.childCount < _gridColumnCount) {
+				row.Add(CreateGridCell());
+			}
+		}
+
+		private VisualElement CreateGridCell()
+		{
+			var cell = new VisualElement();
+			_assetTree.CloneTree(cell);
+			var assetElement = cell.Q<LibraryAssetElement>();
+			var img = cell.Q<VisualElement>("thumbnail-mask");
+			var label = cell.Q<Label>("label");
 			label.style.textOverflow = TextOverflow.Ellipsis;
-			item.RegisterCallback<ClickEvent>(evt => OnAssetClicked(evt, item));
-
+			cell.RegisterCallback<ClickEvent>(evt => OnAssetClicked(evt, cell));
 			assetElement.RegisterDrag(this);
-			img.AddManipulator(new ContextualMenuManipulator(evt => AddAssetContextMenu(evt, result)));
-			label.AddManipulator(new ContextualMenuManipulator(evt => AddAssetContextMenu(evt, result)));
-			return item;
+			img.AddManipulator(new ContextualMenuManipulator(evt => AddAssetContextMenu(evt, cell.userData as AssetResult)));
+			label.AddManipulator(new ContextualMenuManipulator(evt => AddAssetContextMenu(evt, cell.userData as AssetResult)));
+			return cell;
+		}
+
+		private void BindGridCell(VisualElement cell, AssetResult result)
+		{
+			UnbindGridCell(cell);
+			cell.userData = result;
+			cell.style.display = DisplayStyle.Flex;
+			var assetElement = cell.Q<LibraryAssetElement>();
+			assetElement.Result = result;
+			assetElement.SetSize(_thumbnailSize);
+			cell.Q<Label>("label").text = result.Asset.Name;
+			_visibleElements[result] = cell;
+			cell.EnableInClassList("selected", _selectedResults.Contains(result));
+			LoadThumb(cell, result.Asset);
+		}
+
+		private void UnbindGridCell(VisualElement cell)
+		{
+			if (cell.userData is AssetResult previousResult) {
+				_visibleElements.Remove(previousResult);
+			}
+			cell.userData = null;
+			cell.RemoveFromClassList("selected");
+			cell.style.display = DisplayStyle.None;
+			var assetElement = cell.Q<LibraryAssetElement>();
+			if (assetElement != null) {
+				assetElement.Result = null;
+			}
+			var image = cell.Q<Image>("thumbnail");
+			if (image != null) {
+				image.image = null;
+			}
+		}
+
+		private void OnGridGeometryChanged(GeometryChangedEvent evt)
+		{
+			var columnCount = CalculateGridColumnCount(evt.newRect.width);
+			if (columnCount == _gridColumnCount) {
+				return;
+			}
+			_gridColumnCount = columnCount;
+			RebuildGridRows();
+		}
+
+		private void OnGridKeyDown(KeyDownEvent evt)
+		{
+			if (_assetResults == null || _assetResults.Count == 0) {
+				return;
+			}
+			var currentIndex = _firstSelectedResult == null ? 0 : _assetResults.IndexOf(_firstSelectedResult);
+			var targetIndex = evt.keyCode switch {
+				KeyCode.LeftArrow => currentIndex - 1,
+				KeyCode.RightArrow => currentIndex + 1,
+				KeyCode.UpArrow => currentIndex - _gridColumnCount,
+				KeyCode.DownArrow => currentIndex + _gridColumnCount,
+				KeyCode.Home => 0,
+				KeyCode.End => _assetResults.Count - 1,
+				_ => currentIndex
+			};
+			if (targetIndex == currentIndex && evt.keyCode is not KeyCode.Home and not KeyCode.End) {
+				return;
+			}
+			targetIndex = Mathf.Clamp(targetIndex, 0, _assetResults.Count - 1);
+			var target = _assetResults[targetIndex];
+			if (evt.shiftKey && _firstSelectedResult != null) {
+				SelectRange(_assetResults.IndexOf(_firstSelectedResult), targetIndex);
+				LastSelectedResult = target;
+			} else {
+				SelectOnly(target);
+			}
+			_gridContent.ScrollToItem(targetIndex / _gridColumnCount);
+			evt.StopPropagation();
+		}
+
+		private int CalculateGridColumnCount(float width) => Mathf.Max(1, Mathf.FloorToInt((width - 20f) / (_thumbnailSize + 20f)));
+
+		private void UpdateGridMetrics()
+		{
+			_gridContent.fixedItemHeight = _thumbnailSize + 36f;
+			_gridColumnCount = CalculateGridColumnCount(_gridContent.contentRect.width);
+		}
+
+		private void RebuildGridRows(bool resetScroll = false)
+		{
+			if (_gridContent == null || _assetResults == null) {
+				return;
+			}
+			UpdateGridMetrics();
+			_gridRowStarts.Clear();
+			for (var i = 0; i < _assetResults.Count; i += _gridColumnCount) {
+				_gridRowStarts.Add(i);
+			}
+			_visibleElements.Clear();
+			_gridContent.Rebuild();
+			if (resetScroll && _gridRowStarts.Count > 0) {
+				_gridContent.ScrollToItem(0);
+			}
 		}
 
 		private void LoadThumb(VisualElement el, Asset asset)

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser_Init.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser_Init.cs
@@ -54,6 +54,7 @@ namespace VisualPinball.Unity.Editor
 		private long _thumbCacheBytes;
 		private bool _isDestroyed;
 		private IVisualElementScheduledItem _searchScheduledItem;
+		private IVisualElementScheduledItem _libraryRefreshScheduledItem;
 		private string _pendingSearch;
 
 		private const string ClassDrag = "library-element--dragover";
@@ -146,6 +147,7 @@ namespace VisualPinball.Unity.Editor
 			_gridContent.RegisterCallback<PointerUpEvent>(OnEmptyClicked);
 			_gridContent.RegisterCallback<KeyDownEvent>(OnGridKeyDown);
 			_gridContent.RegisterCallback<GeometryChangedEvent>(OnGridGeometryChanged);
+			AssetBrowserPostprocessor.AssetFilesChanged += OnAssetFilesChanged;
 
 			ui.panel.visualTree.userData = this; // children need access to this. if there's another way of getting the panel's owner object, let me know!
 
@@ -156,6 +158,8 @@ namespace VisualPinball.Unity.Editor
 		{
 			_isDestroyed = true;
 			_searchScheduledItem?.Pause();
+			_libraryRefreshScheduledItem?.Pause();
+			AssetBrowserPostprocessor.AssetFilesChanged -= OnAssetFilesChanged;
 			_sizeSlider?.UnregisterValueChangedCallback(OnThumbSizeChanged);
 			_queryInput?.UnregisterValueChangedCallback(OnSearchQueryChanged);
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser_Init.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser_Init.cs
@@ -14,7 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using UnityEditor;
 using UnityEditor.UIElements;
 using UnityEngine;
@@ -43,11 +47,17 @@ namespace VisualPinball.Unity.Editor
 		private VisualTreeAsset _assetTree;
 		private StyleSheet _assetStyle;
 
-		private readonly Dictionary<string, Texture2D> _thumbCache = new();
+		private readonly Dictionary<ThumbnailKey, CachedThumbnail> _thumbCache = new();
+		private readonly LinkedList<ThumbnailKey> _thumbLru = new();
+		private readonly Dictionary<VisualElement, CancellationTokenSource> _thumbnailLoads = new();
+		private readonly SemaphoreSlim _thumbnailDecodeSlots = new(4);
+		private long _thumbCacheBytes;
+		private bool _isDestroyed;
 		private IVisualElementScheduledItem _searchScheduledItem;
 		private string _pendingSearch;
 
 		private const string ClassDrag = "library-element--dragover";
+		private const long ThumbCacheBudget = 256L * 1024L * 1024L;
 
 		public string DragErrorLeft {
 			get => _dragErrorContainerLeft.ClassListContains("hidden") ? null : _dragErrorLabelLeft.text;
@@ -144,6 +154,7 @@ namespace VisualPinball.Unity.Editor
 
 		private void OnDestroy()
 		{
+			_isDestroyed = true;
 			_searchScheduledItem?.Pause();
 			_sizeSlider?.UnregisterValueChangedCallback(OnThumbSizeChanged);
 			_queryInput?.UnregisterValueChangedCallback(OnSearchQueryChanged);
@@ -167,10 +178,16 @@ namespace VisualPinball.Unity.Editor
 			if (Query != null) {
 				Query.OnQueryUpdated -= OnQueryUpdated;
 			}
-			foreach (var texture in _thumbCache.Values) {
-				DestroyImmediate(texture);
+			foreach (var load in _thumbnailLoads.Values) {
+				load.Cancel();
+			}
+			_thumbnailLoads.Clear();
+			foreach (var thumbnail in _thumbCache.Values) {
+				DestroyImmediate(thumbnail.Texture);
 			}
 			_thumbCache.Clear();
+			_thumbLru.Clear();
+			_thumbCacheBytes = 0;
 		}
 
 		private VisualElement MakeGridRow()
@@ -245,6 +262,7 @@ namespace VisualPinball.Unity.Editor
 
 		private void UnbindGridCell(VisualElement cell)
 		{
+			CancelThumbnailLoad(cell);
 			if (cell.userData is AssetResult previousResult) {
 				_visibleElements.Remove(previousResult);
 			}
@@ -326,19 +344,160 @@ namespace VisualPinball.Unity.Editor
 			}
 		}
 
-		private void LoadThumb(VisualElement el, Asset asset)
+		private async void LoadThumb(VisualElement element, Asset asset)
 		{
-			if (!_thumbCache.ContainsKey(asset.GUID)) {
-				if (asset.HasThumbnail) {
-					var tex = asset.LoadThumbTexture(asset.ThumbnailPath);
-					_thumbCache[asset.GUID] = tex;
-				}
+			CancelThumbnailLoad(element);
+			var imageElement = element.Q<Image>("thumbnail");
+			imageElement.image = null;
+			if (!asset.HasThumbnail) {
+				return;
 			}
-			if (_thumbCache.ContainsKey(asset.GUID)) {
-				var img = el.Q<Image>("thumbnail");
-				img.image = _thumbCache[asset.GUID];
-				img.style.width = new StyleLength(new Length(100, LengthUnit.Percent));
-				img.style.height = new StyleLength(new Length(100, LengthUnit.Percent));
+
+			var key = new ThumbnailKey(asset.GUID, _thumbnailSize);
+			if (TryGetCachedThumbnail(key, out var cachedTexture)) {
+				SetThumbnail(imageElement, cachedTexture);
+				return;
+			}
+
+			var thumbnailPath = asset.ThumbnailPath;
+			var result = element.userData as AssetResult;
+			var cancellation = new CancellationTokenSource();
+			var cancellationToken = cancellation.Token;
+			_thumbnailLoads[element] = cancellation;
+			try {
+				await _thumbnailDecodeSlots.WaitAsync(cancellationToken);
+				ThumbnailData data;
+				try {
+					data = await Task.Run(() => {
+						cancellationToken.ThrowIfCancellationRequested();
+						var decoded = Asset.DecodeThumbnail(thumbnailPath, key.Size);
+						cancellationToken.ThrowIfCancellationRequested();
+						return decoded;
+					}, cancellationToken);
+				} finally {
+					_thumbnailDecodeSlots.Release();
+				}
+				await Awaitable.MainThreadAsync();
+				cancellationToken.ThrowIfCancellationRequested();
+				if (_isDestroyed || element.userData as AssetResult != result) {
+					return;
+				}
+				if (TryGetCachedThumbnail(key, out cachedTexture)) {
+					SetThumbnail(imageElement, cachedTexture);
+					return;
+				}
+
+				var texture = new Texture2D(data.Width, data.Height, TextureFormat.RGB24, false) {
+					hideFlags = HideFlags.HideAndDontSave
+				};
+				texture.LoadRawTextureData(data.Pixels);
+				texture.Apply(false, true);
+				CacheThumbnail(key, texture, data.Pixels.LongLength);
+				SetThumbnail(imageElement, texture);
+			} catch (OperationCanceledException) {
+				// A recycled cell no longer needs this thumbnail.
+			} catch (Exception exception) {
+				await Awaitable.MainThreadAsync();
+				if (!_isDestroyed) {
+					Debug.LogWarning($"Could not load thumbnail {thumbnailPath}: {exception.Message}");
+				}
+			} finally {
+				await Awaitable.MainThreadAsync();
+				if (_thumbnailLoads.TryGetValue(element, out var activeLoad) && activeLoad == cancellation) {
+					_thumbnailLoads.Remove(element);
+				}
+				cancellation.Dispose();
+			}
+		}
+
+		private static void SetThumbnail(Image image, Texture2D texture)
+		{
+			image.image = texture;
+			image.style.width = new StyleLength(new Length(100, LengthUnit.Percent));
+			image.style.height = new StyleLength(new Length(100, LengthUnit.Percent));
+		}
+
+		private void CancelThumbnailLoad(VisualElement element)
+		{
+			if (!_thumbnailLoads.TryGetValue(element, out var load)) {
+				return;
+			}
+			_thumbnailLoads.Remove(element);
+			load.Cancel();
+		}
+
+		private bool TryGetCachedThumbnail(ThumbnailKey key, out Texture2D texture)
+		{
+			if (!_thumbCache.TryGetValue(key, out var cached)) {
+				texture = null;
+				return false;
+			}
+			_thumbLru.Remove(cached.LruNode);
+			_thumbLru.AddFirst(cached.LruNode);
+			texture = cached.Texture;
+			return true;
+		}
+
+		private void CacheThumbnail(ThumbnailKey key, Texture2D texture, long sizeBytes)
+		{
+			if (_thumbCache.TryGetValue(key, out var existing)) {
+				_thumbCacheBytes -= existing.SizeBytes;
+				_thumbLru.Remove(existing.LruNode);
+				DestroyImmediate(existing.Texture);
+			}
+			var node = _thumbLru.AddFirst(key);
+			_thumbCache[key] = new CachedThumbnail(texture, sizeBytes, node);
+			_thumbCacheBytes += sizeBytes;
+			while (_thumbCacheBytes > ThumbCacheBudget && _thumbLru.Last != null) {
+				RemoveCachedThumbnail(_thumbLru.Last.Value);
+			}
+		}
+
+		private void RemoveCachedThumbnail(ThumbnailKey key)
+		{
+			if (!_thumbCache.TryGetValue(key, out var cached)) {
+				return;
+			}
+			_thumbCache.Remove(key);
+			_thumbLru.Remove(cached.LruNode);
+			_thumbCacheBytes -= cached.SizeBytes;
+			DestroyImmediate(cached.Texture);
+		}
+
+		private void RemoveCachedThumbnails(string guid)
+		{
+			foreach (var key in _thumbCache.Keys.Where(key => key.Guid == guid).ToArray()) {
+				RemoveCachedThumbnail(key);
+			}
+		}
+
+		private readonly struct ThumbnailKey : System.IEquatable<ThumbnailKey>
+		{
+			public readonly string Guid;
+			public readonly int Size;
+
+			public ThumbnailKey(string guid, int size)
+			{
+				Guid = guid;
+				Size = size;
+			}
+
+			public bool Equals(ThumbnailKey other) => Guid == other.Guid && Size == other.Size;
+			public override bool Equals(object obj) => obj is ThumbnailKey other && Equals(other);
+			public override int GetHashCode() => System.HashCode.Combine(Guid, Size);
+		}
+
+		private sealed class CachedThumbnail
+		{
+			public readonly Texture2D Texture;
+			public readonly long SizeBytes;
+			public readonly LinkedListNode<ThumbnailKey> LruNode;
+
+			public CachedThumbnail(Texture2D texture, long sizeBytes, LinkedListNode<ThumbnailKey> lruNode)
+			{
+				Texture = texture;
+				SizeBytes = sizeBytes;
+				LruNode = lruNode;
 			}
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser_Init.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetBrowser_Init.cs
@@ -1,4 +1,4 @@
-﻿// Visual Pinball Engine
+// Visual Pinball Engine
 // Copyright (C) 2023 freezy and VPE Team
 //
 // This program is free software: you can redistribute it and/or modify
@@ -44,6 +44,8 @@ namespace VisualPinball.Unity.Editor
 		private StyleSheet _assetStyle;
 
 		private readonly Dictionary<string, Texture2D> _thumbCache = new();
+		private IVisualElementScheduledItem _searchScheduledItem;
+		private string _pendingSearch;
 
 		private const string ClassDrag = "library-element--dragover";
 
@@ -100,6 +102,7 @@ namespace VisualPinball.Unity.Editor
 
 			_categoryView = ui.Q<LibraryCategoryView>();
 			_gridContent = ui.Q<VisualElement>("gridContent");
+			_gridContent.styleSheets.Add(_assetStyle);
 			_detailsElement = ui.Q<AssetDetails>();
 
 			_statusLabel = ui.Q<Label>("bottomLabel");
@@ -132,26 +135,37 @@ namespace VisualPinball.Unity.Editor
 
 		private void OnDestroy()
 		{
-			_sizeSlider.UnregisterValueChangedCallback(OnThumbSizeChanged);
-			_queryInput.UnregisterValueChangedCallback(OnSearchQueryChanged);
+			_searchScheduledItem?.Pause();
+			_sizeSlider?.UnregisterValueChangedCallback(OnThumbSizeChanged);
+			_queryInput?.UnregisterValueChangedCallback(OnSearchQueryChanged);
 
-			_gridContent.UnregisterCallback<PointerUpEvent>(OnEmptyClicked);
-			_gridContent.UnregisterCallback<DragLeaveEvent>(OnDragLeaveEvent);
-			_gridContent.UnregisterCallback<DragEnterEvent>(OnDragEnterEvent);
-			_gridContent.UnregisterCallback<DragPerformEvent>(OnDragPerformEvent);
-			_gridContent.UnregisterCallback<DragUpdatedEvent>(OnDragUpdatedEvent);
-			_refreshButton.clicked -= Refresh;
-
-			foreach (var assetLibrary in Libraries) {
-				assetLibrary.OnChange -= OnLibraryChanged;
+			_gridContent?.UnregisterCallback<PointerUpEvent>(OnEmptyClicked);
+			_gridContent?.UnregisterCallback<DragLeaveEvent>(OnDragLeaveEvent);
+			_gridContent?.UnregisterCallback<DragEnterEvent>(OnDragEnterEvent);
+			_gridContent?.UnregisterCallback<DragPerformEvent>(OnDragPerformEvent);
+			_gridContent?.UnregisterCallback<DragUpdatedEvent>(OnDragUpdatedEvent);
+			if (_refreshButton != null) {
+				_refreshButton.clicked -= Refresh;
 			}
+
+			if (Libraries != null) {
+				foreach (var assetLibrary in Libraries) {
+					assetLibrary.OnChange -= OnLibraryChanged;
+				}
+			}
+			if (Query != null) {
+				Query.OnQueryUpdated -= OnQueryUpdated;
+			}
+			foreach (var texture in _thumbCache.Values) {
+				DestroyImmediate(texture);
+			}
+			_thumbCache.Clear();
 		}
 
 		private VisualElement NewItem(AssetResult result)
 		{
 			var item = new VisualElement();
 			_assetTree.CloneTree(item);
-			item.styleSheets.Add(_assetStyle);
 			var assetElement = item.Q<LibraryAssetElement>();
 			assetElement.Result = result;
 
@@ -165,8 +179,8 @@ namespace VisualPinball.Unity.Editor
 			item.RegisterCallback<ClickEvent>(evt => OnAssetClicked(evt, item));
 
 			assetElement.RegisterDrag(this);
-			img.AddManipulator(new ContextualMenuManipulator(AddAssetContextMenu));
-			label.AddManipulator(new ContextualMenuManipulator(AddAssetContextMenu));
+			img.AddManipulator(new ContextualMenuManipulator(evt => AddAssetContextMenu(evt, result)));
+			label.AddManipulator(new ContextualMenuManipulator(evt => AddAssetContextMenu(evt, result)));
 			return item;
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetLibrary.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetLibrary.cs
@@ -1,4 +1,4 @@
-﻿// Visual Pinball Engine
+// Visual Pinball Engine
 // Copyright (C) 2023 freezy and VPE Team
 //
 // This program is free software: you can redistribute it and/or modify
@@ -59,6 +59,9 @@ namespace VisualPinball.Unity.Editor
 		[NonSerialized]
 		public bool IsActive;
 
+		[NonSerialized]
+		private bool _changeScheduled;
+
 		#region Asset
 
 		public bool AddAsset(Object obj, AssetCategory category)
@@ -99,6 +102,7 @@ namespace VisualPinball.Unity.Editor
 		}
 
 		public IEnumerable<AssetResult> GetAssets(LibraryQuery q) => _db.GetAssets(q);
+		internal IEnumerable<Asset> GetAllAssets() => _db.GetAllAssets();
 
 		/// <summary>
 		/// Physically deletes the asset from the library, including thumbnails.
@@ -127,6 +131,7 @@ namespace VisualPinball.Unity.Editor
 				throw new InvalidOperationException($"Cannot remove asset because library {Name} is locked.");
 			}
 			_db.RemoveAsset(asset);
+			SaveLibrary();
 		}
 
 		public void MoveAsset(Asset asset, AssetLibrary destLibrary)
@@ -213,6 +218,7 @@ namespace VisualPinball.Unity.Editor
 		}
 
 		public int NumAssetsWithCategory(AssetCategory category) => _db.NumAssetsWithCategory(category);
+		internal IReadOnlyDictionary<AssetCategory, int> GetCategoryCounts() => _db.GetCategoryCounts();
 
 		public void DeleteCategory(AssetCategory category)
 		{
@@ -307,10 +313,7 @@ namespace VisualPinball.Unity.Editor
 		{
 		}
 
-		// private void OnValidate()
-		// {
-		// 	OnChange?.Invoke(this, EventArgs.Empty);
-		// }
+		private void OnValidate() => ScheduleChange();
 
 		#endregion
 
@@ -325,6 +328,24 @@ namespace VisualPinball.Unity.Editor
 		{
 			EditorUtility.SetDirty(this);
 			AssetDatabase.SaveAssetIfDirty(this);
+			ScheduleChange();
+		}
+
+		private void ScheduleChange()
+		{
+			if (_changeScheduled) {
+				return;
+			}
+			_changeScheduled = true;
+			EditorApplication.delayCall += RaiseChange;
+		}
+
+		private void RaiseChange()
+		{
+			_changeScheduled = false;
+			if (this != null) {
+				OnChange?.Invoke(this, EventArgs.Empty);
+			}
 		}
 
 		#endregion

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetQuery.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetQuery.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using NLog;
 using Unity.Mathematics;
 
@@ -35,22 +34,18 @@ namespace VisualPinball.Unity.Editor
 		public bool HasTag(string tag) => _tags.Contains(tag);
 		public bool HasAttribute(string attrKey, string attrValue) => _attributes.ContainsKey(attrKey) && _attributes[attrKey].Contains(attrValue);
 
-		public bool HasQuality(AssetQuality quality) => _quality == quality.ToString();
+		public bool HasQuality(AssetQuality quality) => string.Equals(_quality, quality.ToString(), StringComparison.OrdinalIgnoreCase);
 
 		private readonly List<AssetLibrary> _libraries;
+		private readonly Dictionary<AssetLibrary, AssetSearchIndex> _indexes = new();
 		private string _keywords;
 		private Dictionary<AssetLibrary, List<AssetCategory>> _categories;
-		private readonly Dictionary<string, HashSet<string>> _attributes = new();
-		private readonly HashSet<string> _tags = new();
+		private Dictionary<string, HashSet<string>> _attributes = new(StringComparer.OrdinalIgnoreCase);
+		private HashSet<string> _tags = new(StringComparer.OrdinalIgnoreCase);
 		private string _quality = null;
 
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 		private readonly Stopwatch _queryTime = new();
-
-		private const string QuotedValuePattern = "(?:\\\\.|[^\"\\\\])*";
-		private static readonly Regex AttributeRegex = new(
-			$"(?:\"(?<key>{QuotedValuePattern})\"|(?<key>[\\w\\d_/-]+)):(?:\"(?<value>{QuotedValuePattern})\"|(?<value>[\\w\\d_/-]+))"
-		);
 
 		public static string ValueToQuery(string value) => value
 			.Replace("\\", "\\\\")
@@ -72,42 +67,20 @@ namespace VisualPinball.Unity.Editor
 		public AssetQuery(List<AssetLibrary> libraries)
 		{
 			_libraries = libraries;
+			foreach (var library in libraries) {
+				_indexes[library] = new AssetSearchIndex(library);
+			}
 		}
 
 		public void Search(string q)
 		{
 			StartTimer();
 
-			// parse attributes
-			_attributes.Clear();
-			q = AttributeRegex.Replace(q, match => {
-				var key = QueryToValue(match.Groups["key"].Value);
-				if (!_attributes.ContainsKey(key)) {
-					_attributes[key] = new HashSet<string>();
-				}
-				_attributes[key].Add(QueryToValue(match.Groups["value"].Value));
-				return " ";
-			});
-
-			_tags.Clear();
-			var tagRegex = new Regex(@"\[([^\]]+)\]");
-			q = tagRegex.Replace(q, match => {
-				_tags.Add(match.Groups[1].Value);
-				return " ";
-			});
-
-			_quality = null;
-			var qualityRegex = new Regex(@"\(([^\)]+)\)");
-			q = qualityRegex.Replace(q, match => {
-				if (_quality != null) {
-					return match.Value;
-				}
-				_quality = match.Groups[1].Value;
-				return " ";
-			});
-
-			// clean white spaces
-			_keywords = Regex.Replace(q, @"\s+", " ").Trim();
+			var parsed = AssetQueryTokenizer.Parse(q ?? string.Empty);
+			_attributes = parsed.Attributes;
+			_tags = parsed.Tags;
+			_quality = parsed.Quality;
+			_keywords = parsed.Keywords;
 
 			Run();
 		}
@@ -124,6 +97,7 @@ namespace VisualPinball.Unity.Editor
 			StartTimer();
 			if (lib.IsActive && !_libraries.Contains(lib)) {
 				_libraries.Add(lib);
+				_indexes[lib] = new AssetSearchIndex(lib);
 			}
 			if (!lib.IsActive && _libraries.Contains(lib)) {
 				_libraries.Remove(lib);
@@ -131,21 +105,28 @@ namespace VisualPinball.Unity.Editor
 			Run();
 		}
 
+		public void Reindex(AssetLibrary library)
+		{
+			if (_libraries.Contains(library)) {
+				_indexes[library] = new AssetSearchIndex(library);
+			}
+		}
+
 		public string[] AttributeNames => _libraries
-			.SelectMany(lib => lib.GetAttributeKeys())
-			.Distinct()
+			.SelectMany(lib => _indexes[lib].AttributeNames)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
 			.OrderBy(x => x)
 			.ToArray();
 
 		public string[] TagNames => _libraries
-			.SelectMany(lib => lib.GetAllTags())
-			.Distinct()
+			.SelectMany(lib => _indexes[lib].TagNames)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
 			.OrderBy(x => x)
 			.ToArray();
 
 		public string[] AttributeValues(string attributeKey) => _libraries
-			.SelectMany(lib => lib.GetAttributeValues(attributeKey))
-			.Distinct()
+			.SelectMany(lib => _indexes[lib].AttributeValues(attributeKey))
+			.Distinct(StringComparer.OrdinalIgnoreCase)
 			.ToArray();
 
 		private void StartTimer()
@@ -162,7 +143,7 @@ namespace VisualPinball.Unity.Editor
 						if (_categories is { Count: > 0 } && !_categories.ContainsKey(lib)) {
 							return Array.Empty<AssetResult>();
 						}
-						return lib.GetAssets(new LibraryQuery {
+						return _indexes[lib].Search(new LibraryQuery {
 							Keywords = _keywords,
 							Categories = _categories != null && _categories.ContainsKey(lib) ? _categories[lib] : null,
 							Attributes = _attributes,
@@ -177,7 +158,7 @@ namespace VisualPinball.Unity.Editor
 					}
 				})
 				.OrderBy(r => r.Score)
-				.ThenBy(r => r.Asset.Name)
+				.ThenBy(r => r.Name)
 				.ToList();
 
 			OnQueryUpdated?.Invoke(this, new AssetQueryResult(assets, _queryTime.ElapsedMilliseconds));
@@ -187,11 +168,13 @@ namespace VisualPinball.Unity.Editor
 	public class AssetResult : IEquatable<AssetResult>
 	{
 		public readonly Asset Asset;
+		public readonly string Name;
 		public long Score;
 
-		public AssetResult(Asset asset, long score)
+		public AssetResult(Asset asset, long score, string name = null)
 		{
 			Asset = asset;
+			Name = name ?? asset.Name;
 			Score = score;
 		}
 
@@ -204,7 +187,7 @@ namespace VisualPinball.Unity.Editor
 
 		public override string ToString()
 		{
-			return $"[{Asset.Library.Name}] {Asset.Name}";
+			return $"[{Asset.Library.Name}] {Name}";
 		}
 
 		#region IEquatable

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetQuery.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetQuery.cs
@@ -1,4 +1,4 @@
-﻿// Visual Pinball Engine
+// Visual Pinball Engine
 // Copyright (C) 2023 freezy and VPE Team
 //
 // This program is free software: you can redistribute it and/or modify
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using NLog;
 using Unity.Mathematics;
@@ -46,9 +47,27 @@ namespace VisualPinball.Unity.Editor
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 		private readonly Stopwatch _queryTime = new();
 
-		public static string ValueToQuery(string value) => value.Contains(" ") ? value.Replace("\"", "in") : value;
+		private const string QuotedValuePattern = "(?:\\\\.|[^\"\\\\])*";
+		private static readonly Regex AttributeRegex = new(
+			$"(?:\"(?<key>{QuotedValuePattern})\"|(?<key>[\\w\\d_/-]+)):(?:\"(?<value>{QuotedValuePattern})\"|(?<value>[\\w\\d_/-]+))"
+		);
 
-		public static string QueryToValue(string query) => query.Contains(" ") ? query.Replace("in", "\"") : query;
+		public static string ValueToQuery(string value) => value
+			.Replace("\\", "\\\\")
+			.Replace("\"", "\\\"");
+
+		public static string QueryToValue(string query)
+		{
+			var value = new StringBuilder(query.Length);
+			for (var i = 0; i < query.Length; i++) {
+				if (query[i] == '\\' && i + 1 < query.Length && (query[i + 1] == '\\' || query[i + 1] == '"')) {
+					value.Append(query[++i]);
+				} else {
+					value.Append(query[i]);
+				}
+			}
+			return value.ToString();
+		}
 
 		public AssetQuery(List<AssetLibrary> libraries)
 		{
@@ -61,39 +80,31 @@ namespace VisualPinball.Unity.Editor
 
 			// parse attributes
 			_attributes.Clear();
-			const string quoted = "\"([\\w\\d\\s_/-]+)\"";
-			const string nonQuoted = "([\\w\\d_/\"-]+)";
-			var regexes = new[] {
-				new Regex($"{quoted}:{quoted}"),
-				new Regex($"{quoted}:{nonQuoted}"),
-				new Regex($"{nonQuoted}:{quoted}"),
-				new Regex($"{nonQuoted}:{nonQuoted}"),
-			};
-			foreach (var regex in regexes) {
-				foreach (Match match in regex.Matches(q)) {
-					var key = match.Groups[1].Value;
-					if (!_attributes.ContainsKey(key)) {
-						_attributes[key] = new HashSet<string>();
-					}
-					_attributes[key].Add(QueryToValue(match.Groups[2].Value));
-					q = q.Replace(match.Value, "");
+			q = AttributeRegex.Replace(q, match => {
+				var key = QueryToValue(match.Groups["key"].Value);
+				if (!_attributes.ContainsKey(key)) {
+					_attributes[key] = new HashSet<string>();
 				}
-			}
+				_attributes[key].Add(QueryToValue(match.Groups["value"].Value));
+				return " ";
+			});
 
 			_tags.Clear();
 			var tagRegex = new Regex(@"\[([^\]]+)\]");
-			foreach (Match match in tagRegex.Matches(q)) {
+			q = tagRegex.Replace(q, match => {
 				_tags.Add(match.Groups[1].Value);
-				q = q.Replace(match.Value, "");
-			}
+				return " ";
+			});
 
 			_quality = null;
-			var qualityRegex = new Regex(@"\(([^\]]+)\)");
-			foreach (Match match in qualityRegex.Matches(q)) {
+			var qualityRegex = new Regex(@"\(([^\)]+)\)");
+			q = qualityRegex.Replace(q, match => {
+				if (_quality != null) {
+					return match.Value;
+				}
 				_quality = match.Groups[1].Value;
-				q = q.Replace(match.Value, "");
-				break;
-			}
+				return " ";
+			});
 
 			// clean white spaces
 			_keywords = Regex.Replace(q, @"\s+", " ").Trim();

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetQueryTokenizer.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetQueryTokenizer.cs
@@ -1,0 +1,145 @@
+// Visual Pinball Engine
+// Copyright (C) 2026 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace VisualPinball.Unity.Editor
+{
+	internal static class AssetQueryTokenizer
+	{
+		public static ParsedAssetQuery Parse(string query)
+		{
+			var parsed = new ParsedAssetQuery();
+			var keywords = new List<string>();
+			var index = 0;
+			while (index < query.Length) {
+				SkipWhitespace(query, ref index);
+				if (index >= query.Length) {
+					break;
+				}
+
+				if (query[index] == '[') {
+					if (TryReadDelimited(query, ref index, '[', ']', out var tag)) {
+						if (!string.IsNullOrWhiteSpace(tag)) {
+							parsed.Tags.Add(tag);
+						}
+						continue;
+					}
+				}
+
+				if (query[index] == '(') {
+					if (TryReadDelimited(query, ref index, '(', ')', out var quality)) {
+						if (string.IsNullOrWhiteSpace(quality)) {
+							keywords.Add($"({quality})");
+						} else if (parsed.Quality == null) {
+							parsed.Quality = quality;
+						} else {
+							keywords.Add($"({quality})");
+						}
+						continue;
+					}
+				}
+
+				var termStart = index;
+				var keyOrKeyword = ReadToken(query, ref index, true);
+				if (index < query.Length && query[index] == ':') {
+					index++;
+					var value = ReadToken(query, ref index, false);
+					if (keyOrKeyword.Length > 0 && value.Length > 0) {
+						parsed.AddAttribute(keyOrKeyword, value);
+					} else {
+						keywords.Add(query.Substring(termStart, index - termStart));
+					}
+				} else if (keyOrKeyword.Length > 0) {
+					keywords.Add(keyOrKeyword);
+				} else {
+					index++;
+				}
+			}
+
+			parsed.Keywords = string.Join(" ", keywords.Where(keyword => keyword.Length > 0));
+			return parsed;
+		}
+
+		private static string ReadToken(string query, ref int index, bool stopAtColon)
+		{
+			if (index >= query.Length) {
+				return string.Empty;
+			}
+			if (query[index] != '"') {
+				var start = index;
+				while (index < query.Length && !char.IsWhiteSpace(query[index]) && (!stopAtColon || query[index] != ':')) {
+					index++;
+				}
+				return query.Substring(start, index - start);
+			}
+
+			index++;
+			var value = new StringBuilder();
+			while (index < query.Length) {
+				var character = query[index++];
+				if (character == '"') {
+					break;
+				}
+				if (character == '\\' && index < query.Length && (query[index] == '\\' || query[index] == '"')) {
+					value.Append(query[index++]);
+				} else {
+					value.Append(character);
+				}
+			}
+			return value.ToString();
+		}
+
+		private static bool TryReadDelimited(string query, ref int index, char opening, char closing, out string value)
+		{
+			var closingIndex = query.IndexOf(closing, index + 1);
+			if (closingIndex < 0) {
+				value = null;
+				return false;
+			}
+			value = query.Substring(index + 1, closingIndex - index - 1);
+			index = closingIndex + 1;
+			return true;
+		}
+
+		private static void SkipWhitespace(string query, ref int index)
+		{
+			while (index < query.Length && char.IsWhiteSpace(query[index])) {
+				index++;
+			}
+		}
+	}
+
+	internal sealed class ParsedAssetQuery
+	{
+		public string Keywords = string.Empty;
+		public string Quality;
+		public readonly Dictionary<string, HashSet<string>> Attributes = new(StringComparer.OrdinalIgnoreCase);
+		public readonly HashSet<string> Tags = new(StringComparer.OrdinalIgnoreCase);
+
+		public void AddAttribute(string key, string value)
+		{
+			if (!Attributes.TryGetValue(key, out var values)) {
+				values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+				Attributes[key] = values;
+			}
+			values.Add(value);
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetQueryTokenizer.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetQueryTokenizer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6b53b9aaecbf457a993d63d558d56148

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetSearchIndex.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetSearchIndex.cs
@@ -1,0 +1,141 @@
+// Visual Pinball Engine
+// Copyright (C) 2026 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor.Search;
+
+namespace VisualPinball.Unity.Editor
+{
+	internal sealed class AssetSearchIndex
+	{
+		private readonly List<IndexedAsset> _assets;
+
+		public AssetSearchIndex(AssetLibrary library)
+		{
+			_assets = library.GetAllAssets().Select(asset => new IndexedAsset(asset)).ToList();
+		}
+
+		public IEnumerable<AssetResult> Search(LibraryQuery query)
+		{
+			IEnumerable<IndexedAsset> results = _assets;
+			if (query.HasCategories) {
+				var categoryIds = new HashSet<string>(query.Categories.Select(category => category.Id));
+				results = results.Where(asset => categoryIds.Contains(asset.CategoryId));
+			}
+
+			if (query.HasAttributes) {
+				foreach (var (key, values) in query.Attributes) {
+					foreach (var value in values) {
+						results = results.Where(asset => asset.HasAttribute(key, value));
+					}
+				}
+			}
+
+			if (query.HasTags) {
+				foreach (var tag in query.Tags) {
+					results = results.Where(asset => asset.Tags.Contains(tag));
+				}
+			}
+
+			if (query.HasQuality && Enum.TryParse(query.Quality, true, out AssetQuality quality)) {
+				results = results.Where(asset => asset.Quality == quality);
+			}
+
+			return query.HasKeywords
+				? results.Select(asset => asset.Match(query.Keywords)).Where(result => result.Score > 0)
+				: results.Select(asset => new AssetResult(asset.Asset, 0L, asset.Name));
+		}
+
+		public IEnumerable<string> AttributeNames => _assets
+			.SelectMany(asset => asset.Attributes.Keys)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.OrderBy(value => value);
+
+		public IEnumerable<string> TagNames => _assets
+			.SelectMany(asset => asset.Tags)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.OrderBy(value => value);
+
+		public IEnumerable<string> AttributeValues(string key) => _assets
+			.Where(asset => asset.Attributes.ContainsKey(key))
+			.SelectMany(asset => asset.Attributes[key])
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.OrderBy(value => value);
+
+		private sealed class IndexedAsset
+		{
+			public readonly Asset Asset;
+			public readonly string Name;
+			public readonly string CategoryId;
+			public readonly AssetQuality Quality;
+			public readonly Dictionary<string, string[]> Attributes = new(StringComparer.OrdinalIgnoreCase);
+			public readonly HashSet<string> Tags = new(StringComparer.OrdinalIgnoreCase);
+
+			private readonly string[] _searchValues;
+
+			public IndexedAsset(Asset asset)
+			{
+				Asset = asset;
+				Name = asset.Name;
+				CategoryId = asset.Category?.Id;
+				Quality = asset.Quality;
+				foreach (var attribute in (IEnumerable<AssetAttribute>)asset.Attributes ?? Enumerable.Empty<AssetAttribute>()) {
+					if (string.IsNullOrEmpty(attribute.Key)) {
+						continue;
+					}
+					var values = (attribute.Value ?? string.Empty)
+						.Split(',')
+						.Select(value => value.Trim())
+						.Where(value => value.Length > 0)
+						.ToArray();
+					if (Attributes.TryGetValue(attribute.Key, out var existing)) {
+						Attributes[attribute.Key] = existing.Concat(values).ToArray();
+					} else {
+						Attributes[attribute.Key] = values;
+					}
+				}
+				foreach (var tag in (IEnumerable<AssetTag>)asset.Tags ?? Enumerable.Empty<AssetTag>()) {
+					if (!string.IsNullOrEmpty(tag.TagName)) {
+						Tags.Add(tag.TagName);
+					}
+				}
+				_searchValues = Tags.Concat(Attributes.Values.SelectMany(values => values)).ToArray();
+			}
+
+			public bool HasAttribute(string key, string value)
+			{
+				if (!Attributes.TryGetValue(key, out var values)) {
+					return false;
+				}
+				return value == null || values.Any(candidate => candidate.IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0);
+			}
+
+			public AssetResult Match(string keywords)
+			{
+				var result = new AssetResult(Asset, 0L, Name);
+				FuzzySearch.FuzzyMatch(keywords, Name, ref result.Score);
+				foreach (var value in _searchValues) {
+					var score = 0L;
+					FuzzySearch.FuzzyMatch(keywords, value, ref score);
+					result.AddScore(score);
+				}
+				return result;
+			}
+		}
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetSearchIndex.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetSearchIndex.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f133e1211bc0472bb0ada6f55a6cd604

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetStructure/Asset.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetStructure/Asset.cs
@@ -1,4 +1,4 @@
-﻿// Visual Pinball Engine
+// Visual Pinball Engine
 // Copyright (C) 2023 freezy and VPE Team
 //
 // This program is free software: you can redistribute it and/or modify
@@ -18,14 +18,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using NetVips;
 using UnityEditor;
 using UnityEditor.Presets;
 using UnityEngine;
-using Debug = UnityEngine.Debug;
 using Object = UnityEngine.Object;
 
 namespace VisualPinball.Unity.Editor
@@ -39,11 +38,14 @@ namespace VisualPinball.Unity.Editor
 	{
 		public string Name => Object != null ? Object.name : "<invalid ref>";
 
-		[SerializeReference]
+		[SerializeField]
 		public AssetLibrary Library;
 
-		[SerializeReference]
+		[SerializeField]
 		public Object Object;
+
+		[SerializeField]
+		private string _guid;
 
 		[SerializeField]
 		private string _categoryId;
@@ -83,7 +85,7 @@ namespace VisualPinball.Unity.Editor
 		[SerializeField]
 		public string EnvironmentGameObjectName;
 		
-		[SerializeReference]
+		[SerializeField]
 		public Preset ThumbCameraPreset;
 
 		[SerializeField]
@@ -94,7 +96,7 @@ namespace VisualPinball.Unity.Editor
 		[SerializeField]
 		public bool UnpackPrefab;
 
-		[SerializeReference]
+		[SerializeField]
 		public AssetQuality Quality = AssetQuality.Measured;
 
 		[NonSerialized]
@@ -107,17 +109,33 @@ namespace VisualPinball.Unity.Editor
 				.ToArray();
 
 		public DateTime AddedAt {
-			get => string.IsNullOrEmpty(_addedAt) ? DateTime.Now : Convert.ToDateTime(_addedAt);
-			set => _addedAt = value.ToString("o");
+			get => string.IsNullOrEmpty(_addedAt)
+				? DateTime.Now
+				: DateTime.Parse(_addedAt, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+			set => _addedAt = value.ToString("o", CultureInfo.InvariantCulture);
 		}
 
 		public string GUID {
 			get {
-				if (AssetDatabase.TryGetGUIDAndLocalFileIdentifier(Object, out var guid, out _)) {
-					return guid;
+				if (!string.IsNullOrEmpty(_guid)) {
+					return _guid;
 				}
-				throw new Exception($"Could not get GUID from {Object.name}");
+				if (AssetDatabase.TryGetGUIDAndLocalFileIdentifier(Object, out var guid, out _)) {
+					_guid = guid;
+					EditorUtility.SetDirty(this);
+				}
+				return _guid ?? string.Empty;
 			}
+		}
+
+		internal Asset SetGuid(string guid)
+		{
+			if (string.IsNullOrEmpty(_guid) && !string.IsNullOrEmpty(guid)) {
+				// Existing metadata is migrated from the library's serialized dictionary key on first read.
+				_guid = guid;
+				EditorUtility.SetDirty(this);
+			}
+			return this;
 		}
 
 		public string ThumbnailPath => Path.GetFullPath($"{Library.ThumbnailRoot}/{GUID}.webp");
@@ -202,8 +220,6 @@ namespace VisualPinball.Unity.Editor
 
 		public Texture2D LoadThumbTexture(string thumbnailPath)
 		{
-			var sw = Stopwatch.StartNew();
-
 			// Load the image using NetVips
 			var image = Image.NewFromBuffer(File.ReadAllBytes(thumbnailPath), access: Enums.Access.Sequential);
 
@@ -231,7 +247,6 @@ namespace VisualPinball.Unity.Editor
 			texture.LoadRawTextureData(raw);
 			texture.Apply();
 
-			Debug.Log($"Texture loaded in {sw.ElapsedMilliseconds}ms: {width}x{height}");
 			return texture;
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetStructure/Asset.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/AssetStructure/Asset.cs
@@ -250,6 +250,16 @@ namespace VisualPinball.Unity.Editor
 			return texture;
 		}
 
+		internal static ThumbnailData DecodeThumbnail(string thumbnailPath, int size)
+		{
+			using var thumbnail = Image.Thumbnail(thumbnailPath, size, height: size, size: Enums.Size.Down);
+			using var srgb = thumbnail.Colourspace(Enums.Interpretation.Srgb);
+			using var rgb = srgb.ExtractBand(0, 3);
+			using var uchar = rgb.Cast(Enums.BandFormat.Uchar);
+			using var flipped = uchar.Flip(Enums.Direction.Vertical);
+			return new ThumbnailData(flipped.WriteToMemory(), flipped.Width, flipped.Height);
+		}
+
 		/// <summary>
 		/// So this is basically a counter where the positions are the variations, and the figures are the overrides.
 		/// When the last override of the last variation has counted up, we're done.
@@ -320,5 +330,19 @@ namespace VisualPinball.Unity.Editor
 		}
 
 		public override string ToString() => Name;
+	}
+
+	internal readonly struct ThumbnailData
+	{
+		public readonly byte[] Pixels;
+		public readonly int Width;
+		public readonly int Height;
+
+		public ThumbnailData(byte[] pixels, int width, int height)
+		{
+			Pixels = pixels;
+			Width = width;
+			Height = height;
+		}
 	}
 }

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/LibraryCategoryElement.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/LibraryCategoryElement.cs
@@ -53,8 +53,9 @@ namespace VisualPinball.Unity.Editor
 		private readonly Label _label;
 		private readonly Image _lockIcon;
 		private readonly LibraryCategoryRenameElement _renameElement;
+		private readonly IReadOnlyDictionary<AssetCategory, int> _assetCounts;
 
-		private int NumAssets => Categories.Select(c => c.Item1.NumAssetsWithCategory(c.Item2)).Sum();
+		private int NumAssets => Categories.Sum(category => _assetCounts.TryGetValue(category.Item2, out var count) ? count : 0);
 		private bool AllLibrariesLocked => Categories.Count(c => !c.Item1.IsLocked) == 0;
 		public bool HasLockedLibraries => Categories.Any(c => c.Item1.IsLocked);
 		public AssetLibrary[] UnlockedLibraries => Categories.Where(c => !c.Item1.IsLocked).Select(c => c.Item1).ToArray();
@@ -70,10 +71,12 @@ namespace VisualPinball.Unity.Editor
 		/// </summary>
 		/// <param name="libraryCategoryView">Reference to parent</param>
 		/// <param name="categories">Category of each library</param>
-		public LibraryCategoryElement(LibraryCategoryView libraryCategoryView, IEnumerable<(AssetLibrary, AssetCategory)> categories)
+		public LibraryCategoryElement(LibraryCategoryView libraryCategoryView, IEnumerable<(AssetLibrary, AssetCategory)> categories,
+			IReadOnlyDictionary<AssetCategory, int> assetCounts = null)
 		{
 			_libraryCategoryView = libraryCategoryView;
 			Categories = categories.ToArray();
+			_assetCounts = assetCounts ?? new Dictionary<AssetCategory, int>();
 
 			var visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>("Packages/org.visualpinball.engine.unity/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/LibraryCategoryElement.uxml");
 			var ui = visualTree.CloneTree();

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/LibraryCategoryElement.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/LibraryCategoryElement.cs
@@ -1,4 +1,4 @@
-﻿// Visual Pinball Engine
+// Visual Pinball Engine
 // Copyright (C) 2023 freezy and VPE Team
 //
 // This program is free software: you can redistribute it and/or modify
@@ -43,6 +43,7 @@ namespace VisualPinball.Unity.Editor
 						break;
 				}
 				_isSelected = value;
+				UpdateIcon();
 			}
 		}
 

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/LibraryCategoryView.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/LibraryCategoryView.cs
@@ -1,4 +1,4 @@
-﻿// Visual Pinball Engine
+// Visual Pinball Engine
 // Copyright (C) 2023 freezy and VPE Team
 //
 // This program is free software: you can redistribute it and/or modify
@@ -106,8 +106,11 @@ namespace VisualPinball.Unity.Editor
 
 			// update categories
 
-			var categories = _browser.Libraries
-				.Where(lib => lib.IsActive)
+			var activeLibraries = _browser.Libraries.Where(lib => lib.IsActive).ToArray();
+			var categoryCounts = activeLibraries
+				.SelectMany(library => library.GetCategoryCounts())
+				.ToDictionary(pair => pair.Key, pair => pair.Value);
+			var categories = activeLibraries
 				.SelectMany(lib => lib.GetCategories().Select(c => (lib, c)))
 				.OrderBy(tuple => tuple.c.Name)
 				.GroupBy(t => t.Item2.Name, (_, g) => g);
@@ -117,7 +120,7 @@ namespace VisualPinball.Unity.Editor
 			NumCategories = 0;
 			_container.Clear();
 			foreach (var cat in categories) {
-				var categoryElement = new LibraryCategoryElement(this, cat);
+				var categoryElement = new LibraryCategoryElement(this, cat, categoryCounts);
 				_container.Add(categoryElement);
 				if (selectedCategoryNames.Contains(categoryElement.Name)) {
 					categoryElement.IsSelected = true;

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/LibraryDatabase.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/LibraryDatabase.cs
@@ -1,4 +1,4 @@
-﻿// Visual Pinball Engine
+// Visual Pinball Engine
 // Copyright (C) 2023 freezy and VPE Team
 //
 // This program is free software: you can redistribute it and/or modify
@@ -56,7 +56,7 @@ namespace VisualPinball.Unity.Editor
 			if (query.HasKeywords) {
 				results = results
 					.Select(result => {
-						FuzzySearch.FuzzyMatch(query.Keywords, result.Asset.Object.name, ref result.Score);
+						FuzzySearch.FuzzyMatch(query.Keywords, result.Asset.Name, ref result.Score);
 						foreach (var tag in result.Asset.Tags.Select(t => t.TagName)) {
 							var score = 0L;
 							FuzzySearch.FuzzyMatch(query.Keywords, tag, ref score);
@@ -82,7 +82,7 @@ namespace VisualPinball.Unity.Editor
 					foreach (var attrValue in attrValues) {
 						results = results.Where(result => result.Asset.Attributes != null && result.Asset.Attributes.Any(at => {
 							var keyMatches = string.Equals(at.Key, attrKey, StringComparison.CurrentCultureIgnoreCase);
-							var valueMatches = attrValue != null && at.Value != null && at.Value.ToLower().Contains(attrValue.ToLower());
+							var valueMatches = attrValue != null && at.Value != null && at.Value.IndexOf(attrValue, StringComparison.OrdinalIgnoreCase) >= 0;
 							return attrValue != null ? keyMatches && valueMatches : keyMatches;
 						}));
 					}
@@ -92,7 +92,7 @@ namespace VisualPinball.Unity.Editor
 			// tag filter
 			if (query.HasTags) {
 				foreach (var tag in query.Tags) {
-					results = results.Where(result => result.Asset.Tags != null && result.Asset.Tags.Any(t => t.TagName == tag));
+					results = results.Where(result => result.Asset.Tags != null && result.Asset.Tags.Any(t => string.Equals(t.TagName, tag, StringComparison.OrdinalIgnoreCase)));
 				}
 			}
 
@@ -115,6 +115,10 @@ namespace VisualPinball.Unity.Editor
 			asset.name = obj.name;
 			asset.Library = lib;
 			asset.Object = obj;
+			if (!AssetDatabase.TryGetGUIDAndLocalFileIdentifier(obj, out var guid, out long _)) {
+				throw new InvalidOperationException($"Cannot add {obj.name} because its GUID could not be resolved.");
+			}
+			asset.SetGuid(guid);
 			asset.Category = category;
 			asset.Attributes = new List<AssetAttribute>();
 			asset.Tags = new List<AssetTag>();
@@ -342,8 +346,12 @@ namespace VisualPinball.Unity.Editor
 				Debug.LogWarning($"Asset with ID {k} is null.");
 				return false;
 			}
+			if (this[k].Object == null) {
+				Debug.LogWarning($"Asset with ID {k} has a missing object reference and will be skipped.");
+				return false;
+			}
 			return true;
-		}).Select(k => this[k].SetCategory(lib));
+		}).Select(k => this[k].SetGuid(k).SetCategory(lib));
 		public void Add(Asset asset) => this[asset.GUID] = asset;
 		public bool Contains(Asset asset) => ContainsKey(asset.GUID);
 		public bool Contains(string guid) => ContainsKey(guid);

--- a/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/LibraryDatabase.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Editor/AssetBrowser/LibraryDatabase.cs
@@ -103,6 +103,8 @@ namespace VisualPinball.Unity.Editor
 			return results;
 		}
 
+		public IEnumerable<Asset> GetAllAssets() => Assets.All(this);
+
 		public bool AddAsset(Object obj, AssetCategory category, AssetLibrary lib)
 		{
 			if (Assets.Contains(obj)) {
@@ -256,6 +258,10 @@ namespace VisualPinball.Unity.Editor
 		}
 
 		public int NumAssetsWithCategory(AssetCategory category) => Assets.Values.Count(a => a.IsOfCategory(category));
+		public IReadOnlyDictionary<AssetCategory, int> GetCategoryCounts() => Assets.All(this)
+			.Where(asset => asset.Category != null)
+			.GroupBy(asset => asset.Category)
+			.ToDictionary(group => group.Key, group => group.Count());
 
 		public void DeleteCategory(AssetCategory category)
 		{

--- a/VisualPinball.Unity/VisualPinball.Unity.Test/AssetBrowser.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity.Test/AssetBrowser.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 950f955067a14ed890116c9677704d80
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/VisualPinball.Unity/VisualPinball.Unity.Test/AssetBrowser/AssetQueryTests.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Test/AssetBrowser/AssetQueryTests.cs
@@ -1,0 +1,82 @@
+// Visual Pinball Engine
+// Copyright (C) 2026 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using VisualPinball.Unity.Editor;
+
+namespace VisualPinball.Unity.Test.AssetBrowser
+{
+	[TestFixture]
+	public class AssetQueryTests
+	{
+		[Test]
+		public void ParsesQuotedAttributeValueContainingIn()
+		{
+			var query = CreateQuery();
+
+			query.Search("style:\"vintage style\"");
+
+			query.HasAttribute("style", "vintage style").Should().BeTrue();
+		}
+
+		[Test]
+		public void RoundTripsEscapedQuotesInAttributeValues()
+		{
+			var query = CreateQuery();
+			var value = "three inch \"standard\"";
+
+			query.Search($"size:\"{AssetQuery.ValueToQuery(value)}\"");
+
+			query.HasAttribute("size", value).Should().BeTrue();
+		}
+
+		[Test]
+		public void PreservesUnknownBackslashEscapesInTypedValues()
+		{
+			var query = CreateQuery();
+
+			query.Search("path:\"C:\\xyz\\part\"");
+
+			query.HasAttribute("path", "C:\\xyz\\part").Should().BeTrue();
+		}
+
+		[Test]
+		public void ParsesMultipleAttributesWithoutMutatingMatchOffsets()
+		{
+			var query = CreateQuery();
+
+			query.Search("manufacturer:williams style:\"vintage style\" color:red");
+
+			query.HasAttribute("manufacturer", "williams").Should().BeTrue();
+			query.HasAttribute("style", "vintage style").Should().BeTrue();
+			query.HasAttribute("color", "red").Should().BeTrue();
+		}
+
+		[Test]
+		public void QualityStopsAtClosingParenthesis()
+		{
+			var query = CreateQuery();
+
+			query.Search("(Measured) foo (bar)");
+
+			query.HasQuality(AssetQuality.Measured).Should().BeTrue();
+		}
+
+		private static AssetQuery CreateQuery() => new(new List<AssetLibrary>());
+	}
+}

--- a/VisualPinball.Unity/VisualPinball.Unity.Test/AssetBrowser/AssetQueryTests.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity.Test/AssetBrowser/AssetQueryTests.cs
@@ -68,11 +68,62 @@ namespace VisualPinball.Unity.Test.AssetBrowser
 		}
 
 		[Test]
+		public void ParsesQuotedAttributeKeysAndValues()
+		{
+			var query = CreateQuery();
+
+			query.Search("\"manufacturer name\":\"Williams in Chicago\"");
+
+			query.HasAttribute("manufacturer name", "Williams in Chicago").Should().BeTrue();
+		}
+
+		[Test]
+		public void PreservesColonsInUnquotedAttributeValues()
+		{
+			var query = CreateQuery();
+
+			query.Search("source:https://example.com/asset");
+
+			query.HasAttribute("source", "https://example.com/asset").Should().BeTrue();
+		}
+
+		[Test]
+		public void QueryFacetsAreCaseInsensitive()
+		{
+			var query = CreateQuery();
+
+			query.Search("Color:RED [Vintage]");
+
+			query.HasAttribute("color", "red").Should().BeTrue();
+			query.HasTag("vintage").Should().BeTrue();
+		}
+
+		[Test]
 		public void QualityStopsAtClosingParenthesis()
 		{
 			var query = CreateQuery();
 
 			query.Search("(Measured) foo (bar)");
+
+			query.HasQuality(AssetQuality.Measured).Should().BeTrue();
+		}
+
+		[Test]
+		public void QualityIsCaseInsensitive()
+		{
+			var query = CreateQuery();
+
+			query.Search("(measured)");
+
+			query.HasQuality(AssetQuality.Measured).Should().BeTrue();
+		}
+
+		[Test]
+		public void EmptyQualityDoesNotSuppressFollowingQuality()
+		{
+			var query = CreateQuery();
+
+			query.Search("() (measured)");
 
 			query.HasQuality(AssetQuality.Measured).Should().BeTrue();
 		}

--- a/VisualPinball.Unity/VisualPinball.Unity.Test/AssetBrowser/AssetQueryTests.cs.meta
+++ b/VisualPinball.Unity/VisualPinball.Unity.Test/AssetBrowser/AssetQueryTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 23af5d175a4a4e33895978649cb61e98


### PR DESCRIPTION
This PR modernizes the Unity Editor asset browser:

- fixes query parsing, lifecycle handling, serialization, missing-reference handling, path handling, and search debouncing
- virtualizes the asset grid with pooled `ListView` rows while preserving cell selection behavior
- loads thumbnails asynchronously with cancellation, bounded concurrency, and a size-aware LRU cache
- adds indexed queries, tokenizer-based parsing, and automatic index invalidation after asset changes

## Notes

The implementation uses `ListView` row virtualization because UI Toolkit does not provide a native virtualized grid, and retains custom per-cell selection semantics.