### PR TITLE
display: add Pinball 2000 video output support

### DIFF
--- a/VisualPinball.Unity/Assets/Shaders/Builtin/DotMatrixDisplayShader.shader
+++ b/VisualPinball.Unity/Assets/Shaders/Builtin/DotMatrixDisplayShader.shader
@@ -6,6 +6,9 @@
 		__Dimensions ("Dimensions", Vector) = (128, 32, 0, 0)
 		__Padding ("Padding", Range(0.0, 0.8)) = .2
 		__Roundness ("Roundness", Range(0.0, 0.5)) = .35
+		[HideInInspector] _SrcBlend ("Source Blend", Float) = 1
+		[HideInInspector] _DstBlend ("Destination Blend", Float) = 0
+		[HideInInspector] _ZWrite ("Z Write", Float) = 1
 	}
 	SubShader
 	{
@@ -14,6 +17,9 @@
 
 		Pass
 		{
+			Blend [_SrcBlend] [_DstBlend]
+			ZWrite [_ZWrite]
+
 			CGPROGRAM
 			#pragma vertex vert
 			#pragma fragment frag

--- a/VisualPinball.Unity/Assets/Shaders/Srp/Display/DotMatrixDisplayGraph.shadergraph
+++ b/VisualPinball.Unity/Assets/Shaders/Srp/Display/DotMatrixDisplayGraph.shadergraph
@@ -570,7 +570,7 @@
     "m_ActiveSubTarget": {
         "m_Id": "0b355835bddd4ed6b6cd051a52c1094f"
     },
-    "m_AllowMaterialOverride": false,
+    "m_AllowMaterialOverride": true,
     "m_SurfaceType": 0,
     "m_ZTestMode": 4,
     "m_ZWriteControl": 0,
@@ -2691,4 +2691,3 @@
     "m_StageCapability": 3,
     "m_BareResource": false
 }
-

--- a/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayComponent.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Display/DotMatrixDisplayComponent.cs
@@ -202,6 +202,7 @@ namespace VisualPinball.Unity
 					break;
 
 				case DisplayFrameFormat.Dmd24:
+				case DisplayFrameFormat.Video24:
 					if (frame.Length == _width * _height * 3) {
 						CopyRgb24FrameToTexture(frame, _texture.GetRawTextureData<byte>());
 						_texture.Apply();
@@ -270,6 +271,7 @@ namespace VisualPinball.Unity
 					break;
 
 				case DisplayFrameFormat.Dmd24:
+				case DisplayFrameFormat.Video24:
 					// no palette to handle here
 					break;
 

--- a/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/IGamelogicEngine.cs
+++ b/VisualPinball.Unity/VisualPinball.Unity/Game/Engine/IGamelogicEngine.cs
@@ -337,7 +337,8 @@ namespace VisualPinball.Unity
 		Dmd24, // rgb (3x 0-255)
 		Segment,
 		AlphaNumeric, // gets a byte-array converted string
-		Numeric       // gets a byte-array converted float
+		Numeric,      // gets a byte-array converted float
+		Video24       // rgb video (3x 0-255)
 	}
 
 	public class DisplayFrameData


### PR DESCRIPTION
## Summary

- add a distinct `Video24` RGB frame format for Pinball 2000 video output
- render `Video24` frames through the existing display texture path
- allow per-material blend and depth overrides so the video display can be composed as an overlay

## Validation

- `git diff --check`
- verified the commit contains only the four intended VPE display/interface files

## Follow-up

The PinMAME-specific producer and CRT presentation live in the companion PinMAME integration package.